### PR TITLE
Don't grab selection on FindNext/FindPrevious if QuickFindBar is visible

### DIFF
--- a/LiteEditor/quickfindbar.cpp
+++ b/LiteEditor/quickfindbar.cpp
@@ -673,10 +673,12 @@ void QuickFindBar::OnFindNext(wxCommandEvent& e)
     CHECK_FOCUS_WIN();
 
     // Highlighted text takes precedence over the current search string
-    wxString selectedText = DoGetSelectedText();
-    if(selectedText.IsEmpty() == false) {
-        m_findWhat->ChangeValue(selectedText);
-        m_findWhat->SelectAll();
+    if (!IsShown()) {
+        wxString selectedText = DoGetSelectedText();
+        if(selectedText.IsEmpty() == false) {
+            m_findWhat->ChangeValue(selectedText);
+            m_findWhat->SelectAll();
+        }
     }
 
     DoSearch(kSearchForward);
@@ -687,10 +689,12 @@ void QuickFindBar::OnFindPrevious(wxCommandEvent& e)
     CHECK_FOCUS_WIN();
 
     // Highlighted text takes precedence over the current search string
-    wxString selectedText = DoGetSelectedText();
-    if(selectedText.IsEmpty() == false) {
-        m_findWhat->ChangeValue(selectedText);
-        m_findWhat->SelectAll();
+    if (!IsShown()) {
+        wxString selectedText = DoGetSelectedText();
+        if(selectedText.IsEmpty() == false) {
+            m_findWhat->ChangeValue(selectedText);
+            m_findWhat->SelectAll();
+        }
     }
 
     DoSearch(0);


### PR DESCRIPTION
I select some text and press Control + F, it opens QuickFindBar, then I frequently press F3 (Control + G for me) to find next and next occurrences, but I also sometimes select another text and copy / paste and I don't want the selected text to replace the search phrase in QuickFindBar.
So  I wanted to remove the 2 code blocks (in `OnFindNext` and `OnFindPrevious`) that is doing that.

But then I realized that FindNext (F3) is also probably used for quick search (without opening QuickFindBar), so you just select the text and press F3 and I finds the next occurrence of the same text without opening QuickFindBar.

So I check if the QuickFindBar is visible, do the replacing.