### PR TITLE
Phpcs

### DIFF
--- a/PHPLint/phplint.cpp
+++ b/PHPLint/phplint.cpp
@@ -175,14 +175,17 @@ void PHPLint::DoCheckFile(const wxFileName& filename)
     }
 
     wxFileName phpmd(m_settings.GetPhpmdPhar());
-    wxFileName phpmdRules(m_settings.GetPhpmdRules());
-    if(phpmd.Exists() && phpmdRules.Exists()) {
+    if(phpmd.Exists()) {
         wxString phpmdPath = phpmd.GetFullPath();
         ::WrapWithQuotes(phpmdPath);
-        wxString phpmdRulesPath = phpmdRules.GetFullPath();
-        ::WrapWithQuotes(phpmdRulesPath);
 
-        command = phpPath + " " + phpmdPath + " " + file + " xml " + phpmdRulesPath;
+        wxString phpmdRules(m_settings.GetPhpmdRules());
+        if (phpmdRules.IsEmpty()) {
+            phpmdRules = "cleancode,codesize,controversial,design,naming,unusedcode";
+        }
+        ::WrapWithQuotes(phpmdRules);
+
+        command = phpPath + " " + phpmdPath + " " + file + " xml " + phpmdRules;
         DispatchCommand(command, filename);
     } else {
         clDEBUG() << "PHPLint: Could not find PHPMD file(s). Ignoring" << clEndl;

--- a/PHPLint/phplint.cpp
+++ b/PHPLint/phplint.cpp
@@ -143,9 +143,8 @@ void PHPLint::RunLint()
 
 void PHPLint::DoCheckFile(const wxFileName& filename)
 {
-    m_output.Clear();
     m_settingsPhp.Load(); // Incase it was modified by the user
-    
+
     // Build the commands
     wxString command;
 
@@ -161,7 +160,7 @@ void PHPLint::DoCheckFile(const wxFileName& filename)
     ::WrapWithQuotes(phpPath);
 
     command = phpPath + " -l " + file;
-    DispatchCommand(command, filename);
+    m_queue.push_back(command);
 
     wxFileName phpcs(m_settings.GetPhpcsPhar());
     if(phpcs.Exists()) {
@@ -169,9 +168,9 @@ void PHPLint::DoCheckFile(const wxFileName& filename)
         ::WrapWithQuotes(phpcsPath);
 
         command = phpPath + " " + phpcsPath + " --report=xml " + file;
-        DispatchCommand(command, filename);
+        m_queue.push_back(command);
     } else  {
-        clDEBUG() << "PHPLint: Could not find PHP-CS file. Ignoring" << clEndl;
+        clDEBUG() << "PHPLint: Could not find the PHP-CS application. Ignoring" << clEndl;
     }
 
     wxFileName phpmd(m_settings.GetPhpmdPhar());
@@ -186,82 +185,82 @@ void PHPLint::DoCheckFile(const wxFileName& filename)
         ::WrapWithQuotes(phpmdRules);
 
         command = phpPath + " " + phpmdPath + " " + file + " xml " + phpmdRules;
-        DispatchCommand(command, filename);
+        m_queue.push_back(command);
     } else {
-        clDEBUG() << "PHPLint: Could not find PHPMD file(s). Ignoring" << clEndl;
+        clDEBUG() << "PHPLint: Could not find the PHPMD application. Ignoring" << clEndl;
     }
-}
 
-void PHPLint::DispatchCommand(const wxString& command, const wxFileName& filename)
-{
-    // Run the check command
-    m_process = ::CreateAsyncProcess(this, command);
-    if(!m_process) {
-        // failed to run the command
-        clWARNING() << "PHPLint: could not run command" << command << clEndl;
-        DoProcessQueue();
-        m_currentFileBeingProcessed.Clear();
-
-    } else {
-        clWARNING() << "PHPLint: running check" << command << clEndl;
-        m_currentFileBeingProcessed = filename.GetFullPath();
-    }
+    DoProcessQueue();
 }
 
 void PHPLint::DoProcessQueue()
 {
     if(!m_process && !m_queue.empty()) {
-        wxFileName filename = m_queue.front();
+        wxString command = m_queue.front();
         m_queue.pop_front();
-        DoCheckFile(filename);
+        DispatchCommand(command);
     }
+}
+
+void PHPLint::DispatchCommand(const wxString& command)
+{
+    // Run the check command
+    m_output.clear();
+    m_process = ::CreateAsyncProcess(this, command);
+    if(!m_process) {
+        // failed to run the command
+        clWARNING() << "PHPLint: Could not run command:" << command << clEndl;
+        DoProcessQueue();
+        return;
+    }
+
+    clDEBUG() << "PHPLint: Running command:" << command << clEndl;
 }
 
 void PHPLint::OnProcessTerminated(clProcessEvent& event)
 {
-    clDEBUG() << "PHPLint: process terminated. output:" << event.GetOutput() << clEndl;
+    clDEBUG() << "PHPLint: process terminated. output:" << m_output << clEndl;
     wxDELETE(m_process);
-    wxString output = m_output.Clone();
-    m_output.clear();
-    CallAfter(&PHPLint::OnLintingDone, output, m_currentFileBeingProcessed);
+    CallAfter(&PHPLint::OnLintingDone, m_output.Clone());
     // Check the queue for more files
     DoProcessQueue();
 }
 
 void PHPLint::OnProcessOutput(clProcessEvent& event) { m_output << event.GetOutput(); }
 
-void PHPLint::OnLintingDone(const wxString& lintOutput, const wxString& filename)
+void PHPLint::OnLintingDone(const wxString& lintOutput)
 {
-    // Find the editor
-    clDEBUG() << "PHPLint: searching editor for file:" << filename << clEndl;
-
-    IEditor* editor = m_mgr->FindEditor(filename);
-    CHECK_PTR_RET(editor);
-
-    if(lintOutput.Contains("Errors parsing")) {
-        ProcessPhpError(lintOutput, editor);
+    if(lintOutput.Contains("Errors parsing ")) {
+        ProcessPhpError(lintOutput);
         return;
     }
 
-    ProcessXML(lintOutput, editor);
+    ProcessXML(lintOutput);
 }
 
-void PHPLint::ProcessPhpError(const wxString& lintOutput, IEditor*& editor)
+void PHPLint::ProcessPhpError(const wxString& lintOutput)
 {
     wxRegEx reLine("[ \t]*on line ([0-9]+)");
     // get the line number
     if(reLine.Matches(lintOutput)) {
         wxString strLine = reLine.GetMatch(lintOutput, 1);
 
-        int start = lintOutput.Find("error:");
+        int start = lintOutput.Find("error:") + 6;
         int end = lintOutput.Find(" in ");
-        wxString errorMessage = lintOutput.Mid(start + 6, end - 6 - start);
+        wxString errorMessage = lintOutput.Mid(start, end - start);
+
+        // Find the editor
+        int fileStart = lintOutput.Find("Errors parsing ") + 15;
+        wxString filename = lintOutput.Mid(fileStart);
+        clDEBUG() << "PHPLint: searching editor for file:" << filename << clEndl;
+        IEditor* editor = m_mgr->FindEditor(filename);
+        CHECK_PTR_RET(editor);
 
         MarkError(errorMessage, strLine, editor);
     }
 }
 
-void PHPLint::ProcessXML(const wxString& lintOutput, IEditor*& editor)
+void PHPLint::ProcessXML(const wxString& lintOutput)
 {
     wxStringInputStream lintOutputStream(lintOutput);
     wxXmlDocument doc;
@@ -269,6 +268,12 @@ void PHPLint::ProcessXML(const wxString& lintOutput, IEditor*& editor)
 
     wxXmlNode* file = doc.GetRoot()->GetChildren();
     if(!file) return;
+
+    // Find the editor
+    wxString filename = file->GetAttribute("name");
+    clDEBUG() << "PHPLint: searching editor for file:" << filename << clEndl;
+    IEditor* editor = m_mgr->FindEditor(filename);
+    CHECK_PTR_RET(editor);
 
     wxString linter = doc.GetRoot()->GetName();
 

--- a/PHPLint/phplint.h
+++ b/PHPLint/phplint.h
@@ -45,6 +45,8 @@ private:
     bool IsWarning(wxXmlNode* violation, const wxString& linter);
     void MarkError(wxString& errorMessage, const wxString& strLine, IEditor*& editor, bool isWarning = false);
     void RunLint();
+    void QueuePhpcsCommand(const wxString& phpPath, const wxString& file);
+    void QueuePhpmdCommand(const wxString& phpPath, const wxString& file);
 
 protected:
     void DoProcessQueue();

--- a/PHPLint/phplint.h
+++ b/PHPLint/phplint.h
@@ -32,17 +32,16 @@
 
 class PHPLint : public IPlugin
 {
-    std::list<wxFileName> m_queue;
+    std::list<wxString> m_queue;
     wxString m_output;
     IProcess* m_process;
-    wxString m_currentFileBeingProcessed;
     LintOptions m_settings;
     LintPhpOptions m_settingsPhp;
 
 private:
-    void DispatchCommand(const wxString& command, const wxFileName& filename);
-    void ProcessPhpError(const wxString& lintOutput, IEditor*& editor);
-    void ProcessXML(const wxString& lintOutput, IEditor*& editor);
+    void DispatchCommand(const wxString& command);
+    void ProcessPhpError(const wxString& lintOutput);
+    void ProcessXML(const wxString& lintOutput);
     bool IsWarning(wxXmlNode* violation, const wxString& linter);
     void MarkError(wxString& errorMessage, const wxString& strLine, IEditor*& editor, bool isWarning = false);
     void RunLint();
@@ -70,7 +69,7 @@ public:
     virtual void UnPlug();
 
     void OnCheck(wxCommandEvent& e);
-    void OnLintingDone(const wxString& lintOutput, const wxString& filename);
+    void OnLintingDone(const wxString& lintOutput);
     void OnLoadFile(clCommandEvent& e);
     void OnSaveFile(clCommandEvent& e);
     void OnProcessTerminated(clProcessEvent &event);


### PR DESCRIPTION
This avoids the need to configure a xml file for phpmd, if no xml is configured it will use phpmd's default configuration.

This also fixes a race condition in PHPLint where a fast linter could silence the output from a slow one.