### PR TITLE
Always load locale for libc

### DIFF
--- a/LiteEditor/app.cpp
+++ b/LiteEditor/app.cpp
@@ -648,7 +648,7 @@ bool CodeLiteApp::OnInit()
         }
     } else {
         // For proper encoding handling by system libraries it's needed to inialize locale even if UI translation is turned off
-        m_locale.Init(wxLANGUAGE_DEFAULT, wxLOCALE_DONT_LOAD_DEFAULT);
+        m_locale.Init(wxLANGUAGE_ENGLISH, wxLOCALE_DONT_LOAD_DEFAULT);
     }
 
 // Append the binary's dir to $PATH. This makes codelite-cc available even for a --prefix= installation

--- a/LiteEditor/app.cpp
+++ b/LiteEditor/app.cpp
@@ -646,6 +646,9 @@ bool CodeLiteApp::OnInit()
             // as otherwise, in a RTL locale, menus, dialogs etc will be displayed RTL, in English...
             // However I couldn't find a way to do this
         }
+    } else {
+        // For proper encoding handling by system libraries it's needed to inialize locale even if UI translation is turned off
+        m_locale.Init(wxLANGUAGE_DEFAULT, wxLOCALE_DONT_LOAD_DEFAULT);
     }
 
 // Append the binary's dir to $PATH. This makes codelite-cc available even for a --prefix= installation


### PR DESCRIPTION
Fix issue with non-English input not working before setting "enable localization" https://github.com/eranif/codelite/issues/147 on Ubuntu 14.04 32-bit running Gnome Fallback (metacity)