### PR TITLE
Fix code navigation accelerator when keyUp

### DIFF
--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -4749,6 +4749,7 @@ void LEditor::OnKeyUp(wxKeyEvent& event)
         // Clear hyperlink markers
         SetIndicatorCurrent(HYPERLINK_INDICATOR);
         IndicatorClearRange(0, GetLength());
+        m_hyperLinkType = wxID_NONE;     
 
         // Clear debugger marker
         SetIndicatorCurrent(DEBUGGER_INDICATOR);


### PR DESCRIPTION
I think there is a bug in the code navigation key behaviour:
1. Press and hold code navigation key (e.g. `Ctrl`).
2. Move mouse to the code item you want to navigate (it appears underlined).
3. Release code navigation key (this should cancel the navigation functionality).
4. Click on the item and the navigation is still working, making the editor jump to the specific declaration.

I use `Ctrl` as code navigation key and this bug produces a lot of undesired jumps, specially when combining code navigation with fast copy&paste operations (`Ctrl+c` / `Ctrl+v`), which is quite normal. 
It is really frustrating as forces me to slow down when programming.

I have not seen any other PR or issue related to this bug. Only a comment here: #843

This PR is a simple proposal to fix the bug.
It has been tested in Ubuntu 14.04.

