### PR TITLE
Remove RPATH settings from plugin CMakeLists

### DIFF
--- a/CMakePlugin/CMakeLists.txt
+++ b/CMakePlugin/CMakeLists.txt
@@ -38,11 +38,6 @@ if (USE_PCH)
     add_definitions(-Winvalid-pch)
 endif (USE_PCH)
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/CallGraph/CMakeLists.txt
+++ b/CallGraph/CMakeLists.txt
@@ -26,12 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 if (UNIX AND NOT APPLE)

--- a/CodeDesigner/CMakeLists.txt
+++ b/CodeDesigner/CMakeLists.txt
@@ -21,11 +21,6 @@ add_definitions(-DWXUSINGDLL_WXSQLITE3)
 add_definitions(-DWXUSINGDLL_CL)
 add_definitions(-DWXUSINGDLL_SDK)
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/CodeFormatter/CMakeLists.txt
+++ b/CodeFormatter/CMakeLists.txt
@@ -36,11 +36,6 @@ if ( APPLE )
     add_definitions(-fPIC)
 endif()
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/CodeLite/CMakeLists.txt
+++ b/CodeLite/CMakeLists.txt
@@ -91,16 +91,11 @@ endif()
 add_definitions(-DWXUSINGDLL_WXSQLITE3)
 
 # Add RPATH
-if (NOT MINGW)
-if ( WXC_APP )
+if (NOT MINGW AND WXC_APP)
     string( REPLACE "codelite" "wxcrafter" WXC_LIBS_DIR ${PLUGINS_DIR}) 
-    set (LINKER_OPTIONS -Wl,-rpath,"${WXC_LIBS_DIR}:${PLUGINS_DIR}")
-    message( "-- libcodelite.so is using RPATH set to ${WXC_LIBS_DIR}:${PLUGINS_DIR}")
-else ( WXC_APP )
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-    message( "-- libcodelite.so is using RPATH set to ${PLUGINS_DIR}")
-endif ( WXC_APP )
-endif (NOT MINGW)
+    set (LINKER_OPTIONS -Wl,-rpath,"${WXC_LIBS_DIR}")
+    message( "-- libcodelite.so is using RPATH set to ${WXC_LIBS_DIR}")
+endif ()
 FILE(GLOB SRCS "*.cpp" "../sdk/codelite_indexer/network/*.cpp" "SocketAPI/*.cpp")
 
 # Define the output

--- a/CodeLiteDiff/CMakeLists.txt
+++ b/CodeLiteDiff/CMakeLists.txt
@@ -34,11 +34,6 @@ if (USE_PCH)
     add_definitions(-Winvalid-pch)
 endif (USE_PCH)
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/ContinuousBuild/CMakeLists.txt
+++ b/ContinuousBuild/CMakeLists.txt
@@ -26,11 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 if (UNIX AND NOT APPLE)

--- a/Copyright/CMakeLists.txt
+++ b/Copyright/CMakeLists.txt
@@ -26,11 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 if (UNIX AND NOT APPLE)

--- a/DatabaseExplorer/CMakeLists.txt
+++ b/DatabaseExplorer/CMakeLists.txt
@@ -75,10 +75,6 @@ add_definitions(-DWXUSINGDLL_WXSQLITE3)
 add_definitions(-DWXUSINGDLL_CL)
 add_definitions(-DWXUSINGDLL_SDK)
 add_definitions(-DDBL_USE_SQLITE)
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
 
 FILE(GLOB SRCS "*.cpp")
 

--- a/Debugger/CMakeLists.txt
+++ b/Debugger/CMakeLists.txt
@@ -35,12 +35,6 @@ if ( APPLE )
     add_definitions(-fPIC)
 endif()
 
-
-# Add RPATH
-if (UNIX)
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/ExternalTools/CMakeLists.txt
+++ b/ExternalTools/CMakeLists.txt
@@ -35,12 +35,6 @@ if ( APPLE )
     add_definitions(-fPIC)
 endif()
 
-
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/Gizmos/CMakeLists.txt
+++ b/Gizmos/CMakeLists.txt
@@ -26,11 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/HelpPlugin/CMakeLists.txt
+++ b/HelpPlugin/CMakeLists.txt
@@ -40,11 +40,6 @@ if ( APPLE )
     add_definitions(-fPIC)
 endif()
 
-# Add RPATH
-if (UNIX)
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/LLDBDebugger/CMakeLists.txt
+++ b/LLDBDebugger/CMakeLists.txt
@@ -71,11 +71,6 @@ if (WITH_LLDB MATCHES 1)
         add_definitions(-DWXUSINGDLL_CL)
         add_definitions(-DWXUSINGDLL_SDK)
 
-        # Add RPATH
-        if (UNIX)
-        set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-        endif (UNIX)
-
         ## By default, use the sources under the current folder
         FILE(GLOB PLUGIN_SRCS "*.cpp")
 

--- a/LLDBDebugger/codelite-lldb/CMakeLists.txt
+++ b/LLDBDebugger/codelite-lldb/CMakeLists.txt
@@ -8,11 +8,6 @@ else ( APPLE )
     find_package(wxWidgets COMPONENTS std aui propgrid stc richtext ribbon REQUIRED)
 endif ( APPLE )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRC "*.cpp")
 include_directories(${CL_SRC_ROOT}/LLDBDebugger)
 

--- a/LiteEditor/CMakeLists.txt
+++ b/LiteEditor/CMakeLists.txt
@@ -62,11 +62,6 @@ if ( USE_CLANG )
   include_directories(${CLANG_INCLUDE})
 endif( USE_CLANG )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 set (RES_FILE "")

--- a/MacBundler/CMakeLists.txt
+++ b/MacBundler/CMakeLists.txt
@@ -30,11 +30,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/MemCheck/CMakeLists.txt
+++ b/MemCheck/CMakeLists.txt
@@ -43,11 +43,6 @@ if(UNIX AND NOT APPLE)
         add_definitions(-fPIC)
     endif()
 
-
-
-    # Add RPATH
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-
     FILE(GLOB SRCS "*.cpp")
 
     # Define the output

--- a/Outline/CMakeLists.txt
+++ b/Outline/CMakeLists.txt
@@ -36,13 +36,6 @@ if ( APPLE )
     add_definitions(-fPIC)
 endif()
 
-
-
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -77,15 +77,10 @@ add_definitions(-DWXUSINGDLL_WXSQLITE3)
 add_definitions(-DWXUSINGDLL_CL)
 
 # Add RPATH
-if(NOT MINGW)
-if ( WXC_APP )
+if(NOT MINGW AND WXC_APP)
     string( REPLACE "codelite" "wxcrafter" WXC_LIBS_DIR ${PLUGINS_DIR})
-    set (LINKER_OPTIONS -Wl,-rpath,"${WXC_LIBS_DIR}:${PLUGINS_DIR}")
-    message( "-- libplugin.so is using RPATH set to ${WXC_LIBS_DIR}:${PLUGINS_DIR}")
-else ( WXC_APP )
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-    message( "-- libplugin.so is using RPATH set to ${PLUGINS_DIR}")
-endif ( WXC_APP )
+    set (LINKER_OPTIONS -Wl,-rpath,"${WXC_LIBS_DIR}")
+    message( "-- libplugin.so is using RPATH set to ${WXC_LIBS_DIR}")
 endif()
 
 FILE(GLOB SRCS "*.cpp")

--- a/QmakePlugin/CMakeLists.txt
+++ b/QmakePlugin/CMakeLists.txt
@@ -26,11 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/Runtime/templates/gizmos/CMakeLists.txt.plugin.wizard
+++ b/Runtime/templates/gizmos/CMakeLists.txt.plugin.wizard
@@ -40,11 +40,6 @@ if ( APPLE )
     add_definitions(-fPIC)
 endif()
 
-# Add RPATH
-if (UNIX)
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/SFTP/CMakeLists.txt
+++ b/SFTP/CMakeLists.txt
@@ -26,12 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/SnipWiz/CMakeLists.txt
+++ b/SnipWiz/CMakeLists.txt
@@ -26,12 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/SpellChecker/CMakeLists.txt
+++ b/SpellChecker/CMakeLists.txt
@@ -67,9 +67,6 @@ else ()
         add_definitions(-Winvalid-pch)
     endif ( USE_PCH )
 
-    # Add RPATH
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-
     FILE(GLOB SRCS "*.cpp")
 
     # Define the output

--- a/Subversion2/CMakeLists.txt
+++ b/Subversion2/CMakeLists.txt
@@ -36,12 +36,6 @@ if ( APPLE )
     add_definitions(-fPIC)
 endif()
 
-
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/Tweaks/CMakeLists.txt
+++ b/Tweaks/CMakeLists.txt
@@ -26,12 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/UnitTestCPP/CMakeLists.txt
+++ b/UnitTestCPP/CMakeLists.txt
@@ -26,12 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/WebTools/CMakeLists.txt
+++ b/WebTools/CMakeLists.txt
@@ -30,11 +30,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/WordCompletion/CMakeLists.txt
+++ b/WordCompletion/CMakeLists.txt
@@ -26,12 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/ZoomNavigator/CMakeLists.txt
+++ b/ZoomNavigator/CMakeLists.txt
@@ -26,12 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/abbreviation/CMakeLists.txt
+++ b/abbreviation/CMakeLists.txt
@@ -26,11 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/cmake/Modules/plugin.cmake
+++ b/cmake/Modules/plugin.cmake
@@ -50,9 +50,6 @@ function( CL_PLUGIN PLUGIN_NAME )
         add_definitions(-include "${CL_PCH_FILE}")
         add_definitions(-Winvalid-pch)
     endif ( USE_PCH )
-
-    # Add RPATH
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
     
     ## By default, use the sources under the current folder
     FILE(GLOB_RECURSE PLUGIN_SRCS "${CMAKE_CURRENT_LIST_DIR}/*.cpp" "${CMAKE_CURRENT_LIST_DIR}/*.c")

--- a/codelite_make/CMakeLists.txt
+++ b/codelite_make/CMakeLists.txt
@@ -14,11 +14,6 @@ find_package(wxWidgets COMPONENTS core base REQUIRED)
 # Include paths
 #include_directories("${CL_SRC_ROOT}/Plugin" "${CL_SRC_ROOT}/sdk/wxsqlite3/include" "${CL_SRC_ROOT}/CodeLite" "${CL_SRC_ROOT}/PCH" "${CL_SRC_ROOT}/Interfaces")
 
-# Add RPATH
-if ( UNIX )
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif ( UNIX )
-
 # we need wxWidgets flags to be set only for the c++ files, so we do it like this
 # by setting the CMAKE_CXX_FLAGS
 if ( NOT MINGW )

--- a/codelite_terminal/CMakeLists.txt
+++ b/codelite_terminal/CMakeLists.txt
@@ -11,11 +11,6 @@ else ( UNIX AND NOT APPLE )
     find_package(wxWidgets REQUIRED)
 endif ( UNIX OR MINGW AND NOT APPLE )
 
-# Add RPATH
-if ( UNIX )
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif ( UNIX )
-
 # we need wxWidgets flags to be set only for the c++ files, so we do it like this
 # by setting the CMAKE_CXX_FLAGS
 if ( NOT MINGW )

--- a/codelitegcc/CMakeLists.txt
+++ b/codelitegcc/CMakeLists.txt
@@ -5,11 +5,6 @@ cmake_minimum_required(VERSION 2.6.2)
 # visual studio, and in our makefiles. 
 project(codelite-cc)
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/codelitephp/CMakeLists.txt
+++ b/codelitephp/CMakeLists.txt
@@ -45,11 +45,6 @@ add_definitions(-DWXUSINGDLL_WXSQLITE3)
 add_definitions(-DWXUSINGDLL_CL)
 add_definitions(-DWXUSINGDLL_SDK)
 
-if (UNIX)
-# Add RPATH
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif()
-
 if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DebugFull)
     ## Debug build of codelite
     set( CL_LIB_DIR lib)

--- a/cppchecker/CMakeLists.txt
+++ b/cppchecker/CMakeLists.txt
@@ -21,11 +21,6 @@ add_definitions(-DWXUSINGDLL_WXSQLITE3)
 add_definitions(-DWXUSINGDLL_CL)
 add_definitions(-DWXUSINGDLL_SDK)
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 if (UNIX AND NOT APPLE)

--- a/cscope/CMakeLists.txt
+++ b/cscope/CMakeLists.txt
@@ -35,12 +35,6 @@ if ( APPLE )
     add_definitions(-fPIC)
 endif()
 
-
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 FILE(GLOB SRCS "*.cpp")
 
 # Define the output

--- a/git/CMakeLists.txt
+++ b/git/CMakeLists.txt
@@ -21,11 +21,6 @@ add_definitions(-DWXUSINGDLL_WXSQLITE3)
 add_definitions(-DWXUSINGDLL_CL)
 add_definitions(-DWXUSINGDLL_SDK)
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/sdk/codelite_cppcheck/CMakeLists.txt
+++ b/sdk/codelite_cppcheck/CMakeLists.txt
@@ -10,11 +10,6 @@ include_directories("${CL_SRC_ROOT}/sdk/codelite_cppcheck/lib" "${CL_SRC_ROOT}/s
 
 set( ADDITIONAL_LIBRARIES "" )
 
-# Add RPATH
-if(UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if(WIN32)
 set(ADDITIONAL_LIBRARIES "-lshlwapi")
 endif(WIN32)

--- a/sdk/codelite_indexer/CMakeLists.txt
+++ b/sdk/codelite_indexer/CMakeLists.txt
@@ -14,11 +14,6 @@ find_package(wxWidgets COMPONENTS core base REQUIRED)
 # Include paths
 #include_directories("${CL_SRC_ROOT}/Plugin" "${CL_SRC_ROOT}/sdk/wxsqlite3/include" "${CL_SRC_ROOT}/CodeLite" "${CL_SRC_ROOT}/PCH" "${CL_SRC_ROOT}/Interfaces")
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 # we need wxWidgets flags to be set only for the c++ files, so we do it like this
 # by setting the CMAKE_CXX_FLAGS
 if ( NOT MINGW )

--- a/sdk/databaselayer/CMakeLists.txt
+++ b/sdk/databaselayer/CMakeLists.txt
@@ -23,11 +23,6 @@ if(WIN32)
     add_definitions(-DWXMAKINGDLL_DATABASELAYER)
 endif(WIN32)
 
-# Add RPATH
-if (UNIX)
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/sdk/wxshapeframework/CMakeLists.txt
+++ b/sdk/wxshapeframework/CMakeLists.txt
@@ -24,11 +24,6 @@ endif ( USE_PCH )
 
 include_directories("${CL_SRC_ROOT}/sdk/wxshapeframework/include" "${CL_SRC_ROOT}/sdk/wxshapeframework/src")
 
-# Add RPATH
-if (UNIX)
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/sdk/wxsqlite3/CMakeLists.txt
+++ b/sdk/wxsqlite3/CMakeLists.txt
@@ -22,11 +22,6 @@ if ( USE_PCH )
 endif ( USE_PCH )
 include_directories(./include ../../sqlite3)
 
-# Add RPATH
-if (UNIX)
-    set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )

--- a/wxformbuilder/CMakeLists.txt
+++ b/wxformbuilder/CMakeLists.txt
@@ -26,11 +26,6 @@ if ( USE_PCH )
     add_definitions(-Winvalid-pch)
 endif ( USE_PCH )
 
-# Add RPATH
-if (UNIX)
-set (LINKER_OPTIONS -Wl,-rpath,"${PLUGINS_DIR}")
-endif (UNIX)
-
 if (UNIX AND NOT APPLE)
     set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC" )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )


### PR DESCRIPTION
If `CMAKE_INSTALL_RPATH` is set (like it is in the toplevel CMakeLists.txt), CMake will automatically handle all this RPATH stuff for you so none of these extra `-Wl,-rpath` additions are needed.

This has a similar effect to a patch I submitted some time ago, but is done in reverse by removing the instances of `-Wl,-rpath` instead of the CMake rule. This way helps reduce the amount of code in each plugin.

There were two changes which handled wxCrafter libraries, but I haven't been able to test them. Hopefully I didn't break anything.