### PR TITLE
Return false instead of NULL.

### DIFF
--- a/CodeFormatter/ASFormatter.cpp
+++ b/CodeFormatter/ASFormatter.cpp
@@ -4520,9 +4520,9 @@ bool ASFormatter::isArrayOperator() const
 
     // find next word
     size_t nextNum = currentLine.find_first_not_of(" \t", charNum + 1);
-    if(nextNum == string::npos) return NULL;
+    if(nextNum == string::npos) return false;
 
-    if(!isLegalNameChar(currentLine[nextNum])) return NULL;
+    if(!isLegalNameChar(currentLine[nextNum])) return false;
 
     // bypass next word and following spaces
     while(nextNum < currentLine.length()) {


### PR DESCRIPTION
The return type of ASFormatter::isArrayOperator is bool, so return false
instead of NULL.