### PR TITLE
#1707 - Silence phpcs progressbar and verbos messages

### DIFF
--- a/PHPLint/phplint.cpp
+++ b/PHPLint/phplint.cpp
@@ -175,7 +175,7 @@ void PHPLint::QueuePhpcsCommand(const wxString& phpPath, const wxString& file)
     wxString phpcsPath = phpcs.GetFullPath();
     ::WrapWithQuotes(phpcsPath);
 
-    m_queue.push_back(phpPath + " " + phpcsPath + " --report=xml " + file);
+    m_queue.push_back(phpPath + " " + phpcsPath + " --report=xml -q " + file);
 }
 
 void PHPLint::QueuePhpmdCommand(const wxString& phpPath, const wxString& file)


### PR DESCRIPTION
Though we don't enable them thease messages can be enabled via the
projects phpcs.xml so best to supress them in any case.