### PR TITLE
* Fixed MinGW GCC Compiler to use wxWidgets team built binary files.

### DIFF
--- a/sdk/wxconfig/wx-config-win.cpp
+++ b/sdk/wxconfig/wx-config-win.cpp
@@ -890,6 +890,7 @@ public:
 
 
         // ### Variables: ###
+        po["COMPILER_VERSION"] = cfg["COMPILER_VERSION"];
         po["WX_RELEASE_NODOT"] = cfg["WXVER_MAJOR"] + cfg["WXVER_MINOR"];
         if (po["WX_RELEASE_NODOT"].empty())
             po["WX_RELEASE_NODOT"] = "26";
@@ -1030,7 +1031,7 @@ public:
 //----------------------------------------------------
 
         // ### Variables, Part 2: ###
-        po["LIBDIRNAME"] = po["prefix"] + "/lib/" + getName() + "_" + po["LIBTYPE_SUFFIX"] + cfg["CFG"];
+        po["LIBDIRNAME"] = po["prefix"] + "/lib/" + getName() + po["COMPILER_VERSION"] + "_" + po["LIBTYPE_SUFFIX"] + cfg["CFG"];
 
         po["SETUPHDIR"]  = po["LIBDIRNAME"] + "/" + po["PORTNAME"] + po["WXUNIVNAME"];
         po["SETUPHDIR"] += po["WXUNICODEFLAG"] + po["WXDEBUGFLAG"];
@@ -2271,10 +2272,11 @@ void checkAdditionalFlags(Options& po, const CmdLineOptions& cl)
 void detectCompiler(Options& po, const CmdLineOptions& cl)
 {
     // input example of po["wxcfg"]:
+    // gcc510TDM_dll/mswu
     // gcc_dll/mswud
     // vc_lib/msw
 
-    if (po["wxcfg"].find("gcc_") != std::string::npos) {
+    if (po["wxcfg"].find("gcc") != std::string::npos) {
         CompilerMinGW compiler;
         compiler.process(po, cl);
         return;
@@ -2299,7 +2301,7 @@ void detectCompiler(Options& po, const CmdLineOptions& cl)
 
         std::cout << g_tokError << "No supported compiler has been detected in the configuration '" << po["wxcfg"] << "'." << std::endl;
         std::cerr << std::endl;
-        std::cerr << "The specified wxcfg must start with a 'gcc_', 'dmc_' or 'vc_'" << std::endl;
+        std::cerr << "The specified wxcfg must start with a 'gcc', 'dmc_' or 'vc_'" << std::endl;
         std::cerr << "to be successfully detected." << std::endl;
 
         exit(1);


### PR DESCRIPTION
I do NOT use CodeLite; but, I use Code::Blocks with wx-config. And, I added code to make wx-config to see the wxTeam built binaries tested the patch by compiling it with Code::Blocks.

I hope my patch works better than the one you reverted. Mine is smaller and only changes stuff I can test.

Tim S.
