### PR TITLE
Better prefix generation

### DIFF
--- a/Plugin/builder_gnumake.cpp
+++ b/Plugin/builder_gnumake.cpp
@@ -1806,9 +1806,9 @@ wxString BuilderGnuMake::DoGetCompilerMacro(const wxString& filename)
 
 wxString BuilderGnuMake::DoGetTargetPrefix(const wxFileName& filename, const wxString& cwd, CompilerPtr cmp)
 {
-    size_t count = filename.GetDirCount();
     const wxArrayString& dirs = filename.GetDirs();
     wxString lastDir;
+    wxString ret;
 
     if(cwd == filename.GetPath()) return wxEmptyString;
 
@@ -1818,8 +1818,11 @@ wxString BuilderGnuMake::DoGetTargetPrefix(const wxFileName& filename, const wxS
         return wxEmptyString;
     }
 
-    if(count) {
-        lastDir = dirs.Item(count - 1);
+    // remove cwd from filename
+    int start = wxFileName(cwd).GetDirCount();
+
+    for(size_t i=start+1; i < filename.GetDirCount(); i++) {
+        lastDir = dirs.Item(i);
 
         // Handle special directory paths
         if(lastDir == wxT("..")) {
@@ -1832,9 +1835,11 @@ wxString BuilderGnuMake::DoGetTargetPrefix(const wxFileName& filename, const wxS
         if(lastDir.IsEmpty() == false) {
             lastDir << wxT("_");
         }
+
+        ret += lastDir;
     }
 
-    return lastDir;
+    return ret;
 }
 
 wxString BuilderGnuMake::DoGetMarkerFileDir(const wxString& projname, const wxString& projectPath)


### PR DESCRIPTION
I had a problem with the output object names not being unique in the mk file. For example I have this directory structure

opencv-3.1.0/modules/core/src/tables.cpp
opencv-3.1.0/modules/imgproc/src/tables.cpp

The current code tries to make two src_tables.cpp.o files, which causes a conflict. The files may have the same name, but the code is different.

My proposed solution generates this instead

opencv-3.1.0_modules_core_src_tables.cpp.o
opencv-3.1.0_modules_imgproc_src_tables.cpp.o

Guarantee no conflict.