### PR TITLE
Make GeneralInfo settings be saved even when not saving layout

### DIFF
--- a/LiteEditor/frame.cpp
+++ b/LiteEditor/frame.cpp
@@ -2032,6 +2032,7 @@ void clMainFrame::OnClose(wxCloseEvent& event)
             return;
         }
     }
+    SaveGeneralSettings();
 
     event.Skip();
 
@@ -4902,6 +4903,11 @@ bool clMainFrame::SaveLayoutAndSession()
     EditorConfigST::Get()->SetInteger(wxT("MainBook"), GetMainBook()->GetBookStyle());
     EditorConfigST::Get()->Save();
     return true;
+}
+
+void clMainFrame::SaveGeneralSettings()
+{
+    EditorConfigST::Get()->WriteObject(wxT("GeneralInfo"), &m_frameGeneralInfo);
 }
 
 void clMainFrame::OnNextFiFMatch(wxCommandEvent& e)

--- a/LiteEditor/frame.h
+++ b/LiteEditor/frame.h
@@ -290,6 +290,12 @@ public:
     bool SaveLayoutAndSession();
 
     /**
+     * @brief save settings (such as whether to show the splashscreen) which should be saved
+     * regardless of whether SaveLayoutAndSession is called
+     */
+    void SaveGeneralSettings();
+
+    /**
      * @brief create the recently-opened-workspaces menu
      */
     void CreateRecentlyOpenedWorkspacesMenu();


### PR DESCRIPTION
I've noticed that some settings (such as disabling the splash screen or the welcome page) seemed like they weren't getting saved: even if I tried to disable the splash screen, it would still come up the next time that I started CodeLite and it would be enabled again in the settings dialog. I did some investigation and discovered that those settings _are_ saved, but (somewhat unexpectedly) _only_ if one chooses "Save and Exit" on the "Save perspective and exit?" dialog. I had chosen "Exit without saving" and asked it to remember my choice, which was why I wasn't seeing those settings persist.

So, this is a small fix which adds a little method for saving settings on shutdown that should be saved whether or not the user wants to save the current perspective, which currently consist of the settings that are a part of `GeneralInfo`.