### PR TITLE
SQL Query parse fix

### DIFF
--- a/DatabaseExplorer/SqlCommandPanel.cpp
+++ b/DatabaseExplorer/SqlCommandPanel.cpp
@@ -154,7 +154,7 @@ void SQLCommandPanel::ExecuteSql()
         }
 
         // save the history
-        SaveSqlHistory();
+        SaveSqlHistory(sqls);
 
         if(!sqls.IsEmpty()) {
             try {
@@ -632,9 +632,8 @@ wxArrayString SQLCommandPanel::ParseSql() const
     return sqls;
 }
 
-void SQLCommandPanel::SaveSqlHistory()
+void SQLCommandPanel::SaveSqlHistory(wxArrayString sqls)
 {
-    wxArrayString sqls = ParseSql();
     if(sqls.IsEmpty()) return;
 
     DbExplorerSettings s;

--- a/DatabaseExplorer/SqlCommandPanel.cpp
+++ b/DatabaseExplorer/SqlCommandPanel.cpp
@@ -146,22 +146,22 @@ void SQLCommandPanel::ExecuteSql()
     std::set<int> blobCols;
     DatabaseLayerPtr m_pDbLayer = m_pDbAdapter->GetDatabaseLayer(m_dbName);
     if(m_pDbLayer->IsOpen()) {
-        // test for empty command string
-        wxArrayString arrCmdLines = wxStringTokenize(m_scintillaSQL->GetText(), wxT("\n"), wxTOKEN_STRTOK);
-        int cmdLines = 0;
-        for(size_t i = 0; i < arrCmdLines.GetCount(); i++) {
-            if(!arrCmdLines[i].Trim(false).StartsWith(wxT("--"))) cmdLines++;
+        // build string of SQL statements with comments removed
+        wxArrayString sqls = ParseSql();
+        wxString sqlStmt = "";
+        for(size_t i = 0; i < sqls.GetCount(); i++) {
+            sqlStmt += sqls[i];
         }
 
         // save the history
         SaveSqlHistory();
 
-        if(cmdLines > 0) {
+        if(!sqls.IsEmpty()) {
             try {
                 m_colsMetaData.clear();
                 if(!m_pDbAdapter->GetUseDb(m_dbName).IsEmpty()) m_pDbLayer->RunQuery(m_pDbAdapter->GetUseDb(m_dbName));
                 // run query
-                DatabaseResultSet* pResultSet = m_pDbLayer->RunQueryWithResults(m_scintillaSQL->GetText());
+                DatabaseResultSet* pResultSet = m_pDbLayer->RunQueryWithResults(sqlStmt);
 
                 // clear variables
                 if(m_gridTable->GetNumberCols()) {

--- a/DatabaseExplorer/SqlCommandPanel.h
+++ b/DatabaseExplorer/SqlCommandPanel.h
@@ -92,7 +92,7 @@ protected:
 protected:
     bool IsBlobColumn(const wxString &str);
     wxArrayString ParseSql() const;
-    void SaveSqlHistory();
+    void SaveSqlHistory(wxArrayString sqls);
 
 public:
     SQLCommandPanel(wxWindow *parent,IDbAdapter* dbAdapter, const wxString& dbName,const wxString& dbTable);

--- a/sdk/databaselayer/src/dblayer/DatabaseQueryParser.cpp
+++ b/sdk/databaselayer/src/dblayer/DatabaseQueryParser.cpp
@@ -10,14 +10,17 @@ bool IsEmptyQuery(const wxString& strQuery)
 wxArrayString ParseQueries(const wxString& strQuery)
 {
   wxArrayString returnArray;
-  bool bInQuote = false;
+  bool bInDQuote = false;
+  bool bInSQuote = false;
   int nLast = 0;
 
-  for ( int i=0; i<(int)strQuery.Length(); i++ )
+  for (int i = 0; i < (int) strQuery.Length(); i++)
   {
-      if ( strQuery.SubString(i, i) == _T("'") )
-          bInQuote = !bInQuote;
-      else if ( strQuery.SubString(i, i) == _T(";") && !bInQuote )
+      if (!bInDQuote && strQuery.SubString(i, i) == _T("'") && strQuery.SubString(i - 1, i - 1) != _T("\\"))
+          bInSQuote = !bInSQuote;
+      else if (!bInSQuote && strQuery.SubString(i, i) == _T("\"") && strQuery.SubString(i - 1, i - 1) != _T("\\"))
+          bInDQuote = !bInDQuote;
+      else if ( strQuery.SubString(i, i) == _T(";") && (!bInSQuote && !bInDQuote))
       {
           wxString str;
           str << strQuery.SubString(nLast, i);

--- a/sdk/databaselayer/src/dblayer/DatabaseQueryParser.cpp
+++ b/sdk/databaselayer/src/dblayer/DatabaseQueryParser.cpp
@@ -14,21 +14,26 @@ wxArrayString ParseQueries(const wxString& strQuery)
   bool bInSQuote = false;
   int nLast = 0;
 
-  for (int i = 0; i < (int) strQuery.Length(); i++)
-  {
-      if (!bInDQuote && strQuery.SubString(i, i) == _T("'") && strQuery.SubString(i - 1, i - 1) != _T("\\"))
-          bInSQuote = !bInSQuote;
-      else if (!bInSQuote && strQuery.SubString(i, i) == _T("\"") && strQuery.SubString(i - 1, i - 1) != _T("\\"))
+  for (int i = 0; i < (int) strQuery.Length(); i++) {
+    if (!bInDQuote && strQuery.SubString(i, i) == _T("'")) {
+        if(!bInSQuote || strQuery.SubString(i - 1, i - 1) != _T("\\")) {
+            bInSQuote = !bInSQuote;
+        }
+            
+    }
+    else if (!bInSQuote && strQuery.SubString(i, i) == _T("\"")) {
+        if(!bInDQuote || strQuery.SubString(i - 1, i - 1) != _T("\\")) {
           bInDQuote = !bInDQuote;
-      else if ( strQuery.SubString(i, i) == _T(";") && (!bInSQuote && !bInDQuote))
-      {
-          wxString str;
-          str << strQuery.SubString(nLast, i);
-          if (!IsEmptyQuery(str))
+        }
+    }
+    else if ( strQuery.SubString(i, i) == _T(";") && (!bInSQuote && !bInDQuote)) {
+        wxString str;
+        str << strQuery.SubString(nLast, i);
+        if (!IsEmptyQuery(str))
             returnArray.Add( str );
 
-          nLast = i + 1;
-      }
+        nLast = i + 1;
+    }
   }
 
   if ( nLast < (int)strQuery.Length() -1 )


### PR DESCRIPTION
The following SQL queries are now parsed and run correctly via the SqlCommandPanel.  

Previously comments at the end of a statement caused statements to fail.
Previously only single quote strings were parsed correctly.

`select ";"; -- TEST`
`select ';'; -- TEST`
`select "Hello";`
`select 'Hello';`
`select '\'Hello\'';`
`select "\"Hello;\"";`
`select '''Hello''';`
`select '"hello"';`
`select "'hello'";`

The following query runs but the Lexer does not highlight the quoted string correctly.
`select '\'Hello;\''; -- lexer does not highlight this correctly`

ParseSql is used to remove the comments from the Sql statements in ExecuteSql.  SaveSqlHistory now takes a parameter so that ParseSql is not called twice in ExecuteSql.