### PR TITLE
Add option to use dark tab theme by default

### DIFF
--- a/LiteEditor/debuggerpane.cpp
+++ b/LiteEditor/debuggerpane.cpp
@@ -94,6 +94,10 @@ void DebuggerPane::CreateGUIControls()
     if(!EditorConfigST::Get()->GetOptions()->GetWorkspaceTabsDirection()) {
         style |= kNotebook_BottomTabs;
     }
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        style &= ~kNotebook_LightTabs;
+        style |= kNotebook_DarkTabs;
+    }
     style |= kNotebook_UnderlineActiveTab;
 
     GeneralImages img;
@@ -257,6 +261,11 @@ void DebuggerPane::OnSettingsChanged(wxCommandEvent& event)
     event.Skip();
     m_book->EnableStyle(kNotebook_BottomTabs,
                         EditorConfigST::Get()->GetOptions()->GetOutputTabsDirection() == wxBOTTOM);
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        m_book->SetStyle(m_book->GetStyle() & ~kNotebook_LightTabs | kNotebook_DarkTabs);
+    } else {
+        m_book->SetStyle(m_book->GetStyle() & ~kNotebook_DarkTabs | kNotebook_LightTabs);
+    }
 }
 
 //----------------------------------------------------------------

--- a/LiteEditor/editor_options_docking_windows.wxcp
+++ b/LiteEditor/editor_options_docking_windows.wxcp
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "m_generatedFilesDir": ".",
-  "m_objCounter": 50,
+  "m_objCounter": 52,
   "m_includeFiles": [],
   "m_bitmapFunction": "wxCrafterKZwxilInitBitmapResources",
   "m_bitmapsFile": "editor_options_docking_windows_liteeditor_bitmaps.cpp",
@@ -1265,6 +1265,81 @@
                    "type": "bool",
                    "m_label": "Value:",
                    "m_value": true
+                  }],
+                 "m_events": [],
+                 "m_children": []
+                }, {
+                 "m_type": 4415,
+                 "proportion": 0,
+                 "border": 5,
+                 "gbSpan": "1,1",
+                 "gbPosition": "0,0",
+                 "m_styles": [],
+                 "m_sizerFlags": ["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
+                 "m_properties": [{
+                   "type": "winid",
+                   "m_label": "ID:",
+                   "m_winid": "wxID_ANY"
+                  }, {
+                   "type": "string",
+                   "m_label": "Size:",
+                   "m_value": "-1,-1"
+                  }, {
+                   "type": "string",
+                   "m_label": "Minimum Size:",
+                   "m_value": "-1,-1"
+                  }, {
+                   "type": "string",
+                   "m_label": "Name:",
+                   "m_value": "m_checkBoxUseDarkTabTheme"
+                  }, {
+                   "type": "multi-string",
+                   "m_label": "Tooltip:",
+                   "m_value": ""
+                  }, {
+                   "type": "colour",
+                   "m_label": "Bg Colour:",
+                   "colour": "<Default>"
+                  }, {
+                   "type": "colour",
+                   "m_label": "Fg Colour:",
+                   "colour": "<Default>"
+                  }, {
+                   "type": "font",
+                   "m_label": "Font:",
+                   "m_value": ""
+                  }, {
+                   "type": "bool",
+                   "m_label": "Hidden",
+                   "m_value": false
+                  }, {
+                   "type": "bool",
+                   "m_label": "Disabled",
+                   "m_value": false
+                  }, {
+                   "type": "bool",
+                   "m_label": "Focused",
+                   "m_value": false
+                  }, {
+                   "type": "string",
+                   "m_label": "Class Name:",
+                   "m_value": ""
+                  }, {
+                   "type": "string",
+                   "m_label": "Include File:",
+                   "m_value": ""
+                  }, {
+                   "type": "string",
+                   "m_label": "Style:",
+                   "m_value": ""
+                  }, {
+                   "type": "string",
+                   "m_label": "Label:",
+                   "m_value": "Use dark notebook tab theme by default"
+                  }, {
+                   "type": "bool",
+                   "m_label": "Value:",
+                   "m_value": false
                   }],
                  "m_events": [],
                  "m_children": []

--- a/LiteEditor/editorsettingsdockingwidows.cpp
+++ b/LiteEditor/editorsettingsdockingwidows.cpp
@@ -54,6 +54,7 @@ EditorSettingsDockingWindows::EditorSettingsDockingWindows(wxWindow* parent)
     m_checkBoxHideCaptions->SetValue(!options->IsShowDockingWindowCaption());
     m_checkBoxEnsureCaptionsVisible->SetValue(options->IsEnsureCaptionsVisible());
     m_checkBoxEditorTabsFollowsTheme->SetValue(options->IsTabColourMatchesTheme());
+    m_checkBoxUseDarkTabTheme->SetValue(options->IsTabColourDark());
     m_checkBoxShowXButton->SetValue(options->IsTabHasXButton());
     m_choiceTabStyle->SetSelection(options->GetOptions() & OptionsConfig::Opt_TabStyleMinimal ? 1 : 0);
     int sel(0);
@@ -145,6 +146,7 @@ void EditorSettingsDockingWindows::Save(OptionsConfigPtr options)
     options->SetShowDockingWindowCaption(!m_checkBoxHideCaptions->IsChecked());
     options->SetEnsureCaptionsVisible(m_checkBoxEnsureCaptionsVisible->IsChecked());
     options->SetTabColourMatchesTheme(m_checkBoxEditorTabsFollowsTheme->IsChecked());
+    options->SetTabColourDark(m_checkBoxUseDarkTabTheme->IsChecked());
     options->SetTabHasXButton(m_checkBoxShowXButton->IsChecked());
     options->EnableOption(OptionsConfig::Opt_TabStyleMinimal, (m_choiceTabStyle->GetSelection() == 1));
     int ht(0);

--- a/LiteEditor/editorsettingsdockingwindowsbase.cpp
+++ b/LiteEditor/editorsettingsdockingwindowsbase.cpp
@@ -129,6 +129,11 @@ EditorSettingsDockingWindowsBase::EditorSettingsDockingWindowsBase(wxWindow* par
     
     staticBoxSizer27->Add(m_checkBoxEditorTabsFollowsTheme, 0, wxALL, WXC_FROM_DIP(5));
     
+    m_checkBoxUseDarkTabTheme = new wxCheckBox(m_panel12, wxID_ANY, _("Use dark notebook tab theme by default"), wxDefaultPosition, wxDLG_UNIT(m_panel12, wxSize(-1,-1)), 0);
+    m_checkBoxUseDarkTabTheme->SetValue(false);
+    
+    staticBoxSizer27->Add(m_checkBoxUseDarkTabTheme, 0, wxALL, WXC_FROM_DIP(5));
+    
     wxBoxSizer* boxSizer25 = new wxBoxSizer(wxVERTICAL);
     
     boxSizer22->Add(boxSizer25, 0, wxALL, WXC_FROM_DIP(10));

--- a/LiteEditor/editorsettingsdockingwindowsbase.h
+++ b/LiteEditor/editorsettingsdockingwindowsbase.h
@@ -54,6 +54,7 @@ protected:
     wxChoice* m_choiceOutputTabsOrientation;
     wxCheckBox* m_checkBoxShowXButton;
     wxCheckBox* m_checkBoxEditorTabsFollowsTheme;
+    wxCheckBox* m_checkBoxUseDarkTabTheme;
     wxCheckBox* m_checkBoxHideCaptions;
     wxCheckBox* m_checkBoxEnsureCaptionsVisible;
     wxPanel* m_panel14;
@@ -93,6 +94,7 @@ public:
     wxChoice* GetChoiceOutputTabsOrientation() { return m_choiceOutputTabsOrientation; }
     wxCheckBox* GetCheckBoxShowXButton() { return m_checkBoxShowXButton; }
     wxCheckBox* GetCheckBoxEditorTabsFollowsTheme() { return m_checkBoxEditorTabsFollowsTheme; }
+    wxCheckBox* GetCheckBoxUseDarkTabTheme() { return m_checkBoxUseDarkTabTheme; }
     wxCheckBox* GetCheckBoxHideCaptions() { return m_checkBoxHideCaptions; }
     wxCheckBox* GetCheckBoxEnsureCaptionsVisible() { return m_checkBoxEnsureCaptionsVisible; }
     wxPanel* GetPanel12() { return m_panel12; }

--- a/LiteEditor/mainbook.cpp
+++ b/LiteEditor/mainbook.cpp
@@ -1143,6 +1143,9 @@ void MainBook::DoUpdateNotebookTheme()
             style &= ~kNotebook_DarkTabs;
             style |= kNotebook_LightTabs;
         }
+    } else if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        style &= ~kNotebook_LightTabs;
+        style |= kNotebook_DarkTabs;
     } else {
         style &= ~kNotebook_DarkTabs;
         style |= kNotebook_LightTabs;

--- a/LiteEditor/output_pane.cpp
+++ b/LiteEditor/output_pane.cpp
@@ -103,6 +103,10 @@ void OutputPane::CreateGUIControls()
         style |= kNotebook_RightTabs;
 #endif
     }
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        style &= ~kNotebook_LightTabs;
+        style |= kNotebook_DarkTabs;
+    }
     style |= kNotebook_UnderlineActiveTab;
 
     m_book = new Notebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, style);
@@ -289,6 +293,11 @@ void OutputPane::OnSettingsChanged(wxCommandEvent& event)
 {
     event.Skip();
     m_book->SetTabDirection(EditorConfigST::Get()->GetOptions()->GetOutputTabsDirection());
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        m_book->SetStyle(m_book->GetStyle() & ~kNotebook_LightTabs | kNotebook_DarkTabs);
+    } else {
+        m_book->SetStyle(m_book->GetStyle() & ~kNotebook_DarkTabs | kNotebook_LightTabs);
+    }
 }
 
 void OutputPane::OnToggleTab(clCommandEvent& event)

--- a/LiteEditor/workspace_pane.cpp
+++ b/LiteEditor/workspace_pane.cpp
@@ -91,6 +91,10 @@ void WorkspacePane::CreateGUIControls()
 #else
     long style = (kNotebook_Default | kNotebook_AllowDnD);
 #endif
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        style &= ~kNotebook_LightTabs;
+        style |= kNotebook_DarkTabs;
+    }
     style |= kNotebook_UnderlineActiveTab;
 
     m_book = new Notebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, style);
@@ -395,6 +399,11 @@ void WorkspacePane::OnSettingsChanged(wxCommandEvent& event)
 {
     event.Skip();
     m_book->SetTabDirection(EditorConfigST::Get()->GetOptions()->GetWorkspaceTabsDirection());
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        m_book->SetStyle(m_book->GetStyle() & ~kNotebook_LightTabs | kNotebook_DarkTabs);
+    } else {
+        m_book->SetStyle(m_book->GetStyle() & ~kNotebook_DarkTabs | kNotebook_LightTabs);
+    }
 }
 
 void WorkspacePane::OnToggleWorkspaceTab(clCommandEvent& event)

--- a/Plugin/optionsconfig.h
+++ b/Plugin/optionsconfig.h
@@ -54,7 +54,7 @@ public:
         Opt_Mark_Debugger_Line = 0x00004000,
         Opt_TabNoXButton = 0x00008000,
         Opt_TabColourPersistent = 0x00010000,
-        Opt_Unused3 = 0x00020000,
+        Opt_TabColourDark = 0x00020000,
         Opt_Use_CodeLite_Terminal = 0x00040000,
         Opt_Unused6 = 0x00080000,
         Opt_Unused5 = 0x00100000,
@@ -179,6 +179,8 @@ public:
     //-------------------------------------
     void SetTabColourMatchesTheme(bool b) { EnableOption(Opt_TabColourPersistent, !b); }
     bool IsTabColourMatchesTheme() const { return !HasOption(Opt_TabColourPersistent); }
+    void SetTabColourDark(bool b) { EnableOption(Opt_TabColourDark, b); }
+    bool IsTabColourDark() const { return HasOption(Opt_TabColourDark); }
     void SetTabHasXButton(bool b) { EnableOption(Opt_TabNoXButton, !b); }
     bool IsTabHasXButton() const { return !HasOption(Opt_TabNoXButton); }
 

--- a/WebTools/NodeJSDebuggerPane.cpp
+++ b/WebTools/NodeJSDebuggerPane.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include "lexer_configuration.h"
 #include "bookmark_manager.h"
+#include <editor_config.h>
 
 class NodeJSLocalClientData : public wxClientData
 {
@@ -47,6 +48,13 @@ NodeJSDebuggerPane::NodeJSDebuggerPane(wxWindow* parent)
     EventNotifier::Get()->Bind(wxEVT_NODEJS_DEBUGGER_SELECT_FRAME, &NodeJSDebuggerPane::OnFrameSelected, this);
     EventNotifier::Get()->Bind(
         wxEVT_NODEJS_DEBUGGER_UPDATE_BREAKPOINTS_VIEW, &NodeJSDebuggerPane::OnUpdateDebuggerView, this);
+    EventNotifier::Get()->Bind(wxEVT_EDITOR_CONFIG_CHANGED, &NodeJSDebuggerPane::OnSettingsChanged, this);
+
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        m_notebook->SetStyle(kNotebook_Default & ~kNotebook_LightTabs | kNotebook_DarkTabs);
+    } else {
+        m_notebook->SetStyle(kNotebook_Default);
+    }
 
     LexerConf::Ptr_t lexer = ColoursAndFontsManager::Get().GetLexer("text");
     if(lexer) {
@@ -75,6 +83,7 @@ NodeJSDebuggerPane::~NodeJSDebuggerPane()
     EventNotifier::Get()->Unbind(wxEVT_NODEJS_DEBUGGER_SELECT_FRAME, &NodeJSDebuggerPane::OnFrameSelected, this);
     EventNotifier::Get()->Unbind(
         wxEVT_NODEJS_DEBUGGER_UPDATE_BREAKPOINTS_VIEW, &NodeJSDebuggerPane::OnUpdateDebuggerView, this);
+    EventNotifier::Get()->Unbind(wxEVT_EDITOR_CONFIG_CHANGED, &NodeJSDebuggerPane::OnSettingsChanged, this);
 
     ClearCallstack();
 }
@@ -510,4 +519,13 @@ void NodeJSDebuggerPane::OnLookup(clDebugEvent& event)
         m_dataviewLocals->Expand(parent);
     }
     m_pendingLookupRefs.clear();
+}
+
+void NodeJSDebuggerPane::OnSettingsChanged(wxCommandEvent& event) {
+    event.Skip();
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        m_notebook->SetStyle(m_notebook->GetStyle() & ~kNotebook_LightTabs | kNotebook_DarkTabs);
+    } else {
+        m_notebook->SetStyle(m_notebook->GetStyle() & ~kNotebook_DarkTabs | kNotebook_LightTabs);
+    }
 }

--- a/WebTools/NodeJSDebuggerPane.h
+++ b/WebTools/NodeJSDebuggerPane.h
@@ -78,6 +78,7 @@ protected:
     void OnExceptionThrown(clDebugEvent& event);
     void OnUpdateDebuggerView(clDebugEvent& event);
     void OnFrameSelected(clDebugEvent& event);
+    void OnSettingsChanged(wxCommandEvent& event);
 
 public:
     NodeJSDebuggerPane(wxWindow* parent);

--- a/codelitephp/php-plugin/PHPDebugPane.cpp
+++ b/codelitephp/php-plugin/PHPDebugPane.cpp
@@ -22,7 +22,14 @@ PHPDebugPane::PHPDebugPane(wxWindow* parent)
     EventNotifier::Get()->Bind(wxEVT_XDEBUG_SESSION_STARTING, &PHPDebugPane::OnXDebugSessionStarting, this);
     EventNotifier::Get()->Bind(wxEVT_XDEBUG_BREAKPOINTS_UPDATED, &PHPDebugPane::OnRefreshBreakpointsView, this);
     EventNotifier::Get()->Bind(wxEVT_XDEBUG_SESSION_ENDED, &PHPDebugPane::OnXDebugSessionEnded, this);
+    EventNotifier::Get()->Bind(wxEVT_EDITOR_CONFIG_CHANGED, &PHPDebugPane::OnSettingsChanged, this);
     m_console = new TerminalEmulatorUI(m_auiBook);
+
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        m_auiBook->SetStyle(kNotebook_Default & ~kNotebook_LightTabs | kNotebook_DarkTabs);
+    } else {
+        m_auiBook->SetStyle(kNotebook_Default);
+    }
 
     m_auiBook->AddPage(m_console, _("Console"), true);
     LexerConf::Ptr_t phpLexer = ColoursAndFontsManager::Get().GetLexer("php");
@@ -38,6 +45,7 @@ PHPDebugPane::~PHPDebugPane()
     EventNotifier::Get()->Unbind(wxEVT_XDEBUG_SESSION_STARTING, &PHPDebugPane::OnXDebugSessionStarting, this);
     EventNotifier::Get()->Unbind(wxEVT_XDEBUG_BREAKPOINTS_UPDATED, &PHPDebugPane::OnRefreshBreakpointsView, this);
     EventNotifier::Get()->Unbind(wxEVT_XDEBUG_SESSION_ENDED, &PHPDebugPane::OnXDebugSessionEnded, this);
+    EventNotifier::Get()->Unbind(wxEVT_EDITOR_CONFIG_CHANGED, &PHPDebugPane::OnSettingsChanged, this);
 }
 
 void PHPDebugPane::OnUpdateStackTrace(XDebugEvent& e)
@@ -201,3 +209,12 @@ void PHPDebugPane::OnXDebugSessionStarting(XDebugEvent& event)
     }
 }
 void PHPDebugPane::OnCallStackMenu(wxDataViewEvent& event) {}
+
+void PHPDebugPane::OnSettingsChanged(wxCommandEvent& event) {
+    event.Skip();
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        m_auiBook->SetStyle(m_auiBook->GetStyle() & ~kNotebook_LightTabs | kNotebook_DarkTabs);
+    } else {
+        m_auiBook->SetStyle(m_auiBook->GetStyle() & ~kNotebook_DarkTabs | kNotebook_LightTabs);
+    }
+}

--- a/codelitephp/php-plugin/PHPDebugPane.h
+++ b/codelitephp/php-plugin/PHPDebugPane.h
@@ -47,6 +47,7 @@ public:
     void OnXDebugSessionEnded(XDebugEvent& e);
     void OnXDebugSessionStarted(XDebugEvent& e);
     void OnXDebugSessionStarting(XDebugEvent& event);
+    void OnSettingsChanged(wxCommandEvent& event);
     void SelectTab(const wxString& title);
     void SetTerminal(TerminalEmulator* terminal) { m_console->SetTerminal(terminal); }
 

--- a/codelitephp/php-plugin/evalpane.cpp
+++ b/codelitephp/php-plugin/evalpane.cpp
@@ -11,11 +11,18 @@ EvalPane::EvalPane(wxWindow* parent)
     Hide();
     EventNotifier::Get()->Bind(wxEVT_XDEBUG_EVAL_EXPRESSION,  &EvalPane::OnExpressionEvaluate, this);
     EventNotifier::Get()->Bind(wxEVT_XDEBUG_UNKNOWN_RESPONSE, &EvalPane::OnDBGPCommandEvaluated, this);
+    EventNotifier::Get()->Bind(wxEVT_EDITOR_CONFIG_CHANGED, &EvalPane::OnSettingsChanged, this);
     LexerConf::Ptr_t lex =  EditorConfigST::Get()->GetLexer("text");
     if ( lex ) {
         lex->Apply(m_stcOutput);
     }
-    
+
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        m_notebook257->SetStyle(kNotebook_Default & ~kNotebook_LightTabs | kNotebook_DarkTabs);
+    } else {
+        m_notebook257->SetStyle(kNotebook_Default);
+    }
+
     // Since XDebug replies with XML, use the XML lexer for the output
     LexerConf::Ptr_t xml_lex =  EditorConfigST::Get()->GetLexer("xml");
     if ( xml_lex ) {
@@ -29,6 +36,7 @@ EvalPane::~EvalPane()
 {
     EventNotifier::Get()->Unbind(wxEVT_XDEBUG_EVAL_EXPRESSION, &EvalPane::OnExpressionEvaluate, this);
     EventNotifier::Get()->Unbind(wxEVT_XDEBUG_UNKNOWN_RESPONSE, &EvalPane::OnDBGPCommandEvaluated, this);
+    EventNotifier::Get()->Unbind(wxEVT_EDITOR_CONFIG_CHANGED, &EvalPane::OnSettingsChanged, this);
 }
 
 void EvalPane::OnEnter(wxCommandEvent& event)
@@ -99,4 +107,13 @@ void EvalPane::OnDBGPCommandEvaluated(XDebugEvent& e)
     m_stcOutputXDebug->SetText(e.GetEvaluted());
     m_stcOutputXDebug->SetEditable(true);
     m_stcOutputXDebug->ScrollToEnd();
+}
+
+void EvalPane::OnSettingsChanged(wxCommandEvent& event) {
+    event.Skip();
+    if (EditorConfigST::Get()->GetOptions()->IsTabColourDark()) {
+        m_notebook257->SetStyle(m_notebook257->GetStyle() & ~kNotebook_LightTabs | kNotebook_DarkTabs);
+    } else {
+        m_notebook257->SetStyle(m_notebook257->GetStyle() & ~kNotebook_DarkTabs | kNotebook_LightTabs);
+    }
 }

--- a/codelitephp/php-plugin/evalpane.h
+++ b/codelitephp/php-plugin/evalpane.h
@@ -41,6 +41,7 @@ protected:
     virtual void OnSendUI(wxUpdateUIEvent& event);
     void OnExpressionEvaluate(XDebugEvent &e);
     void OnDBGPCommandEvaluated(XDebugEvent &e);
+    void OnSettingsChanged(wxCommandEvent& event);
 
 };
 #endif // EVALPANE_H


### PR DESCRIPTION
CodeLite's dark tab theme looks really good when used with other dark-themed UI elements, but there isn't currently a good way to configure CodeLite to use that theme (besides the match-editor-theme option, which only works for editor tabs). These changes add a new option to the settings dialog (Windows & Tabs > Docking > Use dark notebook tab theme by default) which allows the user to switch the tabs to the dark theme (when not overridden by the match-editor-theme option). This option is stored using what appears to be a previously unused options bit, and should have all of the logic in place for initializing and updating the color theme of all four of CodeLite's main notebooks.

I've never used wxCrafter before making this small change, and, since it looks like it clobbered pretty much all of the .wxcb file and the related #include guard, I'm worried that I might be doing something wrong or using the wrong version. I can fix those files manually if you want me to.

I'm also not sure if there's anything special that I need to do to get the new text that's added with this change to be localization-ready; if there is, I'll take care of that too.