### PR TITLE
Update importfilesdialog.wxcp

### DIFF
--- a/LiteEditor/importfilesdialog.wxcp
+++ b/LiteEditor/importfilesdialog.wxcp
@@ -547,7 +547,7 @@
         }, {
          "type": "multi-string",
          "m_label": "Label:",
-         "m_value": "Files extension to import:"
+         "m_value": "Files extension to import (semicolon delimited):"
         }, {
          "type": "string",
          "m_label": "Wrap:",


### PR DESCRIPTION
It is not obvious that you should use a semicolon delimited string to describe file endings
