### PR TITLE
Add some file extensions for default php project file types

### DIFF
--- a/codelitephp/PHPParser/php_project.h
+++ b/codelitephp/PHPParser/php_project.h
@@ -68,8 +68,8 @@ public:
 public:
     PHPProject()
         : m_isActive(false)
-        , m_importFileSpec("*.php;*.php5;*.inc;*.phtml;*.js;*.html;*.css;*.scss;*.json;*.xml;*.ini;*.md;*.txt;*.text;."
-                           "htaccess;*.ctp")
+        , m_importFileSpec("*.php;*.php5;*.inc;*.phtml;*.js;*.html;*.css;*.scss;*.less;*.json;*.yaml;*.xml;*.ini;*.md;"
+                           "*.txt;*.text;.htaccess;*.ctp;*.tpl")
         , m_excludeFolders(".git;.svn;.codelite;.clang")
     {
     }


### PR DESCRIPTION
Add php project file extensions for stylesheet preprocessor less, symfony framework yaml config, smarty template system.

*.yaml - use on my large project and symfony framework;
*.tpl - use on all Smarty template system;
*.less - use another css preprocessor format like scss;