### PR TITLE
Bug fix in the option "Import other IDEs solution"

### DIFF
--- a/Plugin/BorlandCppBuilderImporter.cpp
+++ b/Plugin/BorlandCppBuilderImporter.cpp
@@ -47,7 +47,6 @@ GenericWorkspacePtr BorlandCppBuilderImporter::PerformImport()
     GenericProjectPtr genericProject = std::make_shared<GenericProject>();
     genericProject->name = wsInfo.GetName();
     genericProject->path = wsInfo.GetPath();
-    genericProject->createDefaultVirtualDir = true;
 
     GenericProjectCfgPtr genericProjectCfgDebug = std::make_shared<GenericProjectCfg>();
     GenericProjectCfgPtr genericProjectCfgRelease = std::make_shared<GenericProjectCfg>();

--- a/Plugin/CodeBlocksImporter.cpp
+++ b/Plugin/CodeBlocksImporter.cpp
@@ -146,7 +146,6 @@ void CodeBlocksImporter::GenerateFromProject(GenericWorkspacePtr genericWorkspac
                     wxFileName projectInfo(genericProjectData[wxT("projectFullPath")]);
                     GenericProjectPtr genericProject = std::make_shared<GenericProject>();
                     genericProject->path = projectInfo.GetPath();
-                    genericProject->createDefaultVirtualDir = true;
 
                     wxStringTokenizer deps(genericProjectData[wxT("projectDeps")], wxT(";"));
 

--- a/Plugin/DevCppImporter.cpp
+++ b/Plugin/DevCppImporter.cpp
@@ -61,7 +61,6 @@ GenericWorkspacePtr DevCppImporter::PerformImport()
                     genericProject = std::make_shared<GenericProject>();
                     genericProject->name = projectName;
                     genericProject->path = wsInfo.GetPath();
-                    genericProject->createDefaultVirtualDir = true;
 
                     genericProjectCfgDebug = std::make_shared<GenericProjectCfg>();
                     genericProjectCfgRelease = std::make_shared<GenericProjectCfg>();

--- a/Plugin/GenericImporter.h
+++ b/Plugin/GenericImporter.h
@@ -65,7 +65,6 @@ struct GenericProject {
     GenericCfgType cfgType;
     std::vector<GenericProjectCfgPtr> cfgs;
     std::vector<GenericProjectFilePtr> files;
-    bool createDefaultVirtualDir = false;
 };
 
 typedef std::shared_ptr<GenericProject> GenericProjectPtr;

--- a/Plugin/WSImporter.cpp
+++ b/Plugin/WSImporter.cpp
@@ -276,7 +276,7 @@ bool WSImporter::Import(wxString& errMsg)
                     proj->DeleteVirtualDir("src");
 
                     for(GenericProjectFilePtr file : project->files) {
-                        wxString vpath = GetVPath(file->name, file->vpath, project->createDefaultVirtualDir);
+                        wxString vpath = GetVPath(file->name, file->vpath);
 
                         wxString vDir = wxT("");
                         wxStringTokenizer vDirList(vpath, wxT(":"));
@@ -295,7 +295,7 @@ bool WSImporter::Import(wxString& errMsg)
                     for(GenericProjectCfgPtr cfg : project->cfgs) {
                         for(GenericProjectFilePtr excludeFile : cfg->excludeFiles) {
                             wxString vpath =
-                                GetVPath(excludeFile->name, excludeFile->vpath, project->createDefaultVirtualDir);
+                                GetVPath(excludeFile->name, excludeFile->vpath);
 
                             wxFileName excludeFileNameInfo(project->path + wxFileName::GetPathSeparator() +
                                                            excludeFile->name);
@@ -377,10 +377,10 @@ std::set<wxString> WSImporter::GetListEnvVarName(std::vector<wxString> elems)
     return list;
 }
 
-wxString WSImporter::GetVPath(const wxString& filename, const wxString& virtualPath, const bool& createDefaultVDir)
+wxString WSImporter::GetVPath(const wxString& filename, const wxString& virtualPath)
 {
     wxString vpath;
-    if(virtualPath.IsEmpty() && createDefaultVDir) {
+    if(virtualPath.IsEmpty()) {
         wxFileName fileInfo(filename);
         wxString ext = fileInfo.GetExt().Lower();
 

--- a/Plugin/WSImporter.h
+++ b/Plugin/WSImporter.h
@@ -23,7 +23,7 @@ protected:
 private:
     bool ContainsEnvVar(std::vector<wxString> elems);
     std::set<wxString> GetListEnvVarName(std::vector<wxString> elems);
-    wxString GetVPath(const wxString& filename, const wxString& virtualPath, const bool& createDefaultVDir);
+    wxString GetVPath(const wxString& filename, const wxString& virtualPath);
 
     wxString filename, defaultCompiler;
     std::vector<std::shared_ptr<GenericImporter> > importers;


### PR DESCRIPTION
When a solution is imported and it contains a file without virtual folder and you try move the file the ide show the error "Malformed project name".
To avoid this error is modified to always generate a virtual folder by default.