### PR TITLE
fix SQL Parsing in SQLCommandPanel

### DIFF
--- a/DatabaseExplorer/SqlCommandPanel.h
+++ b/DatabaseExplorer/SqlCommandPanel.h
@@ -77,7 +77,9 @@ public:
 // ----------------------------------------------------------------
 class SQLCommandPanel : public _SqlCommandPanel
 {
-
+    
+    int m_OperatorStyle;
+    int m_CommentStyle;
 protected:
     virtual void OnHistoryToolClicked(wxAuiToolBarEvent& event);
     IDbAdapter*                              m_pDbAdapter;
@@ -89,7 +91,7 @@ protected:
 
 protected:
     bool IsBlobColumn(const wxString &str);
-    wxArrayString ParseSql(const wxString &sql) const;
+    wxArrayString ParseSql() const;
     void SaveSqlHistory();
 
 public:


### PR DESCRIPTION
This fixes SQL statement parsing in order to update the SQL history in SQLCommandPanel correctly.

Two types of statements are not parsed correctly:
- an SQL statement that contains a semicolon in a quoted string or
- an SQL statement followed by a comment on the same line.

This fix uses the style information in the wxStyledTextCtrl (produced by the SQL Lexer) to identify the correct semicolon that ends a command and to identify and strip out comments.

Example failing statements:
select * from People where LName not like '%a%'; -- test comment
select * from People where LName not like '%;%';