### PR TITLE
Fix LLDBDebugger undefined symbol error when using LD_BIND_NOW

### DIFF
--- a/LLDBDebugger/CMakeLists.txt
+++ b/LLDBDebugger/CMakeLists.txt
@@ -83,15 +83,13 @@ if (WITH_LLDB MATCHES 1)
         add_library(${PLUGIN_NAME} SHARED ${PLUGIN_SRCS})
 
         target_link_libraries(LLDBDebugger LLDBProtocol)
-if (APPLE)
-        link_directories(${LLDB_LIB_PATH})
-        target_link_libraries(${PLUGIN_NAME} ${LIBLLDB})
-endif()
+
         # Codelite plugins doesn't use the "lib" prefix.
         set_target_properties(${PLUGIN_NAME} PROPERTIES PREFIX "")
         target_link_libraries(${PLUGIN_NAME}
                               ${LINKER_OPTIONS}
                               ${wxWidgets_LIBRARIES}
+                              ${LIBLLDB}
                               libcodelite
                               plugin
                               wxsqlite3 


### PR DESCRIPTION
LLDBDebugger uses symbols from liblldb.so so it should link against it. If codelite is compiled with -Wl,as-needed and is then run with LD_BIND_NOW set, then I get errors like this:

> Failed to load plugin's dll: /usr/lib/codelite/LLDBDebugger.so
> /usr/lib/codelite/LLDBDebugger.so: undefined symbol: _ZN4lldb7SBValueD1Ev

The link_directories line is removed as it's duplicated from above. ${LIBLLDB} is moved to be with the rest of the libraries to make things neater.