### PR TITLE
Remove uses of __DATE__ and __TIME__ from libctags

### DIFF
--- a/sdk/codelite_indexer/libctags/options.c
+++ b/sdk/codelite_indexer/libctags/options.c
@@ -928,7 +928,6 @@ static void printProgramIdentification (void)
 {
 	printf ("%s %s, Copyright (C) 1996-2004 %s\n",
 			PROGRAM_NAME, PROGRAM_VERSION, AUTHOR_NAME);
-	printf ("  Compiled: %s, %s\n", __DATE__, __TIME__);
 	printf ("  Addresses: <%s>, %s\n", AUTHOR_EMAIL, PROGRAM_URL);
 	printFeatureList ();
 }


### PR DESCRIPTION
There is an effort in Debian (and other distros) to be able to create reproducible binaries. Including a timestamp embedded in the executable will clearly make it slightly different each time it's built. After removing these two instances from libctags, CodeLite can be built reproducibly (with an experimental toolchain).

More info:
https://wiki.debian.org/ReproducibleBuilds/About

The 7.0+dfsg-2 upload to Debian had this patch applied and this is the log:
https://reproducible.debian.net/rb-pkg/unstable/amd64/codelite.html