### PR TITLE
Don't remove leading whitespaces in InsertExpansion

### DIFF
--- a/abbreviation/abbreviation.cpp
+++ b/abbreviation/abbreviation.cpp
@@ -255,6 +255,8 @@ bool AbbreviationPlugin::InsertExpansion(const wxString& abbreviation)
         int selEnd = editor->WordEndPos(editor->GetCurrentPosition(), true);
         int curPos = editor->GetCurrentPosition();
         int typedWordLen = curPos - selStart;
+        wxString textOrig;
+        wxString textLeadingSpaces;
 
         if(typedWordLen < 0) {
             typedWordLen = 0;
@@ -266,10 +268,15 @@ bool AbbreviationPlugin::InsertExpansion(const wxString& abbreviation)
             appendEol = true;
         }
 
+        textOrig = text;
+        text.Trim(false);
+        textLeadingSpaces = textOrig.Left(textOrig.length() - text.length());
+
         text = editor->FormatTextKeepIndent(text, selStart, Format_Text_Save_Empty_Lines);
 
         // remove the first line indenation that might have been placed by CL
         text.Trim(false).Trim();
+        text = textLeadingSpaces + text;
 
         if(appendEol) {
             wxString eol;


### PR DESCRIPTION
User may want to add some spaces/tabs to beginning of abbrevation code as indentation, but `text` is being `Trim`ed because of extra indentation added by `FormatTextKeepIndent`
My change may seem a little complicated. But I didn't find a simpler solution (without adding a flag to `FormatTextKeepIndent`)
