### PR TITLE
Fix crash when using recent versions of wxsqlite3

### DIFF
--- a/CodeLite/tags_storage_sqlite3.h
+++ b/CodeLite/tags_storage_sqlite3.h
@@ -115,7 +115,9 @@ public:
     }
 
     void Close() {
-        wxSQLite3Database::Close();
+        if (IsOpen())
+            wxSQLite3Database::Close();
+
         m_statements.clear();
     }
 


### PR DESCRIPTION
This does not directly affect this version of codelite, but when linked against recent (>= 3.0.1) versions of wxsqlite3, codelite crashes because calling wxSQLite3Database::Close() on an already closed database is no longer allowed.

This patch just adds a call to IsOpen to check this before calling Close.
