### PR TITLE
Bug when installation is not in default directory

### DIFF
--- a/LiteEditor/CMakeLists.txt
+++ b/LiteEditor/CMakeLists.txt
@@ -136,7 +136,7 @@ if(NOT APPLE)
                 DESTINATION ${CL_PREFIX}/share/icons/hicolor/32x32/apps
                 RENAME codelite.png)
         # Clear the icon cache if exists
-        install(CODE "execute_process(COMMAND rm -f ${CL_PREFIX}/share/icons/hicolor/icon-theme.cache)")
+        install(CODE "execute_process(COMMAND rm -f \$ENV{DESTDIR}/${CL_PREFIX}/share/icons/hicolor/icon-theme.cache)")
     endif (  UNIX AND NOT APPLE )
 
     install(


### PR DESCRIPTION
Hi,
I created a Gentoo ebuild for Codelite (versions 8.0 and 8.0-1), but without this modification, the process tries to delete an icone-theme cache file directly in /usr/share which the Gentoo installation process forbids. As installation is done in an image directory, the deletion must be done in this directory.
I am not sure that this correction is the best one in order to correct this bug, but at least, it works (for my ebuilds — see https://github.com/sveyret/sveyret-overlay).
Thank you.