### PR TITLE
fixed "error: ‘for_each’ is not a member of ‘std’"

### DIFF
--- a/Subversion2/SvnShowFileChangesHandler.h
+++ b/Subversion2/SvnShowFileChangesHandler.h
@@ -3,6 +3,7 @@
 
 #include "svncommandhandler.h" // Base class: SvnCommandHandler
 #include <list>
+#include <algorithm>
 
 class Subversion2;
 


### PR DESCRIPTION
Fixed "error: ‘for_each’ is not a member of ‘std’", preventing CodeLite to compile