### PR TITLE
Mass spelling fixes

### DIFF
--- a/CMakePlugin/CMake.cpp
+++ b/CMakePlugin/CMake.cpp
@@ -383,7 +383,7 @@ CMake::LoadFromDatabase()
         }
 
     } catch (const wxSQLite3Exception& e) {
-        CL_ERROR("Error occured while loading data from CMake database: %s", e.GetMessage());
+        CL_ERROR("Error occurred while loading data from CMake database: %s", e.GetMessage());
     }
 
     // Everything is loaded
@@ -468,7 +468,7 @@ CMake::StoreIntoDatabase()
         db.Commit();
 
     } catch (wxSQLite3Exception &e) {
-        CL_ERROR("An error occured while storing CMake data into database: %s", e.GetMessage());
+        CL_ERROR("An error occurred while storing CMake data into database: %s", e.GetMessage());
     }
 }
 

--- a/CMakePlugin/CMakePlugin.wxcp
+++ b/CMakePlugin/CMakePlugin.wxcp
@@ -451,7 +451,7 @@
           }, {
            "type": "multi-string",
            "m_label": "Tooltip:",
-           "m_value": "You can specify default generator for all projects (if is not overrided by project settings). If generator is not selected the CMake uses platform's default."
+           "m_value": "You can specify default generator for all projects (if is not overridden by project settings). If generator is not selected the CMake uses platform's default."
           }, {
            "type": "colour",
            "m_label": "Bg Colour:",

--- a/CMakePlugin/CMakePluginUi.cpp
+++ b/CMakePlugin/CMakePluginUi.cpp
@@ -49,7 +49,7 @@ CMakeSettingsDialogBase::CMakeSettingsDialogBase(wxWindow* parent, wxWindowID id
     
     wxArrayString m_choiceDefaultGeneratorArr;
     m_choiceDefaultGenerator = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxSize(-1,-1), m_choiceDefaultGeneratorArr, 0);
-    m_choiceDefaultGenerator->SetToolTip(_("You can specify default generator for all projects (if is not overrided by project settings). If generator is not selected the CMake uses platform's default."));
+    m_choiceDefaultGenerator->SetToolTip(_("You can specify default generator for all projects (if is not overridden by project settings). If generator is not selected the CMake uses platform's default."));
     
     flexGridSizer->Add(m_choiceDefaultGenerator, 1, wxALL|wxEXPAND|wxALIGN_CENTER_VERTICAL, 5);
     

--- a/CodeFormatter/codeformatterdlg.wxcp
+++ b/CodeFormatter/codeformatterdlg.wxcp
@@ -3636,7 +3636,7 @@
                           }, {
                            "type": "multi-string",
                            "m_label": "Choices:",
-                           "m_value": "Break before class;Break before function;Break before 'while';Break before 'foreach';'else' doesn't break;Break after 'heredoc' statement;Break PHP Arrays vertically;Break after string concatentation operator (\".\")"
+                           "m_value": "Break before class;Break before function;Break before 'while';Break before 'foreach';'else' doesn't break;Break after 'heredoc' statement;Break PHP Arrays vertically;Break after string concatenation operator (\".\")"
                           }, {
                            "type": "multi-string",
                            "m_label": "Array Integer Values",

--- a/CodeFormatter/codeformatterdlgbase.cpp
+++ b/CodeFormatter/codeformatterdlgbase.cpp
@@ -445,7 +445,7 @@ CodeFormatterBaseDlg::CodeFormatterBaseDlg(wxWindow* parent, wxWindowID id, cons
     m_pgMgrPhpArr.Add(_("'else' doesn't break"));
     m_pgMgrPhpArr.Add(_("Break after 'heredoc' statement"));
     m_pgMgrPhpArr.Add(_("Break PHP Arrays vertically"));
-    m_pgMgrPhpArr.Add(_("Break after string concatentation operator (\".\")"));
+    m_pgMgrPhpArr.Add(_("Break after string concatenation operator (\".\")"));
     m_pgMgrPhpIntArr.Add(kPFF_BreakBeforeClass);
     m_pgMgrPhpIntArr.Add(kPFF_BreakBeforeFunction);
     m_pgMgrPhpIntArr.Add(kPFF_BreakBeforeWhile);

--- a/CodeLite/SocketAPI/clSocketBase.cpp
+++ b/CodeLite/SocketAPI/clSocketBase.cpp
@@ -129,7 +129,7 @@ int clSocketBase::SelectRead(long seconds) throw(clSocketException)
         return kTimeout;
 
     } else if(rc < 0) {
-        // an error occured
+        // an error occurred
         throw clSocketException("SelectRead failed: " + error());
 
     } else {
@@ -337,7 +337,7 @@ int clSocketBase::SelectWriteMS(long milliSeconds) throw(clSocketException)
         return kTimeout;
 
     } else if(rc < 0) {
-        // an error occured
+        // an error occurred
         throw clSocketException("SelectWriteMS failed: " + error());
 
     } else {
@@ -368,7 +368,7 @@ int clSocketBase::SelectWrite(long seconds) throw(clSocketException)
         return kTimeout;
 
     } else if(rc < 0) {
-        // an error occured
+        // an error occurred
         throw clSocketException("SelectRead failed: " + error());
 
     } else {
@@ -400,7 +400,7 @@ int clSocketBase::SelectReadMS(long milliSeconds) throw(clSocketException)
         return kTimeout;
 
     } else if(rc < 0) {
-        // an error occured
+        // an error occurred
         throw clSocketException("SelectRead failed: " + error());
 
     } else {

--- a/CodeLite/cl_sftp.h
+++ b/CodeLite/cl_sftp.h
@@ -109,7 +109,7 @@ public:
      * @param folder
      * @param foldersOnly
      * @param filter filter out files that do not match the filter
-     * @throw clException incase an error occured
+     * @throw clException incase an error occurred
      */
     SFTPAttribute::List_t List(const wxString &folder, size_t flags, const wxString &filter = "") throw (clException);
 

--- a/CodeLite/cl_ssh.cpp
+++ b/CodeLite/cl_ssh.cpp
@@ -183,7 +183,7 @@ bool clSSH::AuthenticateServer(wxString& message) throw(clException)
 
     default:
     case SSH_SERVER_ERROR:
-        throw clException(wxString() << "An error occured: " << ssh_get_error(m_session));
+        throw clException(wxString() << "An error occurred: " << ssh_get_error(m_session));
     }
     return false;
 }

--- a/CodeLite/winprocess_impl.h
+++ b/CodeLite/winprocess_impl.h
@@ -54,7 +54,7 @@ public:
 
     /**
      * @brief read data from stdout, if no data is available, return
-     * if timeout occured, return with true.
+     * if timeout occurred, return with true.
      * @param buff check the buffer when true is returned
      * @return return true on success or timeout, flase otherwise, incase of false the reader thread will terminate
      */

--- a/DatabaseExplorer/DbViewerPanel.cpp
+++ b/DatabaseExplorer/DbViewerPanel.cpp
@@ -223,7 +223,7 @@ void DbViewerPanel::OnItemActivate(wxTreeEvent& event)
         }
 
     } catch(DatabaseLayerException& e) {
-        ::wxMessageBox(wxString() << "Error occured while opening SQL panel: " << e.GetErrorMessage(),
+        ::wxMessageBox(wxString() << "Error occurred while opening SQL panel: " << e.GetErrorMessage(),
                        "Database Explorer",
                        wxOK | wxICON_ERROR | wxCENTER);
     }

--- a/DatabaseExplorer/dbconnection.h
+++ b/DatabaseExplorer/dbconnection.h
@@ -30,7 +30,7 @@
 #include <wx/dblayer/include/DatabaseResultSet.h>
 #include <wx/wxxmlserializer/XmlSerializer.h>
 #include "IDbAdapter.h"
-/*! \brief Class representing one db conneciton */
+/*! \brief Class representing one db connection */
 class DbConnection : public xsSerializable {
 
 public:

--- a/LLDBDebugger/LLDBProtocol/LLDBNetworkListenerThread.cpp
+++ b/LLDBDebugger/LLDBProtocol/LLDBNetworkListenerThread.cpp
@@ -132,7 +132,7 @@ void* LLDBNetworkListenerThread::Entry()
                 }
             }
         } catch(clSocketException& e) {
-            CL_WARNING("Seems like we lost conneciton to codelite-lldb (probably crashed): %s", e.what().c_str());
+            CL_WARNING("Seems like we lost connection to codelite-lldb (probably crashed): %s", e.what().c_str());
             LLDBEvent event(wxEVT_LLDB_CRASHED);
             m_owner->AddPendingEvent(event);
 

--- a/LLDBDebugger/codelite-lldb/CodeLiteLLDBApp.cpp
+++ b/LLDBDebugger/codelite-lldb/CodeLiteLLDBApp.cpp
@@ -715,7 +715,7 @@ void CodeLiteLLDBApp::AcceptNewConnection() throw(clSocketException)
         m_networkThread->Start();
 
     } catch(clSocketException& e) {
-        wxPrintf("codelite-lldb: an error occured while waiting for connection. %s\n", e.what().c_str());
+        wxPrintf("codelite-lldb: an error occurred while waiting for connection. %s\n", e.what().c_str());
         Cleanup();
 
         // exit
@@ -870,7 +870,7 @@ void CodeLiteLLDBApp::MainLoop()
 
     } catch(clSocketException& e) {
         wxPrintf(
-            "codelite-lldb: an error occured during MainLoop(). %s. strerror=%s\n", e.what().c_str(), strerror(errno));
+            "codelite-lldb: an error occurred during MainLoop(). %s. strerror=%s\n", e.what().c_str(), strerror(errno));
         // exit now
         exit(0);
     }

--- a/LiteEditor/clang_pch_maker_thread.cpp
+++ b/LiteEditor/clang_pch_maker_thread.cpp
@@ -112,7 +112,7 @@ void ClangWorkerThread::ProcessRequest(ThreadRequest* request)
 
         } else {
 
-            CL_DEBUG(wxT("An error occured during reparsing of the TU for file %s. TU: %p"),
+            CL_DEBUG(wxT("An error occurred during reparsing of the TU for file %s. TU: %p"),
                      task->GetFileName().c_str(),
                      (void*)TU);
 
@@ -461,7 +461,7 @@ CXTranslationUnit ClangWorkerThread::DoCreateTU(CXIndex index, ClangThreadReques
             return TU;
 
         } else {
-            CL_DEBUG(wxT("An error occured during reparsing of the TU for file %s. TU: %p"),
+            CL_DEBUG(wxT("An error occurred during reparsing of the TU for file %s. TU: %p"),
                      task->GetFileName().c_str(),
                      (void*)TU);
 

--- a/LiteEditor/compiler_page.wxcp
+++ b/LiteEditor/compiler_page.wxcp
@@ -3616,7 +3616,7 @@
                     }, {
                      "type": "multi-string",
                      "m_label": "Tooltip:",
-                     "m_value": "Set the 'mkdir' for your OS.\\nLeave it empty to use the defualt for your OS"
+                     "m_value": "Set the 'mkdir' for your OS.\\nLeave it empty to use the default for your OS"
                     }, {
                      "type": "colour",
                      "m_label": "Bg Colour:",

--- a/LiteEditor/compiler_pages.cpp
+++ b/LiteEditor/compiler_pages.cpp
@@ -373,7 +373,7 @@ CompilerMainPageBase::CompilerMainPageBase(wxWindow* parent, wxWindowID id, cons
     m_pgPropMAKE->SetEditor( wxT("TextCtrlAndButton") );
     
     m_pgPropMkdir = m_pgMgrTools->AppendIn( m_pgProp94,  new wxStringProperty( _("mkdir"), wxPG_LABEL, wxT("")) );
-    m_pgPropMkdir->SetHelpString(_("Set the 'mkdir' for your OS.\nLeave it empty to use the defualt for your OS"));
+    m_pgPropMkdir->SetHelpString(_("Set the 'mkdir' for your OS.\nLeave it empty to use the default for your OS"));
     m_pgPropMkdir->SetEditor( wxT("TextCtrlAndButton") );
     
     m_pgPropDebugger = m_pgMgrTools->AppendIn( m_pgProp94,  new wxStringProperty( _("Gdb"), wxPG_LABEL, wxT("")) );

--- a/LiteEditor/editor_options_comments_doxygen.wxcp
+++ b/LiteEditor/editor_options_comments_doxygen.wxcp
@@ -419,7 +419,7 @@
             }, {
              "type": "multi-string",
              "m_label": "Tooltip:",
-             "m_value": "Set the template to use when generating documetation for a class (or C/C++ struct).\\nThe following macros are available: $(CurrentFileName), $(CurrentFilePath), $(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), $(ProjectName), $(WorkspaceName)"
+             "m_value": "Set the template to use when generating documentation for a class (or C/C++ struct).\\nThe following macros are available: $(CurrentFileName), $(CurrentFilePath), $(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), $(ProjectName), $(WorkspaceName)"
             }, {
              "type": "colour",
              "m_label": "Bg Colour:",
@@ -484,7 +484,7 @@
             }, {
              "type": "multi-string",
              "m_label": "Tooltip:",
-             "m_value": "Set the template to use when generating documetation for a function\\nThe following macros are available: $(CurrentFileName), $(CurrentFilePath), $(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), $(ProjectName), $(WorkspaceName)"
+             "m_value": "Set the template to use when generating documentation for a function\\nThe following macros are available: $(CurrentFileName), $(CurrentFilePath), $(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), $(ProjectName), $(WorkspaceName)"
             }, {
              "type": "colour",
              "m_label": "Bg Colour:",

--- a/LiteEditor/editor_options_folding.wxcp
+++ b/LiteEditor/editor_options_folding.wxcp
@@ -714,7 +714,7 @@
             }, {
              "type": "multi-string",
              "m_label": "Tooltip:",
-             "m_value": "Allows to enable/disable the highlight folding block when it is selected. (i.e. block that contains the caret)"
+             "m_value": "Allows enabling/disabling the highlight folding block when it is selected. (i.e. block that contains the caret)"
             }, {
              "type": "colour",
              "m_label": "Bg Colour:",

--- a/LiteEditor/editorsettingscommentsdoxygenpanelbase.cpp
+++ b/LiteEditor/editorsettingscommentsdoxygenpanelbase.cpp
@@ -44,11 +44,11 @@ EditorSettingsCommentsDoxygenPanelBase::EditorSettingsCommentsDoxygenPanelBase(w
     m_pgProp4->SetHelpString(wxT(""));
     
     m_pgPropDoxyClassPrefix = m_pgMgrDoxy->AppendIn( m_pgProp4,  new wxStringProperty( _("Class documentation template"), wxPG_LABEL, wxT("")) );
-    m_pgPropDoxyClassPrefix->SetHelpString(_("Set the template to use when generating documetation for a class (or C/C++ struct).\nThe following macros are available: $(CurrentFileName), $(CurrentFilePath), $(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), $(ProjectName), $(WorkspaceName)"));
+    m_pgPropDoxyClassPrefix->SetHelpString(_("Set the template to use when generating documentation for a class (or C/C++ struct).\nThe following macros are available: $(CurrentFileName), $(CurrentFilePath), $(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), $(ProjectName), $(WorkspaceName)"));
     m_pgPropDoxyClassPrefix->SetEditor( wxT("TextCtrlAndButton") );
     
     m_pgPropDoxyFunctionPrefix = m_pgMgrDoxy->AppendIn( m_pgProp4,  new wxStringProperty( _("Function documentation template"), wxPG_LABEL, wxT("")) );
-    m_pgPropDoxyFunctionPrefix->SetHelpString(_("Set the template to use when generating documetation for a function\nThe following macros are available: $(CurrentFileName), $(CurrentFilePath), $(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), $(ProjectName), $(WorkspaceName)"));
+    m_pgPropDoxyFunctionPrefix->SetHelpString(_("Set the template to use when generating documentation for a function\nThe following macros are available: $(CurrentFileName), $(CurrentFilePath), $(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), $(ProjectName), $(WorkspaceName)"));
     m_pgPropDoxyFunctionPrefix->SetEditor( wxT("TextCtrlAndButton") );
     
     SetName(wxT("EditorSettingsCommentsDoxygenPanelBase"));

--- a/LiteEditor/editorsettingsfoldingbase.cpp
+++ b/LiteEditor/editorsettingsfoldingbase.cpp
@@ -71,7 +71,7 @@ EditorSettingsFoldingBase::EditorSettingsFoldingBase(wxWindow* parent, wxWindowI
     
     m_checkBoxHighlightFolding = new wxCheckBox(this, wxID_ANY, _("Highlight Active Fold Block"), wxDefaultPosition, wxSize(-1,-1), 0);
     m_checkBoxHighlightFolding->SetValue(false);
-    m_checkBoxHighlightFolding->SetToolTip(_("Allows to enable/disable the highlight folding block when it is selected. (i.e. block that contains the caret)"));
+    m_checkBoxHighlightFolding->SetToolTip(_("Allows enabling/disabling the highlight folding block when it is selected. (i.e. block that contains the caret)"));
     
     fgSizer1->Add(m_checkBoxHighlightFolding, 0, wxALL, 5);
     

--- a/LiteEditor/frame.cpp
+++ b/LiteEditor/frame.cpp
@@ -2709,7 +2709,7 @@ void clMainFrame::OnBuildEnded(clCommandEvent& event)
 
     if(m_buildAndRun) {
         // If the build process was part of a 'Build and Run' command, check whether an erros
-        // occured during build process, if non, launch the output
+        // occurred during build process, if non, launch the output
         m_buildAndRun = false;
         if(ManagerST::Get()->IsBuildEndedSuccessfully() ||
             wxMessageBox(_("Build ended with errors. Continue?"), _("Confirm"), wxYES_NO | wxICON_QUESTION, this) ==

--- a/LiteEditor/mainbook.cpp
+++ b/LiteEditor/mainbook.cpp
@@ -799,7 +799,7 @@ void MainBook::ReloadExternallyModified(bool prompt)
 
     time_t workspaceModifiedTimeAfter = clCxxWorkspaceST::Get()->GetFileLastModifiedTime();
     if(workspaceModifiedTimeBefore != workspaceModifiedTimeAfter) {
-        // a workspace reload occured between the "Reload Modified Files" and
+        // a workspace reload occurred between the "Reload Modified Files" and
         // the "Reload WOrkspace" dialog, cancel this it's not needed anymore
         return;
     }

--- a/LiteEditor/quickfindbar.cpp
+++ b/LiteEditor/quickfindbar.cpp
@@ -122,7 +122,7 @@ QuickFindBar::QuickFindBar(wxWindow* parent, wxWindowID id)
     btnMarker->Bind(wxEVT_CMD_FLATBUTTON_CLICK, &QuickFindBar::OnHighlightMatches, this);
     btnMarker->Bind(wxEVT_UPDATE_UI, &QuickFindBar::OnHighlightMatchesUI, this);
     btnMarker->Bind(wxEVT_KEY_DOWN, &QuickFindBar::OnKeyDown, this);
-    btnMarker->SetToolTip(_("Highlight Occurences"));
+    btnMarker->SetToolTip(_("Highlight Occurrences"));
 
     //=======----------------------
     // Find what:

--- a/Plugin/VirtualDirectorySelectorDlg.cpp
+++ b/Plugin/VirtualDirectorySelectorDlg.cpp
@@ -337,7 +337,7 @@ void VirtualDirectorySelectorDlg::OnNewVD(wxCommandEvent& event)
     wxString errmsg;
     if(!clCxxWorkspaceST::Get()->CreateVirtualDirectory(curpath, errmsg, true)) {
         wxMessageBox(
-            _("Error occured while creating virtual folder:\n") + errmsg, "codelite", wxOK | wxICON_WARNING | wxCENTER);
+            _("Error occurred while creating virtual folder:\n") + errmsg, "codelite", wxOK | wxICON_WARNING | wxCENTER);
         return;
     }
 

--- a/Plugin/builder.h
+++ b/Plugin/builder.h
@@ -65,7 +65,7 @@ public:
 
     // ================ API ==========================
     // The below API as default implementation, but can be
-    // overrided in the derived class
+    // overridden in the derived class
     // ================ API ==========================
 
     /**

--- a/Plugin/builder_NMake.cpp
+++ b/Plugin/builder_NMake.cpp
@@ -1068,7 +1068,7 @@ void BuilderNMake::CreateTargets(const wxString& type, BuildConfigPtr bldConf, w
         markRebuilt = false;
     }
 
-    // If a link occured, mark this project as "rebuilt" so the parent project will
+    // If a link occurred, mark this project as "rebuilt" so the parent project will
     // know that a re-link is required
     if(bldConf->IsLinkerRequired() && markRebuilt) {
         text << wxT("\t@$(MakeDirCommand) \"") << DoGetMarkerFileDir(wxEmptyString) << wxT("\"\n");

--- a/Plugin/builder_gnumake.cpp
+++ b/Plugin/builder_gnumake.cpp
@@ -1075,7 +1075,7 @@ void BuilderGnuMake::CreateTargets(
         markRebuilt = false;
     }
 
-    // If a link occured, mark this project as "rebuilt" so the parent project will
+    // If a link occurred, mark this project as "rebuilt" so the parent project will
     // know that a re-link is required
     if(bldConf->IsLinkerRequired() && markRebuilt) {
         text << wxT("\t@$(MakeDirCommand) \"") << DoGetMarkerFileDir(wxEmptyString) << wxT("\"\n");

--- a/Plugin/cl_treelistctrl.cpp
+++ b/Plugin/cl_treelistctrl.cpp
@@ -1388,7 +1388,7 @@ void clTreeListHeaderWindow::OnMouse(wxMouseEvent& event)
         // end of the current column
         int xpos = 0;
 
-        // find the column where this event occured
+        // find the column where this event occurred
         int countCol = GetColumnCount();
         for(int column = 0; column < countCol; column++) {
             if(!IsColumnShown(column)) continue; // do next if not shown

--- a/Plugin/dtl/Diff3.hpp
+++ b/Plugin/dtl/Diff3.hpp
@@ -119,7 +119,7 @@ namespace dtl {
                     return true;
                 } else {                              // A != B != C
                     S = merge_();
-                    if (isConflict()) {               // conflict occured
+                    if (isConflict()) {               // conflict occurred
                         return false;
                     }
                 }

--- a/Plugin/lexer_configuration.h
+++ b/Plugin/lexer_configuration.h
@@ -203,7 +203,7 @@ public:
 
     /**
      * @brief return the font for a given style id
-     * @return return wxNullFont if error occured or could locate the style
+     * @return return wxNullFont if error occurred or could locate the style
      */
     wxFont GetFontForSyle(int styleId) const;
 };

--- a/Plugin/workspace.cpp
+++ b/Plugin/workspace.cpp
@@ -154,7 +154,7 @@ bool clCxxWorkspace::OpenWorkspace(const wxString& fileName, wxString& errMsg)
             wxString projectPath = child->GetPropVal(wxT("Path"), wxEmptyString);
 
             if(!DoAddProject(projectPath, errMsg)) {
-                tmperr << wxString::Format(wxT("Error occured while loading project: \"%s\"\nCodeLite has removed the "
+                tmperr << wxString::Format(wxT("Error occurred while loading project: \"%s\"\nCodeLite has removed the "
                                                "faulty project from the workspace\n"),
                                            projectPath.c_str());
                 removedChildren.push_back(child);

--- a/SnipWiz/wxSerialize.h
+++ b/SnipWiz/wxSerialize.h
@@ -582,7 +582,7 @@ public:
 	*/
     bool Eof();
 
-	/** Returns true when the wxSerialize is in OK condition. This means no error occured. Errors that can occur are
+	/** Returns true when the wxSerialize is in OK condition. This means no error occurred. Errors that can occur are
 	    for example:
 	        - The underlying stream reports that it is not OK (not able to write, not able to read)
 	        - Reading an unexpected type of variable (e.g. expecting int and reading back string)
@@ -723,7 +723,7 @@ public:
         wxSerialize a(stream);
 
         // without the a.IsOk() it will work too, but serializing will
-        // go on writing to dev/null without aborting when an error occured.
+        // go on writing to dev/null without aborting when an error occurred.
 
         if(a.IsOk())
         {
@@ -750,7 +750,7 @@ public:
         wxSerialize a(stream);
 
         // without the a.IsOk() it will work too, but serializing will
-        // go on without aborting when an error occured.
+        // go on without aborting when an error occurred.
 
         if(a.IsOk())
         {

--- a/Subversion2/svn_command_handlers.cpp
+++ b/Subversion2/svn_command_handlers.cpp
@@ -203,7 +203,7 @@ void SvnCheckoutHandler::Process(const wxString& output)
 void SvnBlameHandler::Process(const wxString& output)
 {
     if(output.StartsWith(wxT("svn:"))) {
-        // error occured
+        // error occurred
         GetPlugin()->GetConsole()->AppendText(output);
         GetPlugin()->GetConsole()->AppendText(wxT("--------\n"));
         return;
@@ -218,7 +218,7 @@ void SvnBlameHandler::Process(const wxString& output)
 void SvnRepoListHandler::Process(const wxString& output)
 {
     if(output.StartsWith(wxT("svn:"))) {
-        // error occured
+        // error occurred
         GetPlugin()->GetConsole()->AppendText(output);
         GetPlugin()->GetConsole()->AppendText(wxT("--------\n"));
         return;

--- a/abbreviation/abbreviation.cpp
+++ b/abbreviation/abbreviation.cpp
@@ -222,7 +222,7 @@ void AbbreviationPlugin::InitDefaults()
         m_config.WriteItem(&jsonData);
     }
     clKeyboardManager::Get()->AddGlobalAccelerator(
-        "abbrev_insert", "Ctrl-Alt-SPACE", _("Plugins::Abbreviations::Show abbrevations completion box"));
+        "abbrev_insert", "Ctrl-Alt-SPACE", _("Plugins::Abbreviations::Show abbreviations completion box"));
 }
 
 bool AbbreviationPlugin::InsertExpansion(const wxString& abbreviation)

--- a/codelite_launcher/codelite_launcher.cpp
+++ b/codelite_launcher/codelite_launcher.cpp
@@ -56,7 +56,7 @@ bool Process(wxCmdLineParser& parser)
 //				return true;
 //			}
 //			if (killError == wxKILL_ERROR) {
-//				wxPrintf(wxT("An Error occured attempting to close parent.exe, the helper will now attempt to forcefully close %s\n"), exe_name.c_str());
+//				wxPrintf(wxT("An Error occurred attempting to close parent.exe, the helper will now attempt to forcefully close %s\n"), exe_name.c_str());
 //				int killError2 = wxProcess::Kill(process_id, wxSIGKILL);
 //				if (killError2) {
 //					wxPrintf(wxT("The Helper could not close %s\n"), exe_name.c_str());

--- a/codelite_terminal/winprocess_impl.h
+++ b/codelite_terminal/winprocess_impl.h
@@ -54,7 +54,7 @@ public:
 
     /**
      * @brief read data from stdout, if no data is available, return
-     * if timeout occured, return with true.
+     * if timeout occurred, return with true.
      * @param buff check the buffer when true is returned
      * @return return true on success or timeout, flase otherwise, incase of false the reader thread will terminate
      */

--- a/codelitephp/php-plugin/XDebugCommThread.cpp
+++ b/codelitephp/php-plugin/XDebugCommThread.cpp
@@ -82,7 +82,7 @@ void* XDebugComThread::Entry()
                 // Wait for the reply
                 std::string reply;
                 if ( !DoReadReply( reply, client ) ) {
-                    // AN error occured - close session
+                    // AN error occurred - close session
                     break;
                 }
 

--- a/codelitephp/resources/cc/mysqli.php
+++ b/codelitephp/resources/cc/mysqli.php
@@ -367,7 +367,7 @@ class mysqli  {
 	 *       List of connections to check for outstanding results that can be read.
 	 *      </p>
 	 * @param error array <p>
-	 *      List of connections on which an error occured, for example, query
+	 *      List of connections on which an error occurred, for example, query
 	 *      failure or lost connection.
 	 *      </p>
 	 * @param reject array <p>

--- a/sdk/clang/test-sources/file-buffer.cpp
+++ b/sdk/clang/test-sources/file-buffer.cpp
@@ -157,7 +157,7 @@ void ClangWorkerThread::ProcessRequest(ThreadRequest* request)
                 CL_DEBUG(wxT("Calling clang_reparseTranslationUnit... done"));
 
             } else {
-                CL_DEBUG(wxT("An error occured during reparsing of the TU for file %s. TU: %p"), task->GetFileName().c_str(), (void*)TU);
+                CL_DEBUG(wxT("An error occurred during reparsing of the TU for file %s. TU: %p"), task->GetFileName().c_str(), (void*)TU);
 
                 // The only thing that left to be done here, is to dispose the TU
                 clang_disposeTranslationUnit(TU);
@@ -184,7 +184,7 @@ void ClangWorkerThread::ProcessRequest(ThreadRequest* request)
 
         } else {
             
-            CL_DEBUG(wxT("An error occured during reparsing of the TU for file %s. TU: %p"), task->GetFileName().c_str(), (void*)TU);
+            CL_DEBUG(wxT("An error occurred during reparsing of the TU for file %s. TU: %p"), task->GetFileName().c_str(), (void*)TU);
 
             // The only thing that left to be done here, is to dispose the TU
             clang_disposeTranslationUnit(TU);

--- a/sdk/clang/test-sources/file.cpp
+++ b/sdk/clang/test-sources/file.cpp
@@ -157,7 +157,7 @@ void ClangWorkerThread::ProcessRequest(ThreadRequest* request)
                 CL_DEBUG(wxT("Calling clang_reparseTranslationUnit... done"));
 
             } else {
-                CL_DEBUG(wxT("An error occured during reparsing of the TU for file %s. TU: %p"), task->GetFileName().c_str(), (void*)TU);
+                CL_DEBUG(wxT("An error occurred during reparsing of the TU for file %s. TU: %p"), task->GetFileName().c_str(), (void*)TU);
 
                 // The only thing that left to be done here, is to dispose the TU
                 clang_disposeTranslationUnit(TU);
@@ -184,7 +184,7 @@ void ClangWorkerThread::ProcessRequest(ThreadRequest* request)
 
         } else {
             
-            CL_DEBUG(wxT("An error occured during reparsing of the TU for file %s. TU: %p"), task->GetFileName().c_str(), (void*)TU);
+            CL_DEBUG(wxT("An error occurred during reparsing of the TU for file %s. TU: %p"), task->GetFileName().c_str(), (void*)TU);
 
             // The only thing that left to be done here, is to dispose the TU
             clang_disposeTranslationUnit(TU);

--- a/sdk/codelite_indexer/equeue_win_impl.h
+++ b/sdk/codelite_indexer/equeue_win_impl.h
@@ -77,7 +77,7 @@ bool eQueueImpl<T>::get(T& item, long timeout)
 				return true;
 			}
 		default:
-			// timeout or other error occured here
+			// timeout or other error occurred here
 			return false;
 		}
 	}

--- a/sdk/codelite_indexer/libctags/options.c
+++ b/sdk/codelite_indexer/libctags/options.c
@@ -237,7 +237,7 @@ static optionDescription LongOptionDescription [] = {
  {1,"  --language-force=language"},
  {1,"       Force all files to be interpreted using specified language."},
  {1,"  --languages=[+|-]list"},
- {1,"       Restrict files scanned for tags to those mapped to langauges"},
+ {1,"       Restrict files scanned for tags to those mapped to languages"},
  {1,"       specified in the comma-separated 'list'. The list can contain any"},
  {1,"       built-in or user-defined language [all]."},
  {1,"  --license"},

--- a/sdk/codelite_indexer/network/clindexerprotocol.h
+++ b/sdk/codelite_indexer/network/clindexerprotocol.h
@@ -52,7 +52,7 @@ public:
 	 */
 	static bool SendReply    (clNamedPipe *conn, clIndexerReply   &reply);
 	/**
-	 * @brief read request from the named pipe. If any error occured, return false and abort the connection
+	 * @brief read request from the named pipe. If any error occurred, return false and abort the connection
 	 * @param conn [input] named pipe to use for reading the request
 	 * @param req [output] holds the received request. Should be used only if this function
 	 *        returns true

--- a/sdk/databaselayer/src/dblayer/SqliteDatabaseLayer.cpp
+++ b/sdk/databaselayer/src/dblayer/SqliteDatabaseLayer.cpp
@@ -108,7 +108,7 @@ void SqliteDatabaseLayer::BeginTransaction()
 
 void SqliteDatabaseLayer::Commit()
 {
-  wxLogDebug(_("Commiting transaction"));
+  wxLogDebug(_("Committing transaction"));
   RunQuery(_("commit transaction;"), false);
 }
 

--- a/sdk/databaselayer/src/dblayer/TdsDatabaseLayer.cpp
+++ b/sdk/databaselayer/src/dblayer/TdsDatabaseLayer.cpp
@@ -412,7 +412,7 @@ void TdsDatabaseLayer::BeginTransaction()
 
 void TdsDatabaseLayer::Commit()
 {
-  wxLogDebug(_("Commiting transaction"));
+  wxLogDebug(_("Committing transaction"));
   RunQuery(_("commit transaction;"), false);
 }
 

--- a/translations/codelite.pot
+++ b/translations/codelite.pot
@@ -90,7 +90,7 @@ msgstr ""
 
 #: CMakePlugin/CMakePluginUi.cpp:52
 msgid ""
-"You can specify default generator for all projects (if is not overrided by "
+"You can specify default generator for all projects (if is not overridden by "
 "project settings). If generator is not selected the CMake uses platform's "
 "default."
 msgstr ""
@@ -1383,7 +1383,7 @@ msgid "Break PHP Arrays vertically"
 msgstr ""
 
 #: CodeFormatter/codeformatterdlgbase.cpp:448
-msgid "Break after string concatentation operator (\".\")"
+msgid "Break after string concatenation operator (\".\")"
 msgstr ""
 
 #: CodeFormatter/codeformatterdlgbase.cpp:457
@@ -5484,7 +5484,7 @@ msgstr ""
 #: LiteEditor/compiler_pages.cpp:376
 msgid ""
 "Set the 'mkdir' for your OS.\n"
-"Leave it empty to use the defualt for your OS"
+"Leave it empty to use the default for your OS"
 msgstr ""
 
 #: LiteEditor/compiler_pages.cpp:379
@@ -6706,7 +6706,7 @@ msgstr ""
 
 #: LiteEditor/editorsettingscommentsdoxygenpanelbase.cpp:47
 msgid ""
-"Set the template to use when generating documetation for a class (or C/C++ "
+"Set the template to use when generating documentation for a class (or C/C++ "
 "struct).\n"
 "The following macros are available: $(CurrentFileName), $(CurrentFilePath), "
 "$(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), "
@@ -6719,7 +6719,7 @@ msgstr ""
 
 #: LiteEditor/editorsettingscommentsdoxygenpanelbase.cpp:51
 msgid ""
-"Set the template to use when generating documetation for a function\n"
+"Set the template to use when generating documentation for a function\n"
 "The following macros are available: $(CurrentFileName), $(CurrentFilePath), "
 "$(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), "
 "$(ProjectName), $(WorkspaceName)"
@@ -6982,7 +6982,7 @@ msgstr ""
 
 #: LiteEditor/editorsettingsfoldingbase.cpp:74
 msgid ""
-"Allows to enable/disable the highlight folding block when it is selected. (i."
+"Allows enabling/disabling the highlight folding block when it is selected. (i."
 "e. block that contains the caret)"
 msgstr ""
 
@@ -9465,7 +9465,7 @@ msgid "Use regular expression"
 msgstr ""
 
 #: LiteEditor/quickfindbar.cpp:130
-msgid "Highlight Occurences"
+msgid "Highlight Occurrences"
 msgstr ""
 
 #: LiteEditor/quickfindbar.cpp:139
@@ -11675,7 +11675,7 @@ msgid "New Virtual Folder Name:"
 msgstr ""
 
 #: Plugin/VirtualDirectorySelectorDlg.cpp:339
-msgid "Error occured while creating virtual folder:\n"
+msgid "Error occurred while creating virtual folder:\n"
 msgstr ""
 
 #: Plugin/WSImporterDlgs.cpp:33 codelitephp/php-plugin/php_ui.cpp:1746
@@ -15423,7 +15423,7 @@ msgid "Insert Expansion"
 msgstr ""
 
 #: abbreviation/abbreviation.cpp:225
-msgid "Plugins::Abbreviations::Show abbrevations completion box"
+msgid "Plugins::Abbreviations::Show abbreviations completion box"
 msgstr ""
 
 #: abbreviation/abbreviationssettingsbase.cpp:31
@@ -17815,7 +17815,7 @@ msgstr ""
 
 #: sdk/databaselayer/src/dblayer/SqliteDatabaseLayer.cpp:111
 #: sdk/databaselayer/src/dblayer/TdsDatabaseLayer.cpp:415
-msgid "Commiting transaction"
+msgid "Committing transaction"
 msgstr ""
 
 #: sdk/databaselayer/src/dblayer/SqliteDatabaseLayer.cpp:112

--- a/translations/cs/LC_MESSAGES/cs.po
+++ b/translations/cs/LC_MESSAGES/cs.po
@@ -268,7 +268,7 @@ msgstr "začátek transakcí:"
 
 #: sdk/databaselayer/src/dblayer/SqliteDatabaseLayer.cpp:111
 #: sdk/databaselayer/src/dblayer/TdsDatabaseLayer.cpp:415
-msgid "Commiting transaction"
+msgid "Committing transaction"
 msgstr "Potvrzení transakce"
 
 #: sdk/databaselayer/src/dblayer/SqliteDatabaseLayer.cpp:112

--- a/translations/zh_CN/LC_MESSAGES/codelite.po
+++ b/translations/zh_CN/LC_MESSAGES/codelite.po
@@ -94,7 +94,7 @@ msgstr "默认生成器："
 
 #: CMakePlugin/CMakePluginUi.cpp:52
 msgid ""
-"You can specify default generator for all projects (if is not overrided by "
+"You can specify default generator for all projects (if is not overridden by "
 "project settings). If generator is not selected the CMake uses platform's "
 "default."
 msgstr ""
@@ -1430,7 +1430,7 @@ msgid "Break PHP Arrays vertically"
 msgstr "垂直打断 PHP 数组"
 
 #: CodeFormatter/codeformatterdlgbase.cpp:448
-msgid "Break after string concatentation operator (\".\")"
+msgid "Break after string concatenation operator (\".\")"
 msgstr "打断字符串后连接运算符(\".\")"
 
 #: CodeFormatter/codeformatterdlgbase.cpp:457
@@ -5661,7 +5661,7 @@ msgstr "mkdir"
 #: LiteEditor/compiler_pages.cpp:376
 msgid ""
 "Set the 'mkdir' for your OS.\n"
-"Leave it empty to use the defualt for your OS"
+"Leave it empty to use the default for your OS"
 msgstr ""
 "为您的系统设置“mkdir”。\n"
 "留空就表示在您的系统中使用默认设置"
@@ -6941,7 +6941,7 @@ msgstr "类文档模板"
 
 #: LiteEditor/editorsettingscommentsdoxygenpanelbase.cpp:47
 msgid ""
-"Set the template to use when generating documetation for a class (or C/C++ "
+"Set the template to use when generating documentation for a class (or C/C++ "
 "struct).\n"
 "The following macros are available: $(CurrentFileName), $(CurrentFilePath), "
 "$(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), "
@@ -6958,7 +6958,7 @@ msgstr "函数文档模板"
 
 #: LiteEditor/editorsettingscommentsdoxygenpanelbase.cpp:51
 msgid ""
-"Set the template to use when generating documetation for a function\n"
+"Set the template to use when generating documentation for a function\n"
 "The following macros are available: $(CurrentFileName), $(CurrentFilePath), "
 "$(User), $(Date), $(Name) $(CurrentFileFullPath), $(CurrentFileExt), "
 "$(ProjectName), $(WorkspaceName)"
@@ -7238,7 +7238,7 @@ msgstr "高亮显示折叠块"
 
 #: LiteEditor/editorsettingsfoldingbase.cpp:74
 msgid ""
-"Allows to enable/disable the highlight folding block when it is selected. (i."
+"Allows enabling/disabling the highlight folding block when it is selected. (i."
 "e. block that contains the caret)"
 msgstr "当被选中时允许启用/禁用高亮折叠块。(即块包含插入符号)"
 
@@ -9815,7 +9815,7 @@ msgid "Use regular expression"
 msgstr "启用正则表达式"
 
 #: LiteEditor/quickfindbar.cpp:130
-msgid "Highlight Occurences"
+msgid "Highlight Occurrences"
 msgstr "高亮匹配"
 
 #: LiteEditor/quickfindbar.cpp:139
@@ -12108,7 +12108,7 @@ msgid "New Virtual Folder Name:"
 msgstr "新的虚拟文件夹名称："
 
 #: Plugin/VirtualDirectorySelectorDlg.cpp:339
-msgid "Error occured while creating virtual folder:\n"
+msgid "Error occurred while creating virtual folder:\n"
 msgstr "创建虚拟文件夹错误：\n"
 
 #: Plugin/WSImporterDlgs.cpp:33 codelitephp/php-plugin/php_ui.cpp:1746
@@ -15922,7 +15922,7 @@ msgid "Insert Expansion"
 msgstr "插入扩展字段"
 
 #: abbreviation/abbreviation.cpp:225
-msgid "Plugins::Abbreviations::Show abbrevations completion box"
+msgid "Plugins::Abbreviations::Show abbreviations completion box"
 msgstr "插件::缩略语表::显示缩写补全框"
 
 #: abbreviation/abbreviationssettingsbase.cpp:31
@@ -18428,7 +18428,7 @@ msgstr "开始处理；"
 
 #: sdk/databaselayer/src/dblayer/SqliteDatabaseLayer.cpp:111
 #: sdk/databaselayer/src/dblayer/TdsDatabaseLayer.cpp:415
-msgid "Commiting transaction"
+msgid "Committing transaction"
 msgstr "提交事务中"
 
 #: sdk/databaselayer/src/dblayer/SqliteDatabaseLayer.cpp:112


### PR DESCRIPTION
Found by Lintian (https://lintian.debian.org/).
 Note Lintian only searches binaries so it only finds spelling mistakes in strings.

```
abbrevations   -> abbreviations
Commiting      -> Committing
concatentation -> concatenation
conneciton     -> connection
defualt        -> default
documetation   -> documentation
langauges      -> languages
occured        -> occurred
Occurences     -> Occurrences
overrided      -> overridden

"Allows to enable/disable" -> "Allows enabling/disabling"
```