### PR TITLE
Add missing primitives in PHPSourceFile::MakeIdentifierAbsolute

### DIFF
--- a/CodeLite/PHPSourceFile.cpp
+++ b/CodeLite/PHPSourceFile.cpp
@@ -757,7 +757,9 @@ wxString PHPSourceFile::MakeIdentifierAbsolute(const wxString& type)
     typeWithNS.Trim().Trim(false);
 
     if(typeWithNS == "string" || typeWithNS == "array" || typeWithNS == "mixed" || typeWithNS == "bool" ||
-        typeWithNS == "int" || typeWithNS == "integer" || typeWithNS == "boolean" || typeWithNS == "double") {
+        typeWithNS == "int" || typeWithNS == "integer" || typeWithNS == "boolean" || typeWithNS == "double" ||
+        typeWithNS == "float" || typeWithNS == "void"
+    ) {
         // primitives, don't bother...
         return typeWithNS;
     }


### PR DESCRIPTION
float has been there since 4.3, void as a return type is in 7.1
https://wiki.php.net/rfc/void_return_type

Before this commit float as input or return type would get added to a
docblock as \float