### PR TITLE
Fixes toggling comment when caret at the beginning of a line

### DIFF
--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -5214,9 +5214,9 @@ void LEditor::ToggleLineComment(const wxString& commentSymbol, int commentStyle)
     int lineEnd = LineFromPosition(end);
 
     // Check if the "end" position is at the start of a line, in that case, don't
-    // include it
+    // include it. Only do this in case of a selection.
     int endLineStartPos = PositionFromLine(lineEnd);
-    if(endLineStartPos == end) {
+    if(lineStart < lineEnd && endLineStartPos == end) {
         --lineEnd;
     }
 


### PR DESCRIPTION
Fixes #1699