### PR TITLE
Code formatter: php-cs-fixer, phpbcf: Make rules file a bool option

### DIFF
--- a/CodeFormatter/clClangFormatLocator.cpp
+++ b/CodeFormatter/clClangFormatLocator.cpp
@@ -73,15 +73,3 @@ double clClangFormatLocator::GetVersion(const wxString& clangFormat) const
 #endif
     return double_version; // Default
 }
-
-wxFileName clClangFormatLocator::FindConfigForFile(const wxFileName& filename) const
-{
-    wxFileName clangFormatConfigFile(filename.GetPath(), ".clang-format");
-    while(clangFormatConfigFile.GetDirCount()) {
-        if(clangFormatConfigFile.FileExists()) {
-            return clangFormatConfigFile;
-        }
-        clangFormatConfigFile.RemoveLastDir();
-    }
-    return wxFileName();
-}

--- a/CodeFormatter/clClangFormatLocator.h
+++ b/CodeFormatter/clClangFormatLocator.h
@@ -45,12 +45,6 @@ public:
      * @brief return the clang format version installed
      */
     double GetVersion(const wxString& clangFormat) const;
-
-    /**
-     * @brief When using -style=file, clang-format for each input file will try to find the .clang-format file located
-     * in the closest parent directory of the input file
-     */
-    wxFileName FindConfigForFile(const wxFileName& filename) const;
 };
 
 #endif // CLCLANGFORMATLOCATOR_H

--- a/CodeFormatter/codeformatterdlg.cpp
+++ b/CodeFormatter/codeformatterdlg.cpp
@@ -161,8 +161,10 @@ void CodeFormatterDlg::InitDialog()
 
     // PHP-CS-FIXER
     m_filePickerPHPCsFixerPhar->SetValue(m_options.GetPHPCSFixerPhar());
-    m_pgPropPHPCsFixerOptions->SetValue(m_options.GetPHPCSFixerPharOptions());
+    wxString options = m_options.GetPHPCSFixerPharOptions();
+    m_pgPropPHPCsFixerOptions->SetValue(options.Trim().Trim(false));
 
+    m_pgPropPHPCsFixerUseFile->SetValue(wxVariant((bool)(m_options.GetPHPCSFixerPharSettings() & kPHPFixserFormatFile)));
     m_pgPropPHPCsFixerStandard->SetValue((int)m_options.GetPHPCSFixerPharRules() & (kPcfPSR1 | kPcfPSR2 | kPcfSymfony));
     m_pgPropPHPCsFixerMigration->SetValue((int)m_options.GetPHPCSFixerPharRules() &
                                           (kPcfPHP56Migration | kPcfPHP70Migration | kPcfPHP71Migration));
@@ -181,6 +183,7 @@ void CodeFormatterDlg::InitDialog()
     m_filePickerPhpcbfPhar->SetValue(m_options.GetPhpcbfPhar());
     m_pgPropPhpcbfSeverity->SetValue((int)m_options.GetPhpcbfSeverity());
     m_pgPropPhpcbfEncoding->SetValue(m_options.GetPhpcbfEncoding());
+    m_pgPropPhpcbfUseFile->SetValue(wxVariant((bool)(m_options.GetPhpcbfOptions() & kPhpbcfFormatFile)));
     m_pgPropPhpcbfStandard->SetValue(m_options.GetPhpcbfStandard());
     m_pgPropPhpcbfOptions->SetValue((int)m_options.GetPhpcbfOptions());
 
@@ -367,7 +370,12 @@ void CodeFormatterDlg::OnPgmgrPHPCsFixerPgChanged(wxPropertyGridEvent& event)
 {
     m_isDirty = true;
     m_options.SetPHPCSFixerPhar(m_filePickerPHPCsFixerPhar->GetValueAsString());
-    m_options.SetPHPCSFixerPharOptions(m_pgPropPHPCsFixerOptions->GetValueAsString());
+    m_options.SetPHPCSFixerPharOptions(m_pgPropPHPCsFixerOptions->GetValueAsString().Trim().Trim(false));
+    size_t phpcsfixerSettings(0);
+    if (m_pgPropPHPCsFixerUseFile->GetValue().GetBool()) {
+        phpcsfixerSettings |= kPHPFixserFormatFile;
+    }
+    m_options.SetPHPCSFixerPharSettings(phpcsfixerSettings);
     size_t phpcsfixerOptions(0);
     phpcsfixerOptions |= m_pgPropPHPCsFixerStandard->GetValue().GetInteger();
     phpcsfixerOptions |= m_pgPropPHPCsFixerMigration->GetValue().GetInteger();
@@ -396,6 +404,9 @@ void CodeFormatterDlg::OnPgmgrPhpcbfPgChanged(wxPropertyGridEvent& event)
     m_options.SetPhpcbfStandard(m_pgPropPhpcbfStandard->GetValueAsString());
     size_t phpcbfOptions(0);
     phpcbfOptions |= m_pgPropPhpcbfOptions->GetValue().GetInteger();
+    if(m_pgPropPhpcbfUseFile->GetValue().GetBool()) {
+        phpcbfOptions |= kPhpbcfFormatFile;
+    }
     m_options.SetPhpcbfOptions(phpcbfOptions);
 
     CallAfter(&CodeFormatterDlg::UpdatePreview);

--- a/CodeFormatter/codeformatterdlg.wxcp
+++ b/CodeFormatter/codeformatterdlg.wxcp
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "m_generatedFilesDir": ".",
-  "m_objCounter": 287,
+  "m_objCounter": 289,
   "m_includeFiles": ["formatoptions.h", "PHPFormatterBuffer.h"],
   "m_bitmapFunction": "wxCrafterGgLOZbInitBitmapResources",
   "m_bitmapsFile": "codeformatterdlg_codeformatter_bitmaps.cpp",
@@ -4689,6 +4689,71 @@
                              "m_properties": [{
                                "type": "string",
                                "m_label": "Name:",
+                               "m_value": "m_pgPropPHPCsFixerUseFile"
+                              }, {
+                               "type": "string",
+                               "m_label": "Label:",
+                               "m_value": "Use .php_cs file "
+                              }, {
+                               "type": "multi-string",
+                               "m_label": "Tooltip:",
+                               "m_value": "Use .php_cs file if exists"
+                              }, {
+                               "type": "colour",
+                               "m_label": "Bg Colour:",
+                               "colour": "<Default>"
+                              }, {
+                               "type": "choice",
+                               "m_label": "Property Editor Control",
+                               "m_selection": 0,
+                               "m_options": ["", "TextCtrl", "Choice", "ComboBox", "CheckBox", "TextCtrlAndButton", "ChoiceAndButton", "SpinCtrl", "DatePickerCtrl"]
+                              }, {
+                               "type": "choice",
+                               "m_label": "Kind:",
+                               "m_selection": 3,
+                               "m_options": ["wxPropertyCategory", "wxIntProperty", "wxFloatProperty", "wxBoolProperty", "wxStringProperty", "wxLongStringProperty", "wxDirProperty", "wxArrayStringProperty", "wxFileProperty", "wxEnumProperty", "wxEditEnumProperty", "wxFlagsProperty", "wxDateProperty", "wxImageFileProperty", "wxFontProperty", "wxSystemColourProperty"]
+                              }, {
+                               "type": "string",
+                               "m_label": "String Value",
+                               "m_value": ""
+                              }, {
+                               "type": "multi-string",
+                               "m_label": "Choices:",
+                               "m_value": ""
+                              }, {
+                               "type": "multi-string",
+                               "m_label": "Array Integer Values",
+                               "m_value": ""
+                              }, {
+                               "type": "bool",
+                               "m_label": "Bool Value",
+                               "m_value": true
+                              }, {
+                               "type": "string",
+                               "m_label": "Wildcard",
+                               "m_value": ""
+                              }, {
+                               "type": "font",
+                               "m_label": "Font:",
+                               "m_value": ""
+                              }, {
+                               "type": "colour",
+                               "m_label": "Initial Colour",
+                               "colour": "<Default>"
+                              }],
+                             "m_events": [],
+                             "m_children": []
+                            }, {
+                             "m_type": 4486,
+                             "proportion": 0,
+                             "border": 5,
+                             "gbSpan": "1,1",
+                             "gbPosition": "0,0",
+                             "m_styles": [],
+                             "m_sizerFlags": [],
+                             "m_properties": [{
+                               "type": "string",
+                               "m_label": "Name:",
                                "m_value": "m_pgPropPHPCsFixerStandard"
                               }, {
                                "type": "string",
@@ -6055,6 +6120,71 @@
                              "m_properties": [{
                                "type": "string",
                                "m_label": "Name:",
+                               "m_value": "m_pgPropPhpcbfUseFile"
+                              }, {
+                               "type": "string",
+                               "m_label": "Label:",
+                               "m_value": "Use phpcs.xml file "
+                              }, {
+                               "type": "multi-string",
+                               "m_label": "Tooltip:",
+                               "m_value": "Use phpcs.xml file if exists"
+                              }, {
+                               "type": "colour",
+                               "m_label": "Bg Colour:",
+                               "colour": "<Default>"
+                              }, {
+                               "type": "choice",
+                               "m_label": "Property Editor Control",
+                               "m_selection": 0,
+                               "m_options": ["", "TextCtrl", "Choice", "ComboBox", "CheckBox", "TextCtrlAndButton", "ChoiceAndButton", "SpinCtrl", "DatePickerCtrl"]
+                              }, {
+                               "type": "choice",
+                               "m_label": "Kind:",
+                               "m_selection": 3,
+                               "m_options": ["wxPropertyCategory", "wxIntProperty", "wxFloatProperty", "wxBoolProperty", "wxStringProperty", "wxLongStringProperty", "wxDirProperty", "wxArrayStringProperty", "wxFileProperty", "wxEnumProperty", "wxEditEnumProperty", "wxFlagsProperty", "wxDateProperty", "wxImageFileProperty", "wxFontProperty", "wxSystemColourProperty"]
+                              }, {
+                               "type": "string",
+                               "m_label": "String Value",
+                               "m_value": ""
+                              }, {
+                               "type": "multi-string",
+                               "m_label": "Choices:",
+                               "m_value": ""
+                              }, {
+                               "type": "multi-string",
+                               "m_label": "Array Integer Values",
+                               "m_value": ""
+                              }, {
+                               "type": "bool",
+                               "m_label": "Bool Value",
+                               "m_value": true
+                              }, {
+                               "type": "string",
+                               "m_label": "Wildcard",
+                               "m_value": ""
+                              }, {
+                               "type": "font",
+                               "m_label": "Font:",
+                               "m_value": ""
+                              }, {
+                               "type": "colour",
+                               "m_label": "Initial Colour",
+                               "colour": "<Default>"
+                              }],
+                             "m_events": [],
+                             "m_children": []
+                            }, {
+                             "m_type": 4486,
+                             "proportion": 0,
+                             "border": 5,
+                             "gbSpan": "1,1",
+                             "gbPosition": "0,0",
+                             "m_styles": [],
+                             "m_sizerFlags": [],
+                             "m_properties": [{
+                               "type": "string",
+                               "m_label": "Name:",
                                "m_value": "m_pgPropPhpcbfStandard"
                               }, {
                                "type": "string",
@@ -6063,7 +6193,7 @@
                               }, {
                                "type": "multi-string",
                                "m_label": "Tooltip:",
-                               "m_value": "Coding standard. If the \"phpcs.xml\" option is selected, CodeLite will ignore all the options set here and use the options set in your phpcs.xml file"
+                               "m_value": "Coding standard."
                               }, {
                                "type": "colour",
                                "m_label": "Bg Colour:",
@@ -6081,11 +6211,11 @@
                               }, {
                                "type": "string",
                                "m_label": "String Value",
-                               "m_value": "phpcs.xml;MySource;PEAR;PHPCS;PSR1;PSR2;Squiz;Zend"
+                               "m_value": "MySource;PEAR;PSR1;PSR2;Squiz;Zend"
                               }, {
                                "type": "multi-string",
                                "m_label": "Choices:",
-                               "m_value": "phpcs.xml;MySource;PEAR;PHPCS;PSR1;PSR2;Squiz;Zend"
+                               "m_value": "MySource;PEAR;PSR1;PSR2;Squiz;Zend"
                               }, {
                                "type": "multi-string",
                                "m_label": "Array Integer Values",

--- a/CodeFormatter/codeformatterdlgbase.cpp
+++ b/CodeFormatter/codeformatterdlgbase.cpp
@@ -162,7 +162,6 @@ CodeFormatterBaseDlg::CodeFormatterBaseDlg(wxWindow* parent, wxWindowID id, cons
     m_pgMgrClangIntArr.Add(kClangFormatWebKit);
     m_pgMgrClangIntArr.Add(kClangFormatChromium);
     m_pgMgrClangIntArr.Add(kClangFormatMozilla);
-    m_pgMgrClangIntArr.Add(kClangFormatFile);
     m_pgPropClangFormatStyle = m_pgMgrClang->AppendIn( m_pgPropClangFormat,  new wxEnumProperty( _("Style"), wxPG_LABEL, m_pgMgrClangArr, m_pgMgrClangIntArr, 0) );
     m_pgPropClangFormatStyle->SetHelpString(_("Coding style"));
     
@@ -568,6 +567,9 @@ CodeFormatterBaseDlg::CodeFormatterBaseDlg(wxWindow* parent, wxWindowID id, cons
     m_pgPropPHPCsFixerOptions = m_pgMgrPHPCsFixer->AppendIn( m_pgPropPhpCSFixer,  new wxStringProperty( _("Parameters"), wxPG_LABEL, wxT("")) );
     m_pgPropPHPCsFixerOptions->SetHelpString(_("Manually enter parameters.\nIf filled CodeLite will ignore all other options and use the"));
     
+    m_pgPropPHPCsFixerUseFile = m_pgMgrPHPCsFixer->AppendIn( m_pgPropPhpCSFixer,  new wxBoolProperty( _("Use .php_cs file"), wxPG_LABEL, 1) );
+    m_pgPropPHPCsFixerUseFile->SetHelpString(_("Use .php_cs file if exists"));
+    
     m_pgMgrPHPCsFixerArr.Clear();
     m_pgMgrPHPCsFixerIntArr.Clear();
     m_pgMgrPHPCsFixerArr.Add(_("None"));
@@ -774,18 +776,19 @@ CodeFormatterBaseDlg::CodeFormatterBaseDlg(wxWindow* parent, wxWindowID id, cons
     m_pgPropPhpcbfEncoding = m_pgMgrPhpcbf->AppendIn( m_pgPropPhpcbf,  new wxEnumProperty( _("Encoding"), wxPG_LABEL, m_pgMgrPhpcbfArr, m_pgMgrPhpcbfIntArr, 0) );
     m_pgPropPhpcbfEncoding->SetHelpString(_("The encoding of the files being fixed"));
     
+    m_pgPropPhpcbfUseFile = m_pgMgrPhpcbf->AppendIn( m_pgPropPhpcbf,  new wxBoolProperty( _("Use phpcs.xml file"), wxPG_LABEL, 1) );
+    m_pgPropPhpcbfUseFile->SetHelpString(_("Use phpcs.xml file if exists"));
+    
     m_pgMgrPhpcbfArr.Clear();
     m_pgMgrPhpcbfIntArr.Clear();
-    m_pgMgrPhpcbfArr.Add(_("phpcs.xml"));
     m_pgMgrPhpcbfArr.Add(_("MySource"));
     m_pgMgrPhpcbfArr.Add(_("PEAR"));
-    m_pgMgrPhpcbfArr.Add(_("PHPCS"));
     m_pgMgrPhpcbfArr.Add(_("PSR1"));
     m_pgMgrPhpcbfArr.Add(_("PSR2"));
     m_pgMgrPhpcbfArr.Add(_("Squiz"));
     m_pgMgrPhpcbfArr.Add(_("Zend"));
     m_pgPropPhpcbfStandard = m_pgMgrPhpcbf->AppendIn( m_pgPropPhpcbf,  new wxEnumProperty( _("Standard"), wxPG_LABEL, m_pgMgrPhpcbfArr, m_pgMgrPhpcbfIntArr, 0) );
-    m_pgPropPhpcbfStandard->SetHelpString(_("Coding standard. If the \"phpcs.xml\" option is selected, CodeLite will ignore all the options set here and use the options set in your phpcs.xml file"));
+    m_pgPropPhpcbfStandard->SetHelpString(_("Coding standard."));
     
     m_pgMgrPhpcbfArr.Clear();
     m_pgMgrPhpcbfIntArr.Clear();

--- a/CodeFormatter/codeformatterdlgbase.h
+++ b/CodeFormatter/codeformatterdlgbase.h
@@ -4,8 +4,8 @@
 // Do not modify this file by hand!
 //////////////////////////////////////////////////////////////////////
 
-#ifndef _CODELITE_CODEFORMATTER_CODEFORMATTERDLG_BASE_CLASSES_H
-#define _CODELITE_CODEFORMATTER_CODEFORMATTERDLG_BASE_CLASSES_H
+#ifndef CODELITE_CODEFORMATTER_CODEFORMATTERDLG_BASE_CLASSES_H
+#define CODELITE_CODEFORMATTER_CODEFORMATTERDLG_BASE_CLASSES_H
 
 #include <wx/settings.h>
 #include <wx/xrc/xmlres.h>
@@ -103,6 +103,7 @@ protected:
     wxPGProperty* m_pgPropPhpCSFixer;
     wxPGProperty* m_filePickerPHPCsFixerPhar;
     wxPGProperty* m_pgPropPHPCsFixerOptions;
+    wxPGProperty* m_pgPropPHPCsFixerUseFile;
     wxPGProperty* m_pgPropPHPCsFixerStandard;
     wxPGProperty* m_pgPropPHPCsFixerMigration;
     wxPGProperty* m_pgPropPHPCsFixerDoubleArrows;
@@ -121,6 +122,7 @@ protected:
     wxPGProperty* m_filePickerPhpcbfPhar;
     wxPGProperty* m_pgPropPhpcbfSeverity;
     wxPGProperty* m_pgPropPhpcbfEncoding;
+    wxPGProperty* m_pgPropPhpcbfUseFile;
     wxPGProperty* m_pgPropPhpcbfStandard;
     wxPGProperty* m_pgPropPhpcbfOptions;
     wxPanel* m_splitterPage17313;

--- a/CodeFormatter/formatoptions.h
+++ b/CodeFormatter/formatoptions.h
@@ -89,6 +89,10 @@ enum PHPFormatterEngine {
     kPhpFormatEnginePhpcbf,
 };
 
+enum PHPFixserFormatterSettings {
+    kPHPFixserFormatFile = (1 << 1),
+};
+
 enum PHPFixserFormatterStyle {
     kPcfAllowRisky = (1 << 0),
     kPcfPHP56Migration = (1 << 1),
@@ -126,6 +130,7 @@ enum PHPFixserFormatterStyle {
 
 enum PhpbcfFormatterStyle {
     kWarningSeverity0 = (1 << 0),
+    kPhpbcfFormatFile = (1 << 1),
 };
 
 enum ClangFormatStyle {
@@ -183,6 +188,7 @@ class FormatOptions : public SerializedObject
     size_t m_generalFlags;
     wxString m_PHPCSFixerPhar;
     wxString m_PHPCSFixerPharOptions;
+    size_t m_PHPCSFixerPharSettings;
     size_t m_PHPCSFixerPharRules;
     wxString m_PhpcbfPhar;
     size_t m_phpcbfSeverity;
@@ -200,6 +206,11 @@ private:
      */
     wxString ClangGlobalSettings() const;
     void AutodetectSettings();
+
+    /**
+     * @brief Check if there is a file of the given name in any of the parent directories of the input file
+     */
+    bool HasConfigForFile(const wxFileName& fileName, const wxString& configName) const;
 
 public:
     FormatOptions();
@@ -307,6 +318,7 @@ public:
 
     // PHP-CS-FIXER
     bool GetPhpFixerCommand(const wxFileName& fileName, wxString& command);
+    wxString GetPhpFixerRules(const wxFileName& fileName);
     void SetPHPCSFixerPhar(const wxString& PHPCSFixerPhar)
     {
         this->m_PHPCSFixerPhar = PHPCSFixerPhar;
@@ -323,6 +335,14 @@ public:
     {
         return m_PHPCSFixerPharOptions;
     }
+    void SetPHPCSFixerPharSettings(const size_t& PHPCSFixerPharSettings)
+    {
+        this->m_PHPCSFixerPharSettings = PHPCSFixerPharSettings;
+    }
+    size_t GetPHPCSFixerPharSettings() const
+    {
+        return m_PHPCSFixerPharSettings;
+    }
     void SetPHPCSFixerPharRules(const size_t& PHPCSFixerPharRules)
     {
         this->m_PHPCSFixerPharRules = PHPCSFixerPharRules;
@@ -334,6 +354,7 @@ public:
 
     // PHPCBF
     bool GetPhpcbfCommand(const wxFileName& fileName, wxString& command);
+    wxString GetPhpcbfStandard(const wxFileName& fileName);
     void SetPhpcbfPhar(const wxString& PhpcbfPhar)
     {
         this->m_PhpcbfPhar = PhpcbfPhar;


### PR DESCRIPTION
Additionally check if the file exists. This allows for the settings to
be a fallback for projects that don't come with there own rules.