### PR TITLE
Load environment variables of configuration being used.

### DIFF
--- a/ContinuousBuild/continuousbuild.cpp
+++ b/ContinuousBuild/continuousbuild.cpp
@@ -230,7 +230,7 @@ void ContinuousBuild::DoBuild(const wxString& fileName)
     // Fire it up
     EventNotifier::Get()->AddPendingEvent(event);
 
-    EnvSetter env(NULL, NULL, projectName);
+    EnvSetter env(NULL, NULL, projectName, bldConf->GetName());
     CL_DEBUG(wxString::Format(wxT("cmd:%s\n"), cmd.c_str()));
     if(!m_buildProcess.Execute(cmd, fileName, project->GetFileName().GetPath(), this)) return;
 

--- a/Debugger/debuggergdb.cpp
+++ b/Debugger/debuggergdb.cpp
@@ -205,7 +205,7 @@ void DbgGdb::EmptyQueue()
 bool DbgGdb::Start(const DebugSessionInfo& si)
 {
     // set the environment variables
-    EnvSetter env(m_env, NULL, m_debuggeeProjectName);
+    EnvSetter env(m_env, NULL, m_debuggeeProjectName, wxEmptyString);
 
     wxString dbgExeName;
     if(!DoLocateGdbExecutable(si.debuggerPath, dbgExeName)) {
@@ -1379,7 +1379,7 @@ bool DbgGdb::Disassemble(const wxString& filename, int lineNumber)
 bool DbgGdb::Attach(const DebugSessionInfo& si)
 {
     // set the environment variables
-    EnvSetter env(m_env, NULL, m_debuggeeProjectName);
+    EnvSetter env(m_env, NULL, m_debuggeeProjectName, wxEmptyString);
 
     wxString dbgExeName;
     if(!DoLocateGdbExecutable(si.debuggerPath, dbgExeName)) {

--- a/ExternalTools/externaltools.cpp
+++ b/ExternalTools/externaltools.cpp
@@ -339,11 +339,16 @@ void ExternalToolsPlugin::DoLaunchTool(const ToolInfo& ti)
         working_dir, m_mgr, (m_mgr->GetWorkspace() ? m_mgr->GetWorkspace()->GetActiveProjectName() : ""));
 
     wxString projectName;
+    wxString configName;
     if(clCxxWorkspaceST::Get()->IsOpen()) {
         projectName = clCxxWorkspaceST::Get()->GetActiveProjectName();
+        BuildConfigPtr bldConf = clCxxWorkspaceST::Get()->GetProjBuildConf(projectName, wxEmptyString);
+        if(bldConf) {
+            configName = bldConf->GetName();
+        }
     }
 
-    EnvSetter envGuard(m_mgr->GetEnv(), NULL, projectName);
+    EnvSetter envGuard(m_mgr->GetEnv(), NULL, projectName, configName);
     m_process = ::CreateAsyncProcess(this, command, IProcessCreateDefault, working_dir);
     m_mgr->AppendOutputTabText(kOutputTab_Output, command + "\n");
 }

--- a/LLDBDebugger/LLDBPlugin.cpp
+++ b/LLDBDebugger/LLDBPlugin.cpp
@@ -348,7 +348,7 @@ void LLDBPlugin::OnDebugStart(clDebugEvent& event)
         }
 
         // Determine the executable to debug, working directory and arguments
-        EnvSetter env(NULL, NULL, pProject ? pProject->GetName() : wxString());
+        EnvSetter env(NULL, NULL, pProject ? pProject->GetName() : wxString(), bldConf->GetName());
         wxString exepath = bldConf->GetCommand();
         wxString args;
         wxString workingDirectory;

--- a/LiteEditor/app.cpp
+++ b/LiteEditor/app.cpp
@@ -867,7 +867,7 @@ void CodeLiteApp::MSWReadRegistry()
         // Supprot for wxWidgets
         if(strWx.IsEmpty() == false) {
             // we have WX installed on this machine, set the path of WXWIN & WXCFG to point to it
-            EnvMap envs = vars.GetVariables(wxT("Default"), false, wxT(""));
+            EnvMap envs = vars.GetVariables(wxT("Default"), false, wxEmptyString, wxEmptyString);
 
             if(!envs.Contains(wxT("WXWIN"))) {
                 vars.AddVariable(wxT("Default"), wxT("WXWIN"), strWx);
@@ -883,7 +883,7 @@ void CodeLiteApp::MSWReadRegistry()
         // Support for UnitTest++
         if(strUnitTestPP.IsEmpty() == false) {
             // we have UnitTest++ installed on this machine
-            EnvMap envs = vars.GetVariables(wxT("Default"), false, wxT(""));
+            EnvMap envs = vars.GetVariables(wxT("Default"), false, wxEmptyString, wxEmptyString);
 
             if(!envs.Contains(wxT("UNIT_TEST_PP_SRC_DIR"))) {
                 vars.AddVariable(wxT("Default"), wxT("UNIT_TEST_PP_SRC_DIR"), strUnitTestPP);

--- a/LiteEditor/manager.cpp
+++ b/LiteEditor/manager.cpp
@@ -1751,7 +1751,7 @@ void Manager::ExecuteNoDebug(const wxString& projectName)
     ProjectPtr proj;
 
     {
-        EnvSetter env1(NULL, NULL, projectName);
+        EnvSetter env1(NULL, NULL, projectName, wxEmptyString);
         execLine = GetProjectExecutionCommand(projectName, wd, true);
         proj = GetProject(projectName);
     }
@@ -1772,7 +1772,12 @@ void Manager::ExecuteNoDebug(const wxString& projectName)
     // execute the program:
     //- no hiding the console
     //- no redirection of the stdin/out
-    EnvSetter env(NULL, NULL, projectName);
+    wxString configName;
+    BuildConfigPtr bldConf = clCxxWorkspaceST::Get()->GetProjBuildConf(projectName, wxEmptyString);
+    if(bldConf) {
+        configName = bldConf->GetName();
+    }
+    EnvSetter env(NULL, NULL, projectName, configName);
 
     // call it again here to get the actual exection line - we do it here since
     // the environment has been applied
@@ -2055,7 +2060,7 @@ void Manager::DbgStart(long attachPid)
     dbgr->SetDebuggerInformation(dinfo);
 
     // Apply the environment variables before starting
-    EnvSetter env(NULL, NULL, proj ? proj->GetName() : wxString());
+    EnvSetter env(NULL, NULL, proj ? proj->GetName() : wxString(), bldConf ? bldConf->GetName() : wxString());
 
     if(!bldConf && attachPid == wxNOT_FOUND) {
         wxString errmsg;

--- a/LiteEditor/pluginmanager.cpp
+++ b/LiteEditor/pluginmanager.cpp
@@ -665,7 +665,7 @@ wxArrayString PluginManager::GetProjectCompileFlags(const wxString& projectName,
                     // Expand the backticks into their value
                     wxArrayString outArr;
                     // Apply the environment before executing the command
-                    EnvSetter setter(EnvironmentConfig::Instance(), NULL, projectName);
+                    EnvSetter setter(EnvironmentConfig::Instance(), NULL, projectName, dependProjbldConf->GetName());
                     ProcUtils::SafeExecuteCommand(cmpOption, outArr);
                     wxString expandedValue;
                     for(size_t j = 0; j < outArr.size(); j++) {

--- a/Plugin/builder_gnumake.cpp
+++ b/Plugin/builder_gnumake.cpp
@@ -549,7 +549,7 @@ void BuilderGnuMake::GenerateMakefile(ProjectPtr proj,
     //----------------------------------------------------------
     EvnVarList vars;
     EnvironmentConfig::Instance()->ReadObject(wxT("Variables"), &vars);
-    EnvMap varMap = vars.GetVariables(wxT(""), true, proj->GetName());
+    EnvMap varMap = vars.GetVariables(wxT(""), true, proj->GetName(), bldConf->GetName());
 
     text << wxT("##") << wxT("\n");
     text << wxT("## User defined environment variables") << wxT("\n");

--- a/Plugin/clean_request.cpp
+++ b/Plugin/clean_request.cpp
@@ -151,7 +151,7 @@ void CleanRequest::Process(IManager* manager)
     }
 
     // apply environment settings
-    EnvSetter env(NULL, &om, proj->GetName());
+    EnvSetter env(NULL, &om, proj->GetName(), m_info.GetConfiguration());
     m_proc = CreateAsyncProcess(this, cmd);
     if(!m_proc) {
 

--- a/Plugin/compile_request.cpp
+++ b/Plugin/compile_request.cpp
@@ -196,7 +196,7 @@ void CompileRequest::Process(IManager* manager)
     // Avoid Unicode chars coming from the compiler by setting LC_ALL to "C"
     om["LC_ALL"] = "C";
     
-    EnvSetter envir(env, &om, proj->GetName());
+    EnvSetter envir(env, &om, proj->GetName(), m_info.GetConfiguration());
     m_proc = CreateAsyncProcess(this, cmd);
     if(!m_proc) {
         wxString message;

--- a/Plugin/custombuildrequest.cpp
+++ b/Plugin/custombuildrequest.cpp
@@ -218,7 +218,7 @@ void CustomBuildRequest::Process(IManager* manager)
     
     // Avoid Unicode chars coming from the compiler by setting LC_ALL to "C"
     om["LC_ALL"] = "C";
-    EnvSetter environment(env, &om, proj->GetName());
+    EnvSetter environment(env, &om, proj->GetName(), m_info.GetConfiguration());
 
     m_proc = CreateAsyncProcess(this, cmd);
     if(!m_proc) {

--- a/Plugin/environmentconfig.cpp
+++ b/Plugin/environmentconfig.cpp
@@ -114,7 +114,7 @@ wxString EnvironmentConfig::ExpandVariables(const wxString &in, bool applyEnviro
     return expandedValue;
 }
 
-void EnvironmentConfig::ApplyEnv(wxStringMap_t *overrideMap, const wxString &project)
+void EnvironmentConfig::ApplyEnv(wxStringMap_t *overrideMap, const wxString &project, const wxString &config)
 {
     // We lock the CS here and it will be released in UnApplyEnv
     // this is safe to call without Locker since the UnApplyEnv 
@@ -135,7 +135,7 @@ void EnvironmentConfig::ApplyEnv(wxStringMap_t *overrideMap, const wxString &pro
     ReadObject(wxT("Variables"), &vars);
 
     // get the active environment variables set
-    EnvMap variables = vars.GetVariables(wxEmptyString, true, project);
+    EnvMap variables = vars.GetVariables(wxEmptyString, true, project, config);
 
     // if we have an "override map" place all the entries from the override map
     // into the global map before applying the environment
@@ -246,7 +246,7 @@ wxArrayString EnvironmentConfig::GetActiveSetEnvNames(bool includeWorkspace, con
     
     wxArrayString envnames;
     // get the active environment variables set
-    EnvMap variables = vars.GetVariables(wxEmptyString, includeWorkspace, project);
+    EnvMap variables = vars.GetVariables(wxEmptyString, includeWorkspace, project, wxEmptyString);
     for(size_t i=0; i<variables.GetCount(); ++i) {
         wxString key, val;
         variables.Get(i, key, val);

--- a/Plugin/environmentconfig.h
+++ b/Plugin/environmentconfig.h
@@ -57,7 +57,7 @@ class WXDLLIMPEXP_SDK EnvironmentConfig : public ConfigurationToolBase
     
 protected:
     wxString    DoExpandVariables(const wxString &in);
-    void        ApplyEnv(wxStringMap_t *overrideMap, const wxString &project);
+    void        ApplyEnv(wxStringMap_t *overrideMap, const wxString &project, const wxString &config);
     void        UnApplyEnv();
 
 public:
@@ -93,7 +93,7 @@ public:
         : m_env(EnvironmentConfig::Instance())
         , m_restoreOldValue(false) 
     {
-        m_env->ApplyEnv(om, wxEmptyString);
+        m_env->ApplyEnv(om, wxEmptyString, wxEmptyString);
     }
 
     EnvSetter(EnvironmentConfig *conf, wxStringMap_t *om = NULL) 
@@ -101,14 +101,14 @@ public:
         , m_restoreOldValue(false) 
     {
         wxUnusedVar(conf);
-        m_env->ApplyEnv(om, wxEmptyString);
+        m_env->ApplyEnv(om, wxEmptyString, wxEmptyString);
     }
-    EnvSetter(EnvironmentConfig *conf, wxStringMap_t *om, const wxString &project) 
+    EnvSetter(EnvironmentConfig *conf, wxStringMap_t *om, const wxString &project, const wxString &buildConfig) 
         : m_env(EnvironmentConfig::Instance())
         , m_restoreOldValue(false) 
     {
         wxUnusedVar(conf);
-        m_env->ApplyEnv(om, project);
+        m_env->ApplyEnv(om, project, buildConfig);
     }
     
     EnvSetter(const wxString &var, const wxString &value) 

--- a/Plugin/evnvarlist.cpp
+++ b/Plugin/evnvarlist.cpp
@@ -76,14 +76,14 @@ void EvnVarList::InsertVariable(const wxString& setName, const wxString& name, c
 
     DoGetSetVariablesStr(setName, actualSetName);
 
-    EnvMap set = GetVariables(actualSetName, false, wxT(""));
+    EnvMap set = GetVariables(actualSetName, false, wxEmptyString, wxEmptyString);
 	if ( !set.Contains(name) ) {
 		set.Put(name, value);
 	}
     m_envVarSets[actualSetName] = set.String();
 }
 
-EnvMap EvnVarList::GetVariables(const wxString& setName, bool includeWorkspaceEnvs, const wxString &projectName)
+EnvMap EvnVarList::GetVariables(const wxString& setName, bool includeWorkspaceEnvs, const wxString &projectName, const wxString &configName)
 {
     EnvMap   variables;
     wxString actualSetName;
@@ -97,7 +97,7 @@ EnvMap EvnVarList::GetVariables(const wxString& setName, bool includeWorkspaceEn
 
         if(projectName.IsEmpty() == false) {
             currentValueStr.Trim().Trim(false);
-            BuildConfigPtr buildConf = clCxxWorkspaceST::Get()->GetProjBuildConf(projectName, wxT(""));
+            BuildConfigPtr buildConf = clCxxWorkspaceST::Get()->GetProjBuildConf(projectName, configName);
             if(buildConf) {
                 currentValueStr << wxT("\n");
                 currentValueStr << buildConf->GetEnvvars();

--- a/Plugin/evnvarlist.h
+++ b/Plugin/evnvarlist.h
@@ -85,7 +85,7 @@ public:
 	 */
 	void   InsertVariable(const wxString &setName, const wxString &name, const wxString &value);
 
-	EnvMap GetVariables(const wxString &setName, bool includeWorkspaceEnvs, const wxString &projectName);
+	EnvMap GetVariables(const wxString &setName, bool includeWorkspaceEnvs, const wxString &projectName, const wxString &configName);
 	bool   IsSetExist  (const wxString &setName);
 
 public:

--- a/Plugin/globals.cpp
+++ b/Plugin/globals.cpp
@@ -1165,7 +1165,7 @@ wxString wxShellExec(const wxString& cmd, const wxString& projectName)
     WrapInShell(theCommand);
 
     wxArrayString dummy;
-    EnvSetter es(NULL, NULL, projectName);
+    EnvSetter es(NULL, NULL, projectName, wxEmptyString);
     theCommand = EnvironmentConfig::Instance()->ExpandVariables(theCommand, false);
     ProcUtils::SafeExecuteCommand(theCommand, dummy);
 

--- a/Plugin/project.cpp
+++ b/Plugin/project.cpp
@@ -1192,7 +1192,7 @@ wxArrayString Project::GetIncludePaths(bool clearCache)
     // for non custom projects, take the settings from the build configuration
     if(buildConf) {
         // Apply the environment
-        EnvSetter es(NULL, NULL, GetName());
+        EnvSetter es(NULL, NULL, GetName(), buildConf->GetName());
 
         if(clearCache) {
             s_backticks.clear();
@@ -1588,7 +1588,7 @@ wxString Project::GetCompileLineForCXXFile(const wxString& filenamePlaceholder, 
     commandLine << compilerExe << " -c " << filenamePlaceholder << " -o " << filenamePlaceholder << ".o ";
 
     // Apply the environment
-    EnvSetter es(NULL, NULL, GetName());
+    EnvSetter es(NULL, NULL, GetName(), buildConf->GetName());
 
     // Clear the backticks cache
     s_backticks.clear();
@@ -1777,7 +1777,7 @@ wxArrayString Project::GetPreProcessors(bool clearCache)
     if(buildConf) {
 
         // Apply the environment
-        EnvSetter es(NULL, NULL, GetName());
+        EnvSetter es(NULL, NULL, GetName(), buildConf->GetName());
 
         if(clearCache) {
             s_backticks.clear();
@@ -1829,7 +1829,7 @@ wxArrayString Project::DoGetCompilerOptions(bool cxxOptions, bool clearCache, bo
     if(buildConf && !buildConf->IsCustomBuild()) {
 
         // Apply the environment
-        EnvSetter es(NULL, NULL, GetName());
+        EnvSetter es(NULL, NULL, GetName(), buildConf->GetName());
 
         if(clearCache) {
             s_backticks.clear();

--- a/QmakePlugin/qmakeplugin.cpp
+++ b/QmakePlugin/qmakeplugin.cpp
@@ -597,7 +597,7 @@ void QMakePlugin::OnExportMakefile(wxCommandEvent& event)
                            << generator.GetProFileName();
             wxStringMap_t om;
             om.insert(std::make_pair("QTDIR", qtdir));
-            EnvSetter envGuard(NULL, &om, project);
+            EnvSetter envGuard(NULL, &om, project, config);
             m_mgr->ClearOutputTab(kOutputTab_Build);
             m_mgr->AppendOutputTabText(kOutputTab_Build, wxString() << "-- " << qmake_exe_line << "\n");
             m_qmakeProcess =


### PR DESCRIPTION
I tried to fix #993 myself.

The problem is that in `EnvironmentConfig::ApplyEnv` the *active* environment variables where loaded, where *active* is the build configuration active in the workspace.
In some cases (e.g. batch build from #993), the active build configuration is not the configuration active in the workspace.

I added a parameter to `ApplyEnv` to indicate what build configuration to use. `ApplyEnv` is only used by `EnvSetter`, so I also added the parameter to the relevant `EnvSetter` constructor.

For all the usages of the `EnvSetter` constructor, I added the used build configuration, or `wxEmptyString` when unknown.