### PR TITLE
Install app icon to standard location for Linux/BSD systems

### DIFF
--- a/LiteEditor/CMakeLists.txt
+++ b/LiteEditor/CMakeLists.txt
@@ -140,8 +140,13 @@ if(NOT APPLE)
     install(FILES ${CL_SRC_ROOT}/Runtime/config/codelite.xml.default.gtk 
             DESTINATION ${CL_PREFIX}/share/codelite/config 
             RENAME codelite.xml.default)
+
+    ## Create application launcher, copy application icon to standard location
     if ( UNIX AND NOT APPLE )
         install(FILES ${CL_SRC_ROOT}/Runtime/codelite.desktop DESTINATION ${CL_PREFIX}/share/applications)
+        install(FILES ${CL_SRC_ROOT}/Runtime/images/cubes.png 
+                DESTINATION ${CL_PREFIX}/share/icons/hicolor/32x32/apps
+                RENAME codeleite.png)
     endif (  UNIX AND NOT APPLE )
 
     install(

--- a/Runtime/codelite.desktop.template
+++ b/Runtime/codelite.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=CodeLite
 Exec=codelite %f
-Icon=%%PREFIX%%/share/codelite/images/cubes.png
+Icon=codelite
 Terminal=false
 Type=Application
 Categories=Development;


### PR DESCRIPTION
Made changes in order to have the app icon installed to a standard location (/share/icons/...) + adjusted the the icon path line in the launcher file accordingly. Fixes #707