### PR TITLE
Fixes and additions to quickfindbar

### DIFF
--- a/LiteEditor/quickfindbar.cpp
+++ b/LiteEditor/quickfindbar.cpp
@@ -919,7 +919,7 @@ void QuickFindBar::OnHighlightMatches(wxFlatButtonEvent& e)
     bool showreplace = m_replaceWith->IsShown();
 
     if(e.IsChecked()) {
-        m_matchesFound->Show()
+        m_matchesFound->Show();
 
     } else {
         m_matchesFound->Hide();

--- a/LiteEditor/quickfindbar.h
+++ b/LiteEditor/quickfindbar.h
@@ -69,6 +69,7 @@ protected:
     wxString m_lastText;
     wchar_t* m_lastTextPtr;
     bool m_eventsConnected;
+    bool m_onNextPrev;
     QuickFindBarOptionsMenu* m_optionsWindow;
     wxComboBox* m_findWhat;
     wxComboBox* m_replaceWith;
@@ -77,6 +78,8 @@ protected:
     wxFlatButton* m_caseSensitive;
     wxFlatButton* m_wholeWord;
     wxFlatButton* m_regexOrWildButton;
+    wxFlatButton* m_highlightOccurrences;
+    wxStaticText* m_matchesFound;
     wxButton* m_buttonReplace;
     wxButton* m_buttonReplaceAll;
     wxButton* btnPrev;
@@ -120,6 +123,7 @@ protected:
     void DoFixRegexParen(wxString& findwhat);
     wxString DoGetSelectedText();
     void DoSelectAll(bool addMarkers);
+    void DoHighlightMatches(bool checked);
 
     // General events
     void OnUndo(wxCommandEvent& e);


### PR DESCRIPTION
When activating 'Highlight occurrences' the previous highlighted results where kep even when doing a new search so deactivating 'Highlight occurrences' was needed to remove them. This solves this issue by highlighting occurrences while one is typing.

This pull also adds a counter for the amount of highlighted occurrences which is good to know when doing micro refactoring on a single file using this tool. Overall this small changes should provide a better experience using the quickfindbar which I noticed on the Atom editor that works in a similar way.