### PR TITLE
Allow user to add parse paths to store into the *.workspace* file.

### DIFF
--- a/LiteEditor/code_completion_page.cpp
+++ b/LiteEditor/code_completion_page.cpp
@@ -48,7 +48,7 @@ CodeCompletionPage::CodeCompletionPage(wxWindow *parent, int type)
         
         m_checkBoxCpp11->SetValue( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableCpp11 );
         m_checkBoxCpp14->SetValue( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableCpp14 );
-        m_checkBoxSTWF->SetValue( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableSTWF);
+        m_checkBoxSWTLW->SetValue( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableSWTLW);
     }
 }
 
@@ -80,7 +80,7 @@ void CodeCompletionPage::Save()
 
         if ( m_checkBoxCpp11->IsChecked() ) flags |= LocalWorkspace::EnableCpp11;
         if ( m_checkBoxCpp14->IsChecked() ) flags |= LocalWorkspace::EnableCpp14;
-        if ( m_checkBoxSTWF->IsChecked() ) flags |= LocalWorkspace::EnableSTWF;
+        if ( m_checkBoxSWTLW->IsChecked() ) flags |= LocalWorkspace::EnableSWTLW;
         LocalWorkspaceST::Get()->SetParserFlags( flags );
         LocalWorkspaceST::Get()->Flush();
 

--- a/LiteEditor/code_completion_page.cpp
+++ b/LiteEditor/code_completion_page.cpp
@@ -48,6 +48,7 @@ CodeCompletionPage::CodeCompletionPage(wxWindow *parent, int type)
         
         m_checkBoxCpp11->SetValue( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableCpp11 );
         m_checkBoxCpp14->SetValue( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableCpp14 );
+        m_checkBoxSTWF->SetValue( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableSTWF);
     }
 }
 
@@ -79,6 +80,7 @@ void CodeCompletionPage::Save()
 
         if ( m_checkBoxCpp11->IsChecked() ) flags |= LocalWorkspace::EnableCpp11;
         if ( m_checkBoxCpp14->IsChecked() ) flags |= LocalWorkspace::EnableCpp14;
+        if ( m_checkBoxSTWF->IsChecked() ) flags |= LocalWorkspace::EnableSTWF;
         LocalWorkspaceST::Get()->SetParserFlags( flags );
         LocalWorkspaceST::Get()->Flush();
 

--- a/LiteEditor/workspacesettingsbase.cpp
+++ b/LiteEditor/workspacesettingsbase.cpp
@@ -168,11 +168,11 @@ CodeCompletionBasePage::CodeCompletionBasePage(wxWindow* parent, wxWindowID id, 
     
     boxSizer3->Add(m_checkBoxCpp14, 0, wxALL, 5);
     
-    m_checkBoxSTWF = new wxCheckBox(m_panel6, wxID_ANY, _("Sync to Workspace File"), wxDefaultPosition, wxSize(-1,-1), 0);
-    m_checkBoxSTWF->SetValue(false);
-    m_checkBoxSTWF->SetToolTip(_("When enabled search paths folders for Code Completion will be synced between the Workspace file and the local search paths database."));
+    m_checkBoxSWTLW = new wxCheckBox(m_panel6, wxID_ANY, _("Sync to Workspace File"), wxDefaultPosition, wxSize(-1,-1), 0);
+    m_checkBoxSWTLW->SetValue(false);
+    m_checkBoxSWTLW->SetToolTip(_("When enabled search paths folders for Code Completion will be synced between the Workspace file and the local search paths database."));
     
-    boxSizer3->Add(m_checkBoxSTWF, 0, wxALL, 5);
+    boxSizer3->Add(m_checkBoxSWTLW, 0, wxALL, 5);
     
     SetName(wxT("CodeCompletionBasePage"));
     SetSizeHints(500,300);

--- a/LiteEditor/workspacesettingsbase.cpp
+++ b/LiteEditor/workspacesettingsbase.cpp
@@ -87,24 +87,12 @@ WorkspaceSettingsBase::WorkspaceSettingsBase(wxWindow* parent, wxWindowID id, co
     
     buttonSizer->Add(m_buttonCancel, 0, wxALL, 5);
     
-    
-    #if wxVERSION_NUMBER >= 2900
-    if(!wxPersistenceManager::Get().Find(m_notebook1)){
-        wxPersistenceManager::Get().RegisterAndRestore(m_notebook1);
-    }
-    #endif
-    
     SetName(wxT("WorkspaceSettingsBase"));
     SetSizeHints(-1,-1);
     if ( GetSizer() ) {
          GetSizer()->Fit(this);
     }
     CentreOnParent(wxBOTH);
-#if wxVERSION_NUMBER >= 2900
-    if(!wxPersistenceManager::Get().Find(this)) {
-        wxPersistenceManager::Get().RegisterAndRestore(this);
-    }
-#endif
     // Connect events
     m_choiceEnvSets->Connect(wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(WorkspaceSettingsBase::OnEnvSelected), NULL, this);
     m_buttonOk->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(WorkspaceSettingsBase::OnButtonOK), NULL, this);
@@ -179,6 +167,12 @@ CodeCompletionBasePage::CodeCompletionBasePage(wxWindow* parent, wxWindowID id, 
     m_checkBoxCpp14->SetValue(false);
     
     boxSizer3->Add(m_checkBoxCpp14, 0, wxALL, 5);
+    
+    m_checkBoxSTWF = new wxCheckBox(m_panel6, wxID_ANY, _("Sync to Workspace File"), wxDefaultPosition, wxSize(-1,-1), 0);
+    m_checkBoxSTWF->SetValue(false);
+    m_checkBoxSTWF->SetToolTip(_("When enabled search paths folders for Code Completion will be synced between the Workspace file and the local search paths database."));
+    
+    boxSizer3->Add(m_checkBoxSTWF, 0, wxALL, 5);
     
     SetName(wxT("CodeCompletionBasePage"));
     SetSizeHints(500,300);

--- a/LiteEditor/workspacesettingsbase.h
+++ b/LiteEditor/workspacesettingsbase.h
@@ -64,7 +64,7 @@ protected:
     wxTextCtrl* m_textCtrlMacros;
     wxCheckBox* m_checkBoxCpp11;
     wxCheckBox* m_checkBoxCpp14;
-    wxCheckBox* m_checkBoxSTWF;
+    wxCheckBox* m_checkBoxSWTLW;
 
 protected:
     virtual void OnCCContentModified(wxCommandEvent& event) { event.Skip(); }

--- a/LiteEditor/workspacesettingsbase.h
+++ b/LiteEditor/workspacesettingsbase.h
@@ -26,12 +26,6 @@
 #include <wx/button.h>
 #include <wx/splitter.h>
 #include <wx/checkbox.h>
-#if wxVERSION_NUMBER >= 2900
-#include <wx/persist.h>
-#include <wx/persist/toplevel.h>
-#include <wx/persist/bookctrl.h>
-#include <wx/persist/treebook.h>
-#endif
 
 class WorkspaceSettingsBase : public wxDialog
 {
@@ -53,17 +47,6 @@ protected:
     virtual void OnButtonOK(wxCommandEvent& event) { event.Skip(); }
 
 public:
-    wxStaticText* GetStaticText3() { return m_staticText3; }
-    wxStaticText* GetStaticText4() { return m_staticText4; }
-    wxChoice* GetChoiceEnvSets() { return m_choiceEnvSets; }
-    wxStaticLine* GetStaticline2() { return m_staticline2; }
-    wxStaticText* GetStaticText6() { return m_staticText6; }
-    wxTextCtrl* GetTextCtrlWspEnvVars() { return m_textCtrlWspEnvVars; }
-    wxPanel* GetPanelEnv() { return m_panelEnv; }
-    wxNotebook* GetNotebook1() { return m_notebook1; }
-    wxStaticLine* GetStaticline1() { return m_staticline1; }
-    wxButton* GetButtonOk() { return m_buttonOk; }
-    wxButton* GetButtonCancel() { return m_buttonCancel; }
     WorkspaceSettingsBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("Workspace Settings"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(-1, -1), long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
     virtual ~WorkspaceSettingsBase();
 };
@@ -81,20 +64,12 @@ protected:
     wxTextCtrl* m_textCtrlMacros;
     wxCheckBox* m_checkBoxCpp11;
     wxCheckBox* m_checkBoxCpp14;
+    wxCheckBox* m_checkBoxSTWF;
 
 protected:
     virtual void OnCCContentModified(wxCommandEvent& event) { event.Skip(); }
 
 public:
-    wxStaticText* GetStaticText5() { return m_staticText5; }
-    wxTextCtrl* GetTextCtrlSearchPaths() { return m_textCtrlSearchPaths; }
-    wxPanel* GetPanel8() { return m_panel8; }
-    wxStaticText* GetStaticText12() { return m_staticText12; }
-    wxTextCtrl* GetTextCtrlMacros() { return m_textCtrlMacros; }
-    wxCheckBox* GetCheckBoxCpp11() { return m_checkBoxCpp11; }
-    wxCheckBox* GetCheckBoxCpp14() { return m_checkBoxCpp14; }
-    wxPanel* GetPanel6() { return m_panel6; }
-    wxSplitterWindow* GetSplitter1() { return m_splitter1; }
     CodeCompletionBasePage(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(500,300), long style = wxTAB_TRAVERSAL);
     virtual ~CodeCompletionBasePage();
 };

--- a/LiteEditor/workspacesettingsbase.wxcp
+++ b/LiteEditor/workspacesettingsbase.wxcp
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "m_generatedFilesDir": ".",
-  "m_objCounter": 5,
+  "m_objCounter": 7,
   "m_includeFiles": [],
   "m_bitmapFunction": "wxC3C39InitBitmapResources",
   "m_bitmapsFile": "workspacesettingsbase_liteeditor_bitmaps.cpp",
@@ -1993,6 +1993,81 @@
                  "type": "string",
                  "m_label": "Label:",
                  "m_value": "Enable C++14 Standard"
+                }, {
+                 "type": "bool",
+                 "m_label": "Value:",
+                 "m_value": false
+                }],
+               "m_events": [],
+               "m_children": []
+              }, {
+               "m_type": 4415,
+               "proportion": 0,
+               "border": 5,
+               "gbSpan": "1,1",
+               "gbPosition": "0,0",
+               "m_styles": [],
+               "m_sizerFlags": ["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
+               "m_properties": [{
+                 "type": "winid",
+                 "m_label": "ID:",
+                 "m_winid": "wxID_ANY"
+                }, {
+                 "type": "string",
+                 "m_label": "Size:",
+                 "m_value": "-1,-1"
+                }, {
+                 "type": "string",
+                 "m_label": "Minimum Size:",
+                 "m_value": "-1,-1"
+                }, {
+                 "type": "string",
+                 "m_label": "Name:",
+                 "m_value": "m_checkBoxSTWF"
+                }, {
+                 "type": "multi-string",
+                 "m_label": "Tooltip:",
+                 "m_value": "When enabled search paths folders for Code Completion will be synced between the Workspace file and the local search paths database."
+                }, {
+                 "type": "colour",
+                 "m_label": "Bg Colour:",
+                 "colour": "<Default>"
+                }, {
+                 "type": "colour",
+                 "m_label": "Fg Colour:",
+                 "colour": "<Default>"
+                }, {
+                 "type": "font",
+                 "m_label": "Font:",
+                 "m_value": ""
+                }, {
+                 "type": "bool",
+                 "m_label": "Hidden",
+                 "m_value": false
+                }, {
+                 "type": "bool",
+                 "m_label": "Disabled",
+                 "m_value": false
+                }, {
+                 "type": "bool",
+                 "m_label": "Focused",
+                 "m_value": false
+                }, {
+                 "type": "string",
+                 "m_label": "Class Name:",
+                 "m_value": ""
+                }, {
+                 "type": "string",
+                 "m_label": "Include File:",
+                 "m_value": ""
+                }, {
+                 "type": "string",
+                 "m_label": "Style:",
+                 "m_value": ""
+                }, {
+                 "type": "string",
+                 "m_label": "Label:",
+                 "m_value": "Sync to Workspace File"
                 }, {
                  "type": "bool",
                  "m_label": "Value:",

--- a/LiteEditor/workspacesettingsbase.wxcp
+++ b/LiteEditor/workspacesettingsbase.wxcp
@@ -2023,7 +2023,7 @@
                 }, {
                  "type": "string",
                  "m_label": "Name:",
-                 "m_value": "m_checkBoxSTWF"
+                 "m_value": "m_checkBoxSWTLW"
                 }, {
                  "type": "multi-string",
                  "m_label": "Tooltip:",

--- a/LiteEditor/workspacesettingsbase_liteeditor_bitmaps.cpp
+++ b/LiteEditor/workspacesettingsbase_liteeditor_bitmaps.cpp
@@ -42,6 +42,6 @@ void wxC3C39InitBitmapResources()
         else wxFileSystem::AddHandler(new wxMemoryFSHandlerBase);
     }
 
-    XRC_ADD_FILE(wxT("XRC_resource/workspacesettingsbase_liteeditor_bitmaps.cpp$_home_david_devel_git_CL_LiteEditor_workspacesettingsbase_liteeditor_bitmaps.xrc"), xml_res_file_0, xml_res_size_0, wxT("text/xml"));
-    wxXmlResource::Get()->Load(wxT("memory:XRC_resource/workspacesettingsbase_liteeditor_bitmaps.cpp$_home_david_devel_git_CL_LiteEditor_workspacesettingsbase_liteeditor_bitmaps.xrc"));
+    XRC_ADD_FILE(wxT("XRC_resource/workspacesettingsbase_liteeditor_bitmaps.cpp$_home_yaakuro_Project_codelite_LiteEditor_workspacesettingsbase_liteeditor_bitmaps.xrc"), xml_res_file_0, xml_res_size_0, wxT("text/xml"));
+    wxXmlResource::Get()->Load(wxT("memory:XRC_resource/workspacesettingsbase_liteeditor_bitmaps.cpp$_home_yaakuro_Project_codelite_LiteEditor_workspacesettingsbase_liteeditor_bitmaps.xrc"));
 }

--- a/Plugin/localworkspace.h
+++ b/Plugin/localworkspace.h
@@ -272,7 +272,7 @@ public:
     enum CC_FLAGS {
         EnableCpp11	= 0x00000001,
         EnableCpp14	= 0x00000002,
-        EnableSTWF	= 0x00000004    // Save Parse folders to Workspace file.
+        EnableSWTLW	= 0x00000004    // Save Parse folders to Workspace file.
     };
     
 private:

--- a/Plugin/localworkspace.h
+++ b/Plugin/localworkspace.h
@@ -270,8 +270,9 @@ class WXDLLIMPEXP_SDK LocalWorkspace
 {
 public:
     enum CC_FLAGS {
-        EnableCpp11 = 0x00000001,
-        EnableCpp14 = 0x00000002,
+        EnableCpp11	= 0x00000001,
+        EnableCpp14	= 0x00000002,
+        EnableSTWF	= 0x00000004    // Save Parse folders to Workspace file.
     };
     
 private:

--- a/Plugin/workspace.cpp
+++ b/Plugin/workspace.cpp
@@ -161,10 +161,10 @@ bool Workspace::OpenWorkspace(const wxString& fileName, wxString& errMsg)
         else if(child->GetName() == wxT("WorkspaceParserPaths")) {
             wxString swtlw = wxEmptyString;
             if( (swtlw = m_doc.GetRoot()->GetAttribute(wxT("SWTLW"))) == wxEmptyString) {
-               LocalWorkspaceST::Get()->SetParserFlags(LocalWorkspaceST::Get()->GetParserFlags() & !LocalWorkspace::EnableSTWF);
+               LocalWorkspaceST::Get()->SetParserFlags(LocalWorkspaceST::Get()->GetParserFlags() & !LocalWorkspace::EnableSWTLW);
             } else {
                 if(swtlw == wxT("Yes")) {
-                    LocalWorkspaceST::Get()->SetParserFlags(LocalWorkspaceST::Get()->GetParserFlags() | LocalWorkspace::EnableSTWF);
+                    LocalWorkspaceST::Get()->SetParserFlags(LocalWorkspaceST::Get()->GetParserFlags() | LocalWorkspace::EnableSWTLW);
                     SyncToLocalWorkspaceSTParserPaths();
                 }
             }
@@ -274,7 +274,7 @@ bool Workspace::CreateWorkspace(const wxString& name, const wxString& path, wxSt
     m_doc.GetRoot()->AddProperty(wxT("Database"), dbFileName.GetFullPath(wxPATH_UNIX));
 	
 	m_doc.GetRoot()->DeleteAttribute(wxT("SWTLW"));
-	if ( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableSTWF ) {
+	if ( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableSWTLW ) {
 		m_doc.GetRoot()->AddProperty(wxT("SWTLW"), "Yes");
 	} else {
 		m_doc.GetRoot()->AddProperty(wxT("SWTLW"), "No");		
@@ -697,7 +697,7 @@ bool Workspace::SaveXmlFile()
     if(m_doc.GetRoot()->GetAttribute(wxT("SWTLW")) != wxEmptyString) {
         m_doc.GetRoot()->DeleteAttribute(wxT("SWTLW"));
     }
-    if ( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableSTWF ) {
+    if ( LocalWorkspaceST::Get()->GetParserFlags() & LocalWorkspace::EnableSWTLW ) {
         m_doc.GetRoot()->AddProperty(wxT("SWTLW"), "Yes");
         SyncFromLocalWorkspaceSTParserPaths();
     } else {

--- a/Plugin/workspace.cpp
+++ b/Plugin/workspace.cpp
@@ -158,6 +158,11 @@ bool Workspace::OpenWorkspace(const wxString& fileName, wxString& errMsg)
                 removedChildren.push_back(child);
             }
         }
+        else if(child->GetName() == wxT("WorkspaceParserPaths")) {
+            
+            SyncToLocalWorkspaceSTParserPaths();
+
+        }
         child = child->GetNext();
     }
 
@@ -673,12 +678,74 @@ bool Workspace::RemoveVirtualDirectory(const wxString& vdFullPath, wxString& err
 
 bool Workspace::SaveXmlFile()
 {
+    SyncToLocalWorkspaceSTParserPaths();
+    
     bool ok = m_doc.Save(m_fileName.GetFullPath());
     SetWorkspaceLastModifiedTime(GetFileLastModifiedTime());
     EventNotifier::Get()->PostFileSavedEvent(m_fileName.GetFullPath());
 
     DoUpdateBuildMatrix();
     return ok;
+}
+
+void Workspace::SyncToLocalWorkspaceSTParserPaths()
+{
+    wxArrayString inclduePaths;
+    wxArrayString excludePaths;
+    wxXmlNode* workspaceInclPaths = XmlUtils::FindFirstByTagName(m_doc.GetRoot(), wxT("WorkspaceParserPaths"));
+    if(workspaceInclPaths) {
+        wxXmlNode* child = workspaceInclPaths->GetChildren();
+        while(child) {
+            if(child->GetName() == wxT("Exclude")) {
+                wxString path = child->GetPropVal(wxT("Path"), wxT(""));
+                path.Trim().Trim(false);
+                if(path.IsEmpty() == false) {
+                    excludePaths.Add(path);
+                }
+            }
+
+            else if(child->GetName() == wxT("Include")) {
+                wxString path = child->GetPropVal(wxT("Path"), wxT(""));
+                path.Trim().Trim(false);
+                if(path.IsEmpty() == false) {
+                    inclduePaths.Add(path);
+                }
+            }
+
+            child = child->GetNext();
+        }
+        LocalWorkspaceST::Get()->SetParserPaths(inclduePaths, excludePaths);
+    } 
+}
+
+void Workspace::SyncFromLocalWorkspaceSTParserPaths()
+{
+    //
+    // Here we just get the parser paths from the LocalWorkspaceST and write it into the worspace project file.
+    //
+    wxXmlNode* workspaceInclPaths = XmlUtils::FindFirstByTagName(m_doc.GetRoot(), wxT("WorkspaceParserPaths"));
+    if(workspaceInclPaths) {
+        m_doc.GetRoot()->RemoveChild(workspaceInclPaths);
+        delete workspaceInclPaths;
+    }
+
+    //
+    // Get workspace parse paths from local workspace file.
+    //
+    wxArrayString inclduePaths;
+    wxArrayString excludePaths;
+    LocalWorkspaceST::Get()->GetParserPaths(inclduePaths, excludePaths);
+
+    workspaceInclPaths = new wxXmlNode(m_doc.GetRoot(), wxXML_ELEMENT_NODE, wxT("WorkspaceParserPaths"));
+    for(size_t i = 0; i < inclduePaths.GetCount(); i++) {
+        wxXmlNode* child = new wxXmlNode(workspaceInclPaths, wxXML_ELEMENT_NODE, wxT("Include"));
+        child->AddProperty(wxT("Path"), inclduePaths.Item(i));
+    }
+
+    for(size_t i = 0; i < excludePaths.GetCount(); i++) {
+        wxXmlNode* child = new wxXmlNode(workspaceInclPaths, wxXML_ELEMENT_NODE, wxT("Exclude"));
+        child->AddProperty(wxT("Path"), excludePaths.Item(i));
+    }
 }
 
 void Workspace::Save()

--- a/Plugin/workspace.h
+++ b/Plugin/workspace.h
@@ -379,6 +379,9 @@ private:
     void RemoveProjectFromBuildMatrix(ProjectPtr prj);
 
     bool SaveXmlFile();
+    
+    void SyncToLocalWorkspaceSTParserPaths();
+    void SyncFromLocalWorkspaceSTParserPaths();
 };
 
 class WXDLLIMPEXP_SDK WorkspaceST


### PR DESCRIPTION
Hi CodeLite Team and Eran

This is a PR for my Feature request https://github.com/eranif/codelite/issues/757. I talked in the forum http://forums.codelite.org/viewtopic.php?f=13&t=2950 about my reasons. Hope this version goes into the direction how you where talking about. 
The user can select the checkbox which will sync parse folders between the local database and the .workspacefile. This should not conflict with previous version of CodeLite. :D. This feature allows other programs to initialize code completion information directly into the workspace file as mentioned in the forum. 

Cengiz Terzibas (Yaakuro)