### PR TITLE
Prevent crash if clang reply returns null results without an error

### DIFF
--- a/LiteEditor/clang_driver.cpp
+++ b/LiteEditor/clang_driver.cpp
@@ -576,12 +576,14 @@ void ClangDriver::OnPrepareTUEnded(wxCommandEvent& e)
         break;
     }
 
-    if(!reply->results && !reply->errorMessage.IsEmpty()) {
-        // Notify about this error
-        clCommandEvent event(wxEVT_CLANG_CODE_COMPLETE_MESSAGE);
-        event.SetString(reply->errorMessage);
-        event.SetInt(1); // indicates that this is an error message
-        EventNotifier::Get()->AddPendingEvent(event);
+    if(!reply->results) {
+        if (!reply->errorMessage.IsEmpty()) {
+            // Notify about this error
+            clCommandEvent event(wxEVT_CLANG_CODE_COMPLETE_MESSAGE);
+            event.SetString(reply->errorMessage);
+            event.SetInt(1); // indicates that this is an error message
+            EventNotifier::Get()->AddPendingEvent(event);
+        }
         return;
     }
 


### PR DESCRIPTION
I'm sure its only broken because my clang setup is wrong, but after losing an hour of work, it irritated me enough to track it down. 