### PR TITLE
Prevent initial value of CMAKE_CXX_FLAGS being clobbered

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set( BUILD_WXC 0 )
 set( CL_COPY_WX_LIBS 0 )
 set( WITH_SFTP 1 )
 
-set (CMAKE_CXX_FLAGS -Wno-deprecated-declarations) # Avoid very multiple warnings spam due to deprecated wx methods
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations") # Avoid very multiple warnings spam due to deprecated wx methods
 
 if ( UNIX )
     execute_process(COMMAND pwd OUTPUT_VARIABLE BUILD_DIRECTORY OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
This allows distributions (or anyone else) to add additional flags by setting the CXXFLAGS environment variable.