### PR TITLE
fix Unicode in SQL statements for MysqlDatabaseLayer

### DIFF
--- a/sdk/databaselayer/src/dblayer/MysqlDatabaseLayer.cpp
+++ b/sdk/databaselayer/src/dblayer/MysqlDatabaseLayer.cpp
@@ -342,8 +342,8 @@ DatabaseResultSet* MysqlDatabaseLayer::RunQueryWithResults(const wxString& strQu
     {
       wxCharBuffer sqlBuffer = ConvertToUnicodeStream(strCurrentQuery);
       //puts(sqlBuffer);
-      wxString sqlUTF8((const char*)sqlBuffer, wxConvUTF8);
-      if (m_pInterface->GetMysqlStmtPrepare()(pMysqlStatement, sqlBuffer, sqlUTF8.Length()) == 0)
+      //wxString sqlUTF8((const char*)sqlBuffer, wxConvUTF8);
+      if (m_pInterface->GetMysqlStmtPrepare()(pMysqlStatement, sqlBuffer, sqlBuffer.length()) == 0)
       {
         int nReturn = m_pInterface->GetMysqlStmtExecute()(pMysqlStatement);
         if (nReturn != 0)


### PR DESCRIPTION
This fix allows MysqlDatabaseLayer to pass SQL statements that contain Unicode characters (beyond the 128 ASCII characters) to MySQL.

An example statement:
select * from People where LName not like '☺';