### PR TITLE
Introduce an option of indented line comments

### DIFF
--- a/LiteEditor/EditorOptionsGeneralEdit.cpp
+++ b/LiteEditor/EditorOptionsGeneralEdit.cpp
@@ -14,6 +14,7 @@ EditorOptionsGeneralEdit::EditorOptionsGeneralEdit(wxWindow* parent)
     m_pgPropWrapBrackets->SetValue(options->IsWrapSelectionBrackets());
     m_pgPropWrapQuotes->SetValue(options->IsWrapSelectionWithQuotes());
     m_pgPropZoomUsingCtrlScroll->SetValue(options->IsMouseZoomEnabled());
+    m_pgPropCommentsIndented->SetValue(options->GetIndentedComments());
 }
 
 EditorOptionsGeneralEdit::~EditorOptionsGeneralEdit()
@@ -33,4 +34,5 @@ void EditorOptionsGeneralEdit::Save(OptionsConfigPtr options)
     options->SetWrapSelectionBrackets(m_pgPropWrapBrackets->GetValue().GetBool());
     options->SetWrapSelectionWithQuotes(m_pgPropWrapQuotes->GetValue().GetBool());
     options->SetMouseZoomEnabled(m_pgPropZoomUsingCtrlScroll->GetValue().GetBool());
+    options->SetIndentedComments(m_pgPropCommentsIndented->GetValue().GetBool());
 }

--- a/LiteEditor/cl_editor.h
+++ b/LiteEditor/cl_editor.h
@@ -914,6 +914,10 @@ private:
     void DoWrapPrevSelectionWithChars(wxChar first, wxChar last);
     void DoUpdateOptions();
     int GetFirstSingleLineCommentPos(int from, int commentStyle);
+    /**
+     * @brief return number of whitespace characters in the beginning of the line
+     */
+    int GetNumberFirstSpacesInLine(int line);
 
     void FillBPtoMarkerArray();
     BPtoMarker GetMarkerForBreakpt(enum BreakpointType bp_type);

--- a/LiteEditor/editor_options_guides.wxcp
+++ b/LiteEditor/editor_options_guides.wxcp
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "m_generatedFilesDir": ".",
-  "m_objCounter": 58,
+  "m_objCounter": 60,
   "m_includeFiles": [],
   "m_bitmapFunction": "wxC77E7InitBitmapResources",
   "m_bitmapsFile": "editor_options_guides_liteeditor_bitmaps.cpp",
@@ -9,6 +9,7 @@
   "m_outputFileName": "editoroptionsgeneralguidespanelbase",
   "m_firstWindowId": 1000,
   "m_useEnum": false,
+  "m_useUnderscoreMacro": true,
   "m_templateClasses": []
  },
  "windows": [{
@@ -2006,6 +2007,136 @@
              "type": "bool",
              "m_label": "Bool Value",
              "m_value": true
+            }, {
+             "type": "string",
+             "m_label": "Wildcard",
+             "m_value": ""
+            }, {
+             "type": "font",
+             "m_label": "Font:",
+             "m_value": ""
+            }, {
+             "type": "colour",
+             "m_label": "Initial Colour",
+             "colour": "<Default>"
+            }],
+           "m_events": [],
+           "m_children": []
+          }]
+        }, {
+         "m_type": 4486,
+         "proportion": 0,
+         "border": 5,
+         "gbSpan": "1,1",
+         "gbPosition": "0,0",
+         "m_styles": [],
+         "m_sizerFlags": [],
+         "m_properties": [{
+           "type": "string",
+           "m_label": "Name:",
+           "m_value": "m_pgProp565"
+          }, {
+           "type": "string",
+           "m_label": "Label:",
+           "m_value": "Comments"
+          }, {
+           "type": "multi-string",
+           "m_label": "Tooltip:",
+           "m_value": ""
+          }, {
+           "type": "colour",
+           "m_label": "Bg Colour:",
+           "colour": "<Default>"
+          }, {
+           "type": "choice",
+           "m_label": "Property Editor Control",
+           "m_selection": 0,
+           "m_options": ["", "TextCtrl", "Choice", "ComboBox", "CheckBox", "TextCtrlAndButton", "ChoiceAndButton", "SpinCtrl", "DatePickerCtrl"]
+          }, {
+           "type": "choice",
+           "m_label": "Kind:",
+           "m_selection": 0,
+           "m_options": ["wxPropertyCategory", "wxIntProperty", "wxFloatProperty", "wxBoolProperty", "wxStringProperty", "wxLongStringProperty", "wxDirProperty", "wxArrayStringProperty", "wxFileProperty", "wxEnumProperty", "wxEditEnumProperty", "wxFlagsProperty", "wxDateProperty", "wxImageFileProperty", "wxFontProperty", "wxSystemColourProperty"]
+          }, {
+           "type": "string",
+           "m_label": "String Value",
+           "m_value": ""
+          }, {
+           "type": "multi-string",
+           "m_label": "Choices:",
+           "m_value": ""
+          }, {
+           "type": "multi-string",
+           "m_label": "Array Integer Values",
+           "m_value": ""
+          }, {
+           "type": "bool",
+           "m_label": "Bool Value",
+           "m_value": true
+          }, {
+           "type": "string",
+           "m_label": "Wildcard",
+           "m_value": ""
+          }, {
+           "type": "font",
+           "m_label": "Font:",
+           "m_value": ""
+          }, {
+           "type": "colour",
+           "m_label": "Initial Colour",
+           "colour": "<Default>"
+          }],
+         "m_events": [],
+         "m_children": [{
+           "m_type": 4486,
+           "proportion": 0,
+           "border": 5,
+           "gbSpan": "1,1",
+           "gbPosition": "0,0",
+           "m_styles": [],
+           "m_sizerFlags": [],
+           "m_properties": [{
+             "type": "string",
+             "m_label": "Name:",
+             "m_value": "m_pgPropCommentsIndented"
+            }, {
+             "type": "string",
+             "m_label": "Label:",
+             "m_value": "Indented line comments"
+            }, {
+             "type": "multi-string",
+             "m_label": "Tooltip:",
+             "m_value": "Indent line comments (C++-style comments) according to the indentation of the selected fragmant of the text"
+            }, {
+             "type": "colour",
+             "m_label": "Bg Colour:",
+             "colour": "<Default>"
+            }, {
+             "type": "choice",
+             "m_label": "Property Editor Control",
+             "m_selection": 0,
+             "m_options": ["", "TextCtrl", "Choice", "ComboBox", "CheckBox", "TextCtrlAndButton", "ChoiceAndButton", "SpinCtrl", "DatePickerCtrl"]
+            }, {
+             "type": "choice",
+             "m_label": "Kind:",
+             "m_selection": 3,
+             "m_options": ["wxPropertyCategory", "wxIntProperty", "wxFloatProperty", "wxBoolProperty", "wxStringProperty", "wxLongStringProperty", "wxDirProperty", "wxArrayStringProperty", "wxFileProperty", "wxEnumProperty", "wxEditEnumProperty", "wxFlagsProperty", "wxDateProperty", "wxImageFileProperty", "wxFontProperty", "wxSystemColourProperty"]
+            }, {
+             "type": "string",
+             "m_label": "String Value",
+             "m_value": ""
+            }, {
+             "type": "multi-string",
+             "m_label": "Choices:",
+             "m_value": ""
+            }, {
+             "type": "multi-string",
+             "m_label": "Array Integer Values",
+             "m_value": ""
+            }, {
+             "type": "bool",
+             "m_label": "Bool Value",
+             "m_value": false
             }, {
              "type": "string",
              "m_label": "Wildcard",

--- a/LiteEditor/editoroptionsgeneralguidespanelbase.cpp
+++ b/LiteEditor/editoroptionsgeneralguidespanelbase.cpp
@@ -154,6 +154,12 @@ EditorOptionsGeneralEditBase::EditorOptionsGeneralEditBase(wxWindow* parent, wxW
     m_pgPropZoomUsingCtrlScroll = m_pgMgrEdit->AppendIn( m_pgProp56,  new wxBoolProperty( _("Enable mouse zoom"), wxPG_LABEL, 1) );
     m_pgPropZoomUsingCtrlScroll->SetHelpString(_("When holding Ctrl/CMD + scrolling with the mouse zoom the text"));
     
+    m_pgProp565 = m_pgMgrEdit->Append(  new wxPropertyCategory( _("Comments") ) );
+    m_pgProp565->SetHelpString(wxT(""));
+    
+    m_pgPropCommentsIndented = m_pgMgrEdit->AppendIn( m_pgProp565,  new wxBoolProperty( _("Indented line comments"), wxPG_LABEL, 0) );
+    m_pgPropCommentsIndented->SetHelpString(_("Indent line comments (C++-style comments) according to the indentation of the selected fragmant of the text"));
+    
     SetName(wxT("EditorOptionsGeneralEditBase"));
     SetSizeHints(500,300);
     if ( GetSizer() ) {

--- a/LiteEditor/editoroptionsgeneralguidespanelbase.h
+++ b/LiteEditor/editoroptionsgeneralguidespanelbase.h
@@ -91,6 +91,8 @@ protected:
     wxPGProperty* m_pgPropWrapBrackets;
     wxPGProperty* m_pgProp56;
     wxPGProperty* m_pgPropZoomUsingCtrlScroll;
+    wxPGProperty* m_pgProp565;
+    wxPGProperty* m_pgPropCommentsIndented;
 
 protected:
     virtual void OnValueChanged(wxPropertyGridEvent& event) { event.Skip(); }

--- a/Plugin/optionsconfig.cpp
+++ b/Plugin/optionsconfig.cpp
@@ -128,6 +128,7 @@ OptionsConfig::OptionsConfig(wxXmlNode* node)
           Opt_TabStyleMinimal)
     , m_workspaceTabsDirection(wxUP)
     , m_outputTabsDirection(wxUP)
+    , m_indentedComments(false)
 {
     m_debuggerMarkerLine = DrawingUtils::LightColour("LIME GREEN", 8.0);
     m_mswTheme = false;
@@ -214,6 +215,7 @@ OptionsConfig::OptionsConfig(wxXmlNode* node)
         m_options = XmlUtils::ReadLong(node, wxT("m_options"), m_options);
         m_debuggerMarkerLine = XmlUtils::ReadString(
             node, wxT("m_debuggerMarkerLine"), m_debuggerMarkerLine.GetAsString(wxC2S_HTML_SYNTAX));
+        m_indentedComments = XmlUtils::ReadBool(node, wxT("IndentedComments"), m_indentedComments);
 
         // These hacks will likely be changed in the future. If so, we'll be able to remove the #include
         // "editor_config.h" too
@@ -311,6 +313,7 @@ wxXmlNode* OptionsConfig::ToXml() const
     n->AddProperty(wxT("m_debuggerMarkerLine"), m_debuggerMarkerLine.GetAsString(wxC2S_HTML_SYNTAX));
     n->AddProperty(wxT("OutputTabsDirection"), wxString() << (int)m_outputTabsDirection);
     n->AddProperty(wxT("WorkspaceTabsDirection"), wxString() << (int)m_workspaceTabsDirection);
+    n->AddProperty(wxT("IndentedComments"), BoolToString(m_indentedComments));
 
     wxString tmp;
     tmp << m_indentWidth;

--- a/Plugin/optionsconfig.h
+++ b/Plugin/optionsconfig.h
@@ -140,6 +140,7 @@ protected:
     wxColour m_debuggerMarkerLine;
     wxDirection m_workspaceTabsDirection; // Up/Down/Left/Right
     wxDirection m_outputTabsDirection;    // Up/Down
+    bool m_indentedComments;
 
 public:
     // Helpers
@@ -290,6 +291,7 @@ public:
 
     bool GetHideChangeMarkerMargin() const { return m_hideChangeMarkerMargin; }
 
+    bool GetIndentedComments() const { return m_indentedComments; }
     bool GetDisplayFoldMargin() const { return m_displayFoldMargin; }
     bool GetUnderlineFoldLine() const { return m_underlineFoldLine; }
     bool GetScrollBeyondLastLine() const { return m_scrollBeyondLastLine; }
@@ -309,6 +311,7 @@ public:
     bool GetShowIndentationGuidelines() const { return m_showIndentationGuidelines; }
     wxColour GetCaretLineColour() const { return m_caretLineColour; }
 
+    void SetIndentedComments(bool b) { m_indentedComments = b; }
     void SetDisplayFoldMargin(bool b) { m_displayFoldMargin = b; }
     void SetUnderlineFoldLine(bool b) { m_underlineFoldLine = b; }
     void SetScrollBeyondLastLine(bool b) { m_scrollBeyondLastLine = b; }


### PR DESCRIPTION
Propose a feature of making the line comments (C++-style comments) indented. Currently, CodeLite places line comments in the very beginning of each commented line. Like this, for example:

```cpp
int LEditor::GetFirstSingleLineCommentPos(int from, int commentStyle)
{
    int lineNu = LineFromPos(from);
    int lastPos = from + LineLength(lineNu);
    for(int i = from; i < lastPos; ++i) {
//        if(GetStyleAt(i) == commentStyle) {
//            return i;
//        }
    }
    return wxNOT_FOUND;
}
```

The new behaviour is to indent the comments to the right so that the column of comments touches the text. The same fragment of code with the new indented comments:

```cpp
int LEditor::GetFirstSingleLineCommentPos(int from, int commentStyle)
{
    int lineNu = LineFromPos(from);
    int lastPos = from + LineLength(lineNu);
    for(int i = from; i < lastPos; ++i) {
        //if(GetStyleAt(i) == commentStyle) {
        //    return i;
        //}
    }
    return wxNOT_FOUND;
}
```

The feature is optional, of course. The setting to enable/disable the indented comments is added to the CodeLite settings:
Editor Settings -> Editor -> Edit -> Comments -> Indented line comments.
By default, the feature is disabled so that the users will have the conventional behaviour unless the setting is changed.