### PR TITLE
Rename bottom git tab caption & some spell for JS

### DIFF
--- a/WebTools/webtools.cpp
+++ b/WebTools/webtools.cpp
@@ -39,7 +39,7 @@ CL_PLUGIN_API PluginInfo* GetPluginInfo()
     static PluginInfo info;
     info.SetAuthor(wxT("eran"));
     info.SetName(wxT("WebTools"));
-    info.SetDescription(_("Support for JavScript, HTML and other web development tools"));
+    info.SetDescription(_("Support for JavaScript, CSS/SCSS, HTML, XML and other web development tools"));
     info.SetVersion(wxT("v1.0"));
     return &info;
 }
@@ -53,7 +53,7 @@ WebTools::WebTools(IManager* manager)
     , m_nodejsDebuggerPane(NULL)
     , m_hideToolBarOnDebugStop(false)
 {
-    m_longName = _("Support for JavScript, XML, HTML, CSS/SCSS and other web development tools");
+    m_longName = _("Support for JavaScript, CSS/SCSS, HTML, XML and other web development tools");
     m_shortName = wxT("WebTools");
 
     // Register our new workspace type

--- a/git/git.cpp
+++ b/git/git.cpp
@@ -183,7 +183,7 @@ GitPlugin::GitPlugin(IManager* manager)
 
     // Add the console
     m_console = new GitConsole(m_mgr->GetOutputPaneNotebook(), this);
-    m_mgr->GetOutputPaneNotebook()->AddPage(m_console, _("git"), false, m_mgr->GetStdIcons()->LoadBitmap("git"));
+    m_mgr->GetOutputPaneNotebook()->AddPage(m_console, _("Git"), false, m_mgr->GetStdIcons()->LoadBitmap("git"));
     m_tabToggler.reset(new clTabTogglerHelper(_("git"), m_console, "", NULL));
     m_tabToggler->SetOutputTabBmp(m_mgr->GetStdIcons()->LoadBitmap("git"));
 


### PR DESCRIPTION
Output pane: rename caption "git" to "Git";
WebTools: some change description;