### PR TITLE
Remove uses of PATH_MAX so codelite builds on GNU Hurd

### DIFF
--- a/Plugin/globals.cpp
+++ b/Plugin/globals.cpp
@@ -1216,17 +1216,17 @@ wxString CLRealPath(const wxString& filepath) // This is readlink on steroids: i
                                               // any symlinked dirs in the path
 {
 #if defined(__WXGTK__)
-    char buf[PATH_MAX];
     if(!filepath.empty()) {
-        if(realpath(filepath.mb_str(wxConvUTF8), buf) == NULL) {
-            return filepath;
+        char* buf = realpath(filepath.mb_str(wxConvUTF8), NULL);
+        if (buf != NULL) {
+            wxString result(buf, wxConvUTF8);
+            free(buf);
+            return result;
         }
     }
-
-    return wxString(buf, wxConvUTF8);
-#else
-    return filepath;
 #endif
+
+    return filepath;
 }
 
 int wxStringToInt(const wxString& str, int defval, int minval, int maxval)

--- a/codelitegcc/main.cpp
+++ b/codelitegcc/main.cpp
@@ -188,7 +188,7 @@ char * normalize_path(const char * src, size_t src_len)
 
         // relative path
 
-        char pwd[PATH_MAX];
+        char pwd[4096];
         size_t pwd_len;
 
         if (getcwd(pwd, sizeof(pwd)) == NULL) {


### PR DESCRIPTION
This is the first of a few separate patches I've already applied to the Debian package.

This patch removes uses of PATH_MAX so that Codelite builds on GNU Hurd which doesn't define this constant.
