### PR TITLE
[quickfindbar] Reset previous marked occurrences on not found

### DIFF
--- a/LiteEditor/quickfindbar.cpp
+++ b/LiteEditor/quickfindbar.cpp
@@ -648,7 +648,9 @@ bool QuickFindBar::DoShow(bool s, const wxString& findWhat, bool replaceBar)
         m_findWhat->SelectAll();
         m_findWhat->SetFocus();
         if(m_highlightOccurrences->IsChecked()) {
-            DoHighlightMatches(true);
+            if(!m_regexOrWildButton->IsChecked() || m_findWhat->GetValue().Length() > 2) {
+                DoHighlightMatches(true);
+            }
         }
         PostCommandEvent(this, m_findWhat);
 
@@ -663,7 +665,9 @@ bool QuickFindBar::DoShow(bool s, const wxString& findWhat, bool replaceBar)
         m_findWhat->SelectAll();
         m_findWhat->SetFocus();
         if(m_highlightOccurrences->IsChecked()) {
-            DoHighlightMatches(true);
+            if(!m_regexOrWildButton->IsChecked() || m_findWhat->GetValue().Length() > 2) {
+                DoHighlightMatches(true);
+            }
         }
         PostCommandEvent(this, m_findWhat);
     }

--- a/LiteEditor/quickfindbar.cpp
+++ b/LiteEditor/quickfindbar.cpp
@@ -85,7 +85,7 @@ QuickFindBar::QuickFindBar(wxWindow* parent, wxWindowID id)
     , m_disableTextUpdateEvent(false)
 {
     m_bar = new wxFlatButtonBar(this, wxFlatButton::kThemeNormal, 0, 10);
-    
+
     //-------------------------------------------------------------
     // Find / Replace bar
     //-------------------------------------------------------------
@@ -248,7 +248,7 @@ QuickFindBar::QuickFindBar(wxWindow* parent, wxWindowID id)
     // Initialize the list with the history
     m_findWhat->Append(clConfig::Get().GetQuickFindSearchItems());
     m_replaceWith->Append(clConfig::Get().GetQuickFindReplaceItems());
-    
+
     // Update the search flags
     size_t searchFlags = clConfig::Get().Read("FindBar/SearchFlags", 0);
     bool highlightOccurences = clConfig::Get().Read("FindBar/HighlightOccurences", true);
@@ -338,13 +338,20 @@ void QuickFindBar::DoSearch(size_t searchFlags)
         // Restore the caret position
         m_sci->SetCurrentPos(curpos);
         m_sci->ClearSelections();
+        DoHighlightMatches(false);
         return;
     }
 
     DoEnsureLineIsVisible();
 
-    if(m_highlightOccurrences->IsChecked() && !m_onNextPrev) {
-        DoHighlightMatches(true);
+    if(m_highlightOccurrences->IsChecked() && !m_onNextPrev && pos != wxNOT_FOUND) {
+        // Fix issue when regex is enabled hanging the editor if too few chars
+        if(m_regexOrWildButton->IsChecked() && m_findWhat->GetValue().Length() < 3) {
+            return;
+
+        } else {
+            DoHighlightMatches(true);
+        }
     }
 }
 
@@ -985,7 +992,7 @@ QuickFindBar::~QuickFindBar()
     // Remember the buttons clicked
     clConfig::Get().Write("FindBar/SearchFlags", (int)DoGetSearchFlags());
     clConfig::Get().Write("FindBar/HighlightOccurences", m_highlightOccurrences->IsChecked());
-    
+
     wxTheApp->Disconnect(
         XRCID("find_next"), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(QuickFindBar::OnFindNext), NULL, this);
     wxTheApp->Disconnect(XRCID("find_previous"), wxEVT_COMMAND_MENU_SELECTED,


### PR DESCRIPTION
Reset previous marked occurrences when new search is not found, fixed hang when enabling regex.