### PR TITLE
Workspace Macro Changes for Issues 933 & 934

### DIFF
--- a/LiteEditor/code_completion_manager.cpp
+++ b/LiteEditor/code_completion_manager.cpp
@@ -583,6 +583,13 @@ bool CodeCompletionManager::GetDefinitionsAndSearchPaths(LEditor* editor,
 
     // includePaths.insert(includePaths.end(), compileIncludePaths.begin(), compileIncludePaths.end());
     definitions = proj->GetPreProcessors();
+
+    // get macros out of workspace
+    wxString strWorkspaceMacros = clCxxWorkspaceST::Get()->GetParserMacros();
+    wxArrayString workspaceMacros = wxStringTokenize(strWorkspaceMacros, wxT("\n\r"), wxTOKEN_STRTOK);
+    for(size_t i = 0; i < workspaceMacros.GetCount(); i++)
+        definitions.Add(workspaceMacros.Item(i).Trim().Trim(false).c_str());
+
     CL_DEBUG("CxxPreProcessor will use the following macros:");
     CL_DEBUG_ARR(definitions);
 

--- a/Plugin/workspace.h
+++ b/Plugin/workspace.h
@@ -321,6 +321,14 @@ public:
     void AddProjectToBuildMatrix(ProjectPtr prj);
 
     //----------------------------------
+    // Workspace Parser Macros
+    //----------------------------------
+    /**
+     * @brief return the workspace environment variables
+     */
+    wxString GetParserMacros();
+
+    //----------------------------------
     // Workspace environment variables
     //----------------------------------
     /**
@@ -390,6 +398,8 @@ private:
 
     void SyncToLocalWorkspaceSTParserPaths();
     void SyncFromLocalWorkspaceSTParserPaths();
+    void SyncToLocalWorkspaceSTParserMacros();
+    void SyncFromLocalWorkspaceSTParserMacros();
 };
 
 class WXDLLIMPEXP_SDK clCxxWorkspaceST


### PR DESCRIPTION
Fixed issue with storing macros, allowed macros to be synced from local to global, and passed macros to ctag in order to properly color #ifdefs

I am new at Git. This should only include:

Plugin/worksapce.cpp
Plugin/workspace.hpp
LiteEditor/code_completion_manager.cpp
