### PR TITLE
Make tab switcher not crash in debug builds

### DIFF
--- a/Plugin/NotebookNavigationDlg.cpp
+++ b/Plugin/NotebookNavigationDlg.cpp
@@ -62,7 +62,8 @@ NotebookNavigationDlg::NotebookNavigationDlg(wxWindow* parent, Notebook* book)
             // add extra info
             wxVariant modifiedItem;
             wxVariant nullBmp;
-            nullBmp << wxNullBitmap;
+            unsigned char zeros[] = "\0\0";
+            nullBmp << wxBitmap{wxImage{1, 1, zeros, zeros, true}};
             std::map<void*, clTab>::iterator iter = tabsInfoMap.find(windows.Item(i));
             if(iter != tabsInfoMap.end()) {
                 d->isFile = iter->second.isFile;


### PR DESCRIPTION
I've noticed an odd bug where using the tab switcher in a debug build of CodeLite causes CodeLite to crash after displaying an error window like this one:
![odd_tab_switcher_crash](https://cloud.githubusercontent.com/assets/3191150/21959604/1aa16216-da9a-11e6-94a4-0275a3b3f3f1.png)

It seems like this arises from specifying the modified/unmodified indicator in the leftmost column of the tab switcher to be `wxNullBitmap`, which apparently can't be used for this when building in debug mode even though release mode seems to have no problems with it (unless it's a silent memory error or something?). In any case, this commit changes that usage of `wxNullBitmap` to a single-pixel transparent bitmap which doesn't seem to have this problem.