### PR TITLE
Continuous Integration: Configure Tea CI.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,13 @@
+build:
+  image: teaci/msys$$arch
+  pull: true
+  shell: msys$$arch
+  commands:
+    - svn co https://github.com/Alexpux/MINGW-packages/trunk/mingw-w64-codelite-git
+    - cd mingw-w64-codelite-git
+    - makepkg-mingw -s --noconfirm --skippgpcheck --noprogressbar
+
+matrix:
+  arch:
+    - 64
+    - 32


### PR DESCRIPTION
Hi folks,

Tea CI is a continuous integration service for Windows / Linux applications, I wrote a proof-of-concept to build codelite on Tea CI: https://tea-ci.org/fracting/codelite/4

Currently it builds both 32 bit Windows binaries and 64 bit binaries in a matrix. If Linux binaries are needed, we can add that as well.

How do you like it? Any feedback is great appreciated.

See http://docs.tea-ci.org/usage/overview/ for more about Tea CI.