### PR TITLE
Added x86 search path for libsqlite3.so

### DIFF
--- a/cmake/Modules/FindSqlite3.cmake
+++ b/cmake/Modules/FindSqlite3.cmake
@@ -5,6 +5,7 @@ if(UNIX AND NOT APPLE)
                  /usr/local/lib
                  /usr/lib
                  /usr/lib/x86_64-linux-gnu
+                 /usr/lib/i386-linux-gnu
                  )
                  
     find_path(SQLITE3_INCLUDE_DIR NAMES sqlite3.h


### PR DESCRIPTION
[cmake/Modules/FindSqlite3.cmake] Added /usr/lib/i386-linux-gnu to the default lib search path