### PR TITLE
Improved code compliance

### DIFF
--- a/CodeLite/CxxPreProcessorScanner.cpp
+++ b/CodeLite/CxxPreProcessorScanner.cpp
@@ -65,7 +65,7 @@ bool CxxPreProcessorScanner::ConsumeBlock()
     return false;
 }
 
-void CxxPreProcessorScanner::Parse(CxxPreProcessor* pp) throw(CxxLexerException)
+void CxxPreProcessorScanner::Parse(CxxPreProcessor* pp)
 {
     CxxLexerToken token;
     bool searchingForBranch = false;
@@ -389,7 +389,7 @@ bool CxxPreProcessorScanner::ConsumeCurrentBranch()
     return false;
 }
 
-void CxxPreProcessorScanner::ReadUntilMatch(int type, CxxLexerToken& token) throw(CxxLexerException)
+void CxxPreProcessorScanner::ReadUntilMatch(int type, CxxLexerToken& token)
 {
     while(::LexerNext(m_scanner, token)) {
         if(token.type == type) {

--- a/CodeLite/CxxPreProcessorScanner.h
+++ b/CodeLite/CxxPreProcessorScanner.h
@@ -62,7 +62,7 @@ private:
      * If we reached the end of the 'PreProcessor' state and there is no match
      * throw an exception
      */
-    void ReadUntilMatch(int type, CxxLexerToken& token) throw (CxxLexerException);
+    void ReadUntilMatch(int type, CxxLexerToken& token);
     
     void GetRestOfPPLine(wxString &rest, bool collectNumberOnly = false);
     bool CheckIfDefined(const CxxPreProcessorToken::Map_t& table);
@@ -85,7 +85,7 @@ public:
      * @brief the main parsing function
      * @param ppTable
      */
-    void Parse(CxxPreProcessor* pp)  throw (CxxLexerException);
+    void Parse(CxxPreProcessor* pp);
 };
 
 #endif // CXXPREPROCESSORSCANNER_H

--- a/CodeLite/SocketAPI/clSocketBase.cpp
+++ b/CodeLite/SocketAPI/clSocketBase.cpp
@@ -54,7 +54,7 @@ void clSocketBase::Initialize()
 }
 
 // Read API
-int clSocketBase::Read(wxMemoryBuffer& content, long timeout) throw(clSocketException)
+int clSocketBase::Read(wxMemoryBuffer& content, long timeout)
 {
     content.Clear();
 
@@ -88,7 +88,7 @@ int clSocketBase::Read(wxMemoryBuffer& content, long timeout) throw(clSocketExce
     return kTimeout;
 }
 
-int clSocketBase::Read(wxString& content, const wxMBConv& conv, long timeout) throw(clSocketException)
+int clSocketBase::Read(wxString& content, const wxMBConv& conv, long timeout)
 {
     wxMemoryBuffer mb;
     int rc = Read(mb, timeout);
@@ -98,7 +98,7 @@ int clSocketBase::Read(wxString& content, const wxMBConv& conv, long timeout) th
     return rc;
 }
 
-int clSocketBase::Read(char* buffer, size_t bufferSize, size_t& bytesRead, long timeout) throw(clSocketException)
+int clSocketBase::Read(char* buffer, size_t bufferSize, size_t& bytesRead, long timeout)
 {
     if(SelectRead(timeout) == kTimeout) {
         return kTimeout;
@@ -108,7 +108,7 @@ int clSocketBase::Read(char* buffer, size_t bufferSize, size_t& bytesRead, long 
     return kSuccess;
 }
 
-int clSocketBase::SelectRead(long seconds) throw(clSocketException)
+int clSocketBase::SelectRead(long seconds)
 {
     if(seconds == -1) {
         return kSuccess;
@@ -139,7 +139,7 @@ int clSocketBase::SelectRead(long seconds) throw(clSocketException)
 }
 
 // Send API
-void clSocketBase::Send(const wxString& msg, const wxMBConv& conv) throw(clSocketException)
+void clSocketBase::Send(const wxString& msg, const wxMBConv& conv)
 {
     if(m_socket == INVALID_SOCKET) {
         throw clSocketException("Invalid socket!");
@@ -150,7 +150,7 @@ void clSocketBase::Send(const wxString& msg, const wxMBConv& conv) throw(clSocke
     Send(mb);
 }
 
-void clSocketBase::Send(const std::string& msg) throw(clSocketException)
+void clSocketBase::Send(const std::string& msg)
 {
     if(m_socket == INVALID_SOCKET) {
         throw clSocketException("Invalid socket!");
@@ -160,7 +160,7 @@ void clSocketBase::Send(const std::string& msg) throw(clSocketException)
     Send(mb);
 }
 
-void clSocketBase::Send(const wxMemoryBuffer& msg) throw(clSocketException)
+void clSocketBase::Send(const wxMemoryBuffer& msg)
 {
     if(m_socket == INVALID_SOCKET) {
         throw clSocketException("Invalid socket!");
@@ -221,7 +221,7 @@ void clSocketBase::DestroySocket()
     m_socket = INVALID_SOCKET;
 }
 
-int clSocketBase::ReadMessage(wxString& message, int timeout) throw(clSocketException)
+int clSocketBase::ReadMessage(wxString& message, int timeout)
 {
     // send the length in string form to avoid binary / arch differences between remote and local machine
     char msglen[11];
@@ -268,7 +268,7 @@ int clSocketBase::ReadMessage(wxString& message, int timeout) throw(clSocketExce
     return kSuccess;
 }
 
-void clSocketBase::WriteMessage(const wxString& message) throw(clSocketException)
+void clSocketBase::WriteMessage(const wxString& message)
 {
     if(m_socket == INVALID_SOCKET) {
         throw clSocketException("Invalid socket!");
@@ -313,7 +313,7 @@ void clSocketBase::MakeSocketBlocking(bool blocking)
 #endif
 }
 
-int clSocketBase::SelectWriteMS(long milliSeconds) throw(clSocketException)
+int clSocketBase::SelectWriteMS(long milliSeconds)
 {
     if(milliSeconds == -1) {
         return kSuccess;
@@ -346,7 +346,7 @@ int clSocketBase::SelectWriteMS(long milliSeconds) throw(clSocketException)
     }
 }
 
-int clSocketBase::SelectWrite(long seconds) throw(clSocketException)
+int clSocketBase::SelectWrite(long seconds)
 {
     if(seconds == -1) {
         return kSuccess;
@@ -377,7 +377,7 @@ int clSocketBase::SelectWrite(long seconds) throw(clSocketException)
     }
 }
 
-int clSocketBase::SelectReadMS(long milliSeconds) throw(clSocketException)
+int clSocketBase::SelectReadMS(long milliSeconds)
 {
     if(milliSeconds == -1) {
         return kSuccess;

--- a/CodeLite/SocketAPI/clSocketBase.h
+++ b/CodeLite/SocketAPI/clSocketBase.h
@@ -102,54 +102,54 @@ public:
      * @brief
      * @param msg
      */
-    void Send(const std::string& msg) throw(clSocketException);
-    void Send(const wxMemoryBuffer& msg) throw(clSocketException);
-    void Send(const wxString& msg, const wxMBConv& conv = wxConvUTF8) throw(clSocketException);
+    void Send(const std::string& msg);
+    void Send(const wxMemoryBuffer& msg);
+    void Send(const wxString& msg, const wxMBConv& conv = wxConvUTF8);
 
     /**
      * @brief
      * @return
      */
-    int Read(char* buffer, size_t bufferSize, size_t& bytesRead, long timeout = -1) throw(clSocketException);
+    int Read(char* buffer, size_t bufferSize, size_t& bytesRead, long timeout = -1);
     /**
      * @brief read string content from remote server
      * @param content [output]
      * @param timeout seconds to wait
      */
-    int Read(wxString& content, const wxMBConv& conv = wxConvUTF8, long timeout = -1) throw(clSocketException);
+    int Read(wxString& content, const wxMBConv& conv = wxConvUTF8, long timeout = -1);
     
     /**
      * @brief read a buffer from the socket
      * @param content [output]
      * @param timeout seconds to wait
      */
-    int Read(wxMemoryBuffer& content, long timeout = -1) throw(clSocketException);
+    int Read(wxMemoryBuffer& content, long timeout = -1);
 
     /**
      * @brief
      * @param seconds
      * @return
      */
-    int SelectRead(long seconds = -1) throw(clSocketException);
+    int SelectRead(long seconds = -1);
     
     /**
      * @brief select for read. Same as above, but use milli seconds instead
      * @param milliSeconds number of _milliseconds_ to wait
      * @return 
      */
-    int SelectReadMS(long milliSeconds = -1) throw(clSocketException);
+    int SelectReadMS(long milliSeconds = -1);
     
     /**
      * @brief select for write
      * @return
      */
-    int SelectWrite(long seconds = -1) throw(clSocketException);
+    int SelectWrite(long seconds = -1);
     
     /**
      * @brief select for write (milli seconds version)
      * @return
      */
-    int SelectWriteMS(long milliSeconds = -1) throw(clSocketException);
+    int SelectWriteMS(long milliSeconds = -1);
 
     /**
      * @brief read a full message that was sent with 'SendMessage'
@@ -157,13 +157,13 @@ public:
      * @param timeout seconds to wait
      * @return kSuccess, kTimeout or kError
      */
-    int ReadMessage(wxString& message, int timeout) throw(clSocketException);
+    int ReadMessage(wxString& message, int timeout);
 
     /**
      * @brief write a full message
      * @param message
      */
-    void WriteMessage(const wxString& message) throw(clSocketException);
+    void WriteMessage(const wxString& message);
 
 protected:
     /**

--- a/CodeLite/SocketAPI/clSocketServer.cpp
+++ b/CodeLite/SocketAPI/clSocketServer.cpp
@@ -45,7 +45,7 @@ clSocketServer::~clSocketServer()
     DestroySocket();
 }
 
-void clSocketServer::CreateServer(const std::string &pipePath) throw (clSocketException)
+void clSocketServer::CreateServer(const std::string &pipePath)
 {
 #ifndef __WXMSW__
     unlink(pipePath.c_str());
@@ -84,7 +84,7 @@ void clSocketServer::CreateServer(const std::string &pipePath) throw (clSocketEx
 #endif
 }
 
-clSocketBase::Ptr_t clSocketServer::WaitForNewConnection(long timeout) throw (clSocketException)
+clSocketBase::Ptr_t clSocketServer::WaitForNewConnection(long timeout)
 {
     if ( SelectRead( timeout ) == kTimeout ) {
         return clSocketBase::Ptr_t( NULL );
@@ -97,7 +97,7 @@ clSocketBase::Ptr_t clSocketServer::WaitForNewConnection(long timeout) throw (cl
     return clSocketBase::Ptr_t(new clSocketBase(fd));
 }
 
-void clSocketServer::CreateServer(const std::string &address, int port) throw (clSocketException)
+void clSocketServer::CreateServer(const std::string &address, int port)
 {
     // Create a socket
     if( (m_socket = ::socket(AF_INET , SOCK_STREAM , 0)) == INVALID_SOCKET) {

--- a/CodeLite/SocketAPI/clSocketServer.h
+++ b/CodeLite/SocketAPI/clSocketServer.h
@@ -40,9 +40,9 @@ public:
      * LocalSocket is implemented under Windows with TCP/IP with IP always set to 127.0.0.1
      * @param pipePath
      */
-    void CreateServer(const std::string &pipePath) throw (clSocketException);
-    void CreateServer(const std::string &address, int port) throw (clSocketException);
-    clSocketBase::Ptr_t WaitForNewConnection( long timeout = -1 ) throw (clSocketException);
+    void CreateServer(const std::string &pipePath);
+    void CreateServer(const std::string &address, int port);
+    clSocketBase::Ptr_t WaitForNewConnection( long timeout = -1 );
 };
 
 #endif // CLSOCKETSERVER_H

--- a/CodeLite/cl_calltip.cpp
+++ b/CodeLite/cl_calltip.cpp
@@ -51,6 +51,7 @@ clCallTip& clCallTip::operator=(const clCallTip& rhs)
 {
     if(this == &rhs) return *this;
     m_tips = rhs.m_tips;
+    m_curr = rhs.m_curr;
     return *this;
 }
 

--- a/CodeLite/cl_sftp.cpp
+++ b/CodeLite/cl_sftp.cpp
@@ -53,7 +53,7 @@ clSFTP::clSFTP(clSSH::Ptr_t ssh)
 
 clSFTP::~clSFTP() { Close(); }
 
-void clSFTP::Initialize() throw(clException)
+void clSFTP::Initialize()
 {
     if(m_sftp) return;
 
@@ -82,7 +82,7 @@ void clSFTP::Close()
 
 void clSFTP::Write(const wxFileName& localFile,
                    const wxString& remotePath,
-                   SFTPAttribute::Ptr_t attributes) throw(clException)
+                   SFTPAttribute::Ptr_t attributes)
 {
     if(!m_connected) {
         throw clException("scp is not initialized!");
@@ -115,7 +115,7 @@ void clSFTP::Write(const wxFileName& localFile,
 
 void clSFTP::Write(const wxMemoryBuffer& fileContent,
                    const wxString& remotePath,
-                   SFTPAttribute::Ptr_t attributes) throw(clException)
+                   SFTPAttribute::Ptr_t attributes)
 {
     if(!m_sftp) {
         throw clException("SFTP is not initialized");
@@ -180,7 +180,7 @@ void clSFTP::Write(const wxMemoryBuffer& fileContent,
     }
 }
 
-SFTPAttribute::List_t clSFTP::List(const wxString& folder, size_t flags, const wxString& filter) throw(clException)
+SFTPAttribute::List_t clSFTP::List(const wxString& folder, size_t flags, const wxString& filter)
 {
     sftp_dir dir;
     sftp_attributes attributes;
@@ -231,7 +231,7 @@ SFTPAttribute::List_t clSFTP::List(const wxString& folder, size_t flags, const w
     return files;
 }
 
-SFTPAttribute::List_t clSFTP::CdUp(size_t flags, const wxString& filter) throw(clException)
+SFTPAttribute::List_t clSFTP::CdUp(size_t flags, const wxString& filter)
 {
     wxString curfolder = m_currentFolder;
     curfolder << "/../"; // Force a cd up
@@ -241,7 +241,7 @@ SFTPAttribute::List_t clSFTP::CdUp(size_t flags, const wxString& filter) throw(c
     return List(fn.GetPath(false, wxPATH_UNIX), flags, filter);
 }
 
-SFTPAttribute::Ptr_t clSFTP::Read(const wxString& remotePath, wxMemoryBuffer& buffer) throw(clException)
+SFTPAttribute::Ptr_t clSFTP::Read(const wxString& remotePath, wxMemoryBuffer& buffer)
 {
     if(!m_sftp) {
         throw clException("SFTP is not initialized");
@@ -287,7 +287,7 @@ SFTPAttribute::Ptr_t clSFTP::Read(const wxString& remotePath, wxMemoryBuffer& bu
     return fileAttr;
 }
 
-void clSFTP::CreateDir(const wxString& dirname) throw(clException)
+void clSFTP::CreateDir(const wxString& dirname)
 {
     if(!m_sftp) {
         throw clException("SFTP is not initialized");
@@ -303,7 +303,7 @@ void clSFTP::CreateDir(const wxString& dirname) throw(clException)
     }
 }
 
-void clSFTP::Rename(const wxString& oldpath, const wxString& newpath) throw(clException)
+void clSFTP::Rename(const wxString& oldpath, const wxString& newpath)
 {
     if(!m_sftp) {
         throw clException("SFTP is not initialized");
@@ -318,7 +318,7 @@ void clSFTP::Rename(const wxString& oldpath, const wxString& newpath) throw(clEx
     }
 }
 
-void clSFTP::RemoveDir(const wxString& dirname) throw(clException)
+void clSFTP::RemoveDir(const wxString& dirname)
 {
     if(!m_sftp) {
         throw clException("SFTP is not initialized");
@@ -334,7 +334,7 @@ void clSFTP::RemoveDir(const wxString& dirname) throw(clException)
     }
 }
 
-void clSFTP::UnlinkFile(const wxString& path) throw(clException)
+void clSFTP::UnlinkFile(const wxString& path)
 {
     if(!m_sftp) {
         throw clException("SFTP is not initialized");
@@ -350,7 +350,7 @@ void clSFTP::UnlinkFile(const wxString& path) throw(clException)
     }
 }
 
-SFTPAttribute::Ptr_t clSFTP::Stat(const wxString& path) throw(clException)
+SFTPAttribute::Ptr_t clSFTP::Stat(const wxString& path)
 {
     if(!m_sftp) {
         throw clException("SFTP is not initialized");
@@ -367,14 +367,14 @@ SFTPAttribute::Ptr_t clSFTP::Stat(const wxString& path) throw(clException)
 
 void clSFTP::CreateRemoteFile(const wxString& remoteFullPath,
                               const wxString& content,
-                              SFTPAttribute::Ptr_t attr) throw(clException)
+                              SFTPAttribute::Ptr_t attr)
 {
     // Create the path to the file
     Mkpath(wxFileName(remoteFullPath).GetPath());
     Write(content, remoteFullPath, attr);
 }
 
-void clSFTP::Mkpath(const wxString& remoteDirFullpath) throw(clException)
+void clSFTP::Mkpath(const wxString& remoteDirFullpath)
 {
     if(!m_sftp) {
         throw clException("SFTP is not initialized");
@@ -408,13 +408,13 @@ void clSFTP::Mkpath(const wxString& remoteDirFullpath) throw(clException)
 
 void clSFTP::CreateRemoteFile(const wxString& remoteFullPath,
                               const wxFileName& localFile,
-                              SFTPAttribute::Ptr_t attr) throw(clException)
+                              SFTPAttribute::Ptr_t attr)
 {
     Mkpath(wxFileName(remoteFullPath).GetPath());
     Write(localFile, remoteFullPath, attr);
 }
 
-void clSFTP::Chmod(const wxString& remotePath, size_t permissions) throw(clException)
+void clSFTP::Chmod(const wxString& remotePath, size_t permissions)
 {
     if(!m_sftp) {
         throw clException("SFTP is not initialized");

--- a/CodeLite/cl_sftp.h
+++ b/CodeLite/cl_sftp.h
@@ -75,7 +75,7 @@ public:
     /**
      * @brief intialize the scp over ssh
      */
-    void Initialize() throw(clException);
+    void Initialize();
 
     /**
      * @brief close the scp channel
@@ -89,20 +89,20 @@ public:
      */
     void Write(const wxFileName& localFile,
                const wxString& remotePath,
-               SFTPAttribute::Ptr_t attributes = SFTPAttribute::Ptr_t(NULL)) throw(clException);
+               SFTPAttribute::Ptr_t attributes = SFTPAttribute::Ptr_t(NULL));
 
     /**
      * @brief write the content of 'fileContent' into the remote file represented by remotePath
      */
     void Write(const wxMemoryBuffer& fileContent,
                const wxString& remotePath,
-               SFTPAttribute::Ptr_t attributes = SFTPAttribute::Ptr_t(NULL)) throw(clException);
+               SFTPAttribute::Ptr_t attributes = SFTPAttribute::Ptr_t(NULL));
 
     /**
      * @brief read remote file and return its content
      * @return the file content + the file attributes
      */
-    SFTPAttribute::Ptr_t Read(const wxString& remotePath, wxMemoryBuffer& buffer) throw(clException);
+    SFTPAttribute::Ptr_t Read(const wxString& remotePath, wxMemoryBuffer& buffer);
 
     /**
      * @brief list the content of a folder
@@ -111,20 +111,20 @@ public:
      * @param filter filter out files that do not match the filter
      * @throw clException incase an error occurred
      */
-    SFTPAttribute::List_t List(const wxString& folder, size_t flags, const wxString& filter = "") throw(clException);
+    SFTPAttribute::List_t List(const wxString& folder, size_t flags, const wxString& filter = "");
 
     /**
      * @brief create a directory
      * @param dirname
      */
-    void CreateDir(const wxString& dirname) throw(clException);
+    void CreateDir(const wxString& dirname);
 
     /**
      * @brief create a file. This function also creates the path to the file (by calling internally to Mkpath)
      */
     void CreateRemoteFile(const wxString& remoteFullPath,
                           const wxString& content,
-                          SFTPAttribute::Ptr_t attr) throw(clException);
+                          SFTPAttribute::Ptr_t attr);
 
     /**
      * @brief this version create a copy of the local file on the remote server. Similar to the previous
@@ -132,46 +132,46 @@ public:
      */
     void CreateRemoteFile(const wxString& remoteFullPath,
                           const wxFileName& localFile,
-                          SFTPAttribute::Ptr_t attr) throw(clException);
+                          SFTPAttribute::Ptr_t attr);
 
     /**
      * @brief create path . If the directory does not exist, create it (all sub paths if needed)
      */
-    void Mkpath(const wxString& remoteDirFullpath) throw(clException);
+    void Mkpath(const wxString& remoteDirFullpath);
 
     /**
      * @brief Remove a directoy.
      * @param dirname
      */
-    void RemoveDir(const wxString& dirname) throw(clException);
+    void RemoveDir(const wxString& dirname);
 
     /**
      * @brief Unlink (delete) a file.
      * @param dirname
      */
-    void UnlinkFile(const wxString& path) throw(clException);
+    void UnlinkFile(const wxString& path);
 
     /**
      * @brief Rename or move a file or directory
      * @param oldpath
      * @param newpath
      */
-    void Rename(const wxString& oldpath, const wxString& newpath) throw(clException);
+    void Rename(const wxString& oldpath, const wxString& newpath);
     /**
      * @brief cd up and list the content of the directory
      * @return
      */
-    SFTPAttribute::List_t CdUp(size_t flags, const wxString& filter) throw(clException);
+    SFTPAttribute::List_t CdUp(size_t flags, const wxString& filter);
 
     /**
      * @brief stat the path
      */
-    SFTPAttribute::Ptr_t Stat(const wxString& path) throw(clException);
+    SFTPAttribute::Ptr_t Stat(const wxString& path);
 
     /**
      * @brief change remote file permissions
      */
-    void Chmod(const wxString& remotePath, size_t permissions) throw(clException);
+    void Chmod(const wxString& remotePath, size_t permissions);
 
     /**
      * @brief return the current folder

--- a/CodeLite/cl_ssh.cpp
+++ b/CodeLite/cl_ssh.cpp
@@ -102,7 +102,7 @@ clSSH::clSSH()
 
 clSSH::~clSSH() { Close(); }
 
-void clSSH::Connect(int seconds) throw(clException)
+void clSSH::Connect(int seconds)
 {
     m_session = ssh_new();
     if(!m_session) {
@@ -125,7 +125,7 @@ void clSSH::Connect(int seconds) throw(clException)
     ssh_set_blocking(m_session, 1);
 }
 
-bool clSSH::AuthenticateServer(wxString& message) throw(clException)
+bool clSSH::AuthenticateServer(wxString& message)
 {
     int state;
     unsigned char* hash = NULL;
@@ -188,7 +188,7 @@ bool clSSH::AuthenticateServer(wxString& message) throw(clException)
     return false;
 }
 
-void clSSH::AcceptServerAuthentication() throw(clException)
+void clSSH::AcceptServerAuthentication()
 {
     if(!m_session) {
         throw clException("NULL SSH session");
@@ -202,7 +202,7 @@ void clSSH::AcceptServerAuthentication() throw(clException)
     }                           \
     return false;
 
-bool clSSH::LoginPassword(bool throwExc) throw(clException)
+bool clSSH::LoginPassword(bool throwExc)
 {
     if(!m_session) {
         THROW_OR_FALSE("NULL SSH session");
@@ -223,7 +223,7 @@ bool clSSH::LoginPassword(bool throwExc) throw(clException)
     return false;
 }
 
-bool clSSH::LoginInteractiveKBD(bool throwExc) throw(clException)
+bool clSSH::LoginInteractiveKBD(bool throwExc)
 {
     if(!m_session) {
         THROW_OR_FALSE("NULL SSH session");
@@ -266,7 +266,7 @@ bool clSSH::LoginInteractiveKBD(bool throwExc) throw(clException)
     return false;
 }
 
-bool clSSH::LoginPublicKey(bool throwExc) throw(clException)
+bool clSSH::LoginPublicKey(bool throwExc)
 {
     if(!m_session) {
         THROW_OR_FALSE("NULL SSH session");
@@ -301,7 +301,7 @@ void clSSH::Close()
     m_channel = NULL;
 }
 
-void clSSH::Login() throw(clException)
+void clSSH::Login()
 {
     int rc;
 
@@ -326,7 +326,7 @@ void clSSH::Login() throw(clException)
     }
 }
 
-void clSSH::ExecuteShellCommand(wxEvtHandler* owner, const wxString& command) throw(clException)
+void clSSH::ExecuteShellCommand(wxEvtHandler* owner, const wxString& command)
 {
     DoOpenChannel();
 
@@ -391,7 +391,7 @@ void clSSH::DoCloseChannel()
     m_channel = NULL;
 }
 
-void clSSH::DoOpenChannel() throw(clException)
+void clSSH::DoOpenChannel()
 {
     if(m_channel) return;
 
@@ -421,7 +421,7 @@ void clSSH::DoOpenChannel() throw(clException)
     }
 }
 
-void clSSH::DoConnectWithRetries(int retries) throw(clException)
+void clSSH::DoConnectWithRetries(int retries)
 {
     while(retries) {
         int rc = ssh_connect(m_session);

--- a/CodeLite/cl_ssh.h
+++ b/CodeLite/cl_ssh.h
@@ -69,8 +69,8 @@ public:
 protected:
     void OnCheckRemoteOutut(wxTimerEvent& event);
     void DoCloseChannel();
-    void DoOpenChannel()  throw(clException);
-    void DoConnectWithRetries(int retries) throw(clException);
+    void DoOpenChannel();
+    void DoConnectWithRetries(int retries);
     
 public:
     clSSH(const wxString& host, const wxString& user, const wxString& pass, int port = 22);
@@ -83,7 +83,7 @@ public:
     /**
      * @brief connect to the remote server
      */
-    void Connect(int seconds = 10) throw(clException);
+    void Connect(int seconds = 10);
 
     /**
      * @brief authenticate the server
@@ -91,38 +91,38 @@ public:
      * @return true if the server could be authenticated, otherwise return false.
      * In case an error occurs, throw a clException
      */
-    bool AuthenticateServer(wxString& message) throw(clException);
+    bool AuthenticateServer(wxString& message);
 
     /**
      * @brief accepts the server authentication and add it to the "known_hosts"
      */
-    void AcceptServerAuthentication() throw(clException);
+    void AcceptServerAuthentication();
 
     /**
      * @brief login to the server with the user credentials
      * @return true if we managed to login
      * @throw clException incase something really bad happened
      */
-    bool LoginPassword(bool throwExc = true) throw(clException);
+    bool LoginPassword(bool throwExc = true);
 
     /**
      * @brief login using public key
      * @return true if we managed to login
      * @throw clException incase something really bad happened
      */
-    bool LoginPublicKey(bool throwExc = true) throw(clException);
+    bool LoginPublicKey(bool throwExc = true);
 
     /**
      * @brief login using interactive-keyboard method
      * @return true if we managed to login
      * @throw clException incase something really bad happened
      */
-    bool LoginInteractiveKBD(bool throwExc = true) throw(clException);
+    bool LoginInteractiveKBD(bool throwExc = true);
 
     /**
      * @brief try to login using all the methods we support (interactive-kbd, user/pass and public key)
      */
-    void Login() throw(clException);
+    void Login();
 
     /**
      * @brief close the SSH session
@@ -133,7 +133,7 @@ public:
     /**
      * @brief execute a remote command and return the output. open the shell if no is opened
      */
-    void ExecuteShellCommand(wxEvtHandler* owner, const wxString& command) throw(clException);
+    void ExecuteShellCommand(wxEvtHandler* owner, const wxString& command);
 
     SSHSession_t GetSession() { return m_session; }
 

--- a/LiteEditor/message_pane.cpp
+++ b/LiteEditor/message_pane.cpp
@@ -276,7 +276,7 @@ void MessagePane::DoPostEvent(ButtonDetails btn)
     }
 }
 
-void MessagePane::SavePreferenceIfNeeded(const MessageDetails msg, int choice)
+void MessagePane::SavePreferenceIfNeeded(const MessageDetails& msg, int choice)
 {
     // If the checkbox is both shown (to cater for random ticks) and checked, save the preference
     if (choice != wxNOT_FOUND && m_DontAnnoyMeCheck->IsShown() && m_DontAnnoyMeCheck->IsChecked()) {

--- a/LiteEditor/message_pane.h
+++ b/LiteEditor/message_pane.h
@@ -126,7 +126,7 @@ protected:
     void DoShowNextMessage();
     void DoShowCurrentMessage();
     void DoPostEvent(ButtonDetails btn);
-    void SavePreferenceIfNeeded(const MessageDetails msg, int choice);
+    void SavePreferenceIfNeeded(const MessageDetails &msg, int choice);
 
 public:
     /** Constructor */

--- a/Plugin/clPatch.cpp
+++ b/Plugin/clPatch.cpp
@@ -17,7 +17,7 @@ clPatch::clPatch()
 clPatch::~clPatch() {}
 
 void
-clPatch::Patch(const wxFileName& patchFile, const wxString& workingDirectory, const wxString& args) throw(clException)
+clPatch::Patch(const wxFileName& patchFile, const wxString& workingDirectory, const wxString& args)
 {
     // Sanity
     if(!m_patch.FileExists()) {

--- a/Plugin/clPatch.h
+++ b/Plugin/clPatch.h
@@ -21,7 +21,7 @@ public:
      */
     void Patch(const wxFileName& patchFile,
                const wxString& workingDirectory = "",
-               const wxString& args = "") throw(clException);
+               const wxString& args = "");
 };
 
 #endif // CLPATCH_H

--- a/sdk/databaselayer/src/dblayer/DatabaseLayer.cpp
+++ b/sdk/databaselayer/src/dblayer/DatabaseLayer.cpp
@@ -177,7 +177,7 @@ int DatabaseLayer::GetSingleResultInt(const wxString& strSQL, const wxVariant* f
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -261,7 +261,7 @@ wxString DatabaseLayer::GetSingleResultString(const wxString& strSQL, const wxVa
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -345,7 +345,7 @@ long DatabaseLayer::GetSingleResultLong(const wxString& strSQL, const wxVariant*
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -429,7 +429,7 @@ bool DatabaseLayer::GetSingleResultBool(const wxString& strSQL, const wxVariant*
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -513,7 +513,7 @@ wxDateTime DatabaseLayer::GetSingleResultDate(const wxString& strSQL, const wxVa
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -597,7 +597,7 @@ void* DatabaseLayer::GetSingleResultBlob(const wxString& strSQL, const wxVariant
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -681,7 +681,7 @@ double DatabaseLayer::GetSingleResultDouble(const wxString& strSQL, const wxVari
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -744,7 +744,7 @@ wxArrayInt DatabaseLayer::GetResultsArrayInt(const wxString& strSQL, const wxVar
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -797,7 +797,7 @@ wxArrayString DatabaseLayer::GetResultsArrayString(const wxString& strSQL, const
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -850,7 +850,7 @@ wxArrayLong DatabaseLayer::GetResultsArrayLong(const wxString& strSQL, const wxV
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 

--- a/sdk/databaselayer/src/dblayer/FirebirdDatabaseLayer.cpp
+++ b/sdk/databaselayer/src/dblayer/FirebirdDatabaseLayer.cpp
@@ -727,7 +727,7 @@ bool FirebirdDatabaseLayer::TableExists(const wxString& table)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -793,7 +793,7 @@ bool FirebirdDatabaseLayer::ViewExists(const wxString& view)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -838,7 +838,7 @@ wxArrayString FirebirdDatabaseLayer::GetTables()
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -877,7 +877,7 @@ wxArrayString FirebirdDatabaseLayer::GetViews()
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -934,7 +934,7 @@ wxArrayString FirebirdDatabaseLayer::GetColumns(const wxString& table)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 

--- a/sdk/databaselayer/src/dblayer/FirebirdPreparedStatement.cpp
+++ b/sdk/databaselayer/src/dblayer/FirebirdPreparedStatement.cpp
@@ -158,7 +158,7 @@ FirebirdPreparedStatement* FirebirdPreparedStatement::CreateStatement(FirebirdIn
       }
 
       // Pass on the error
-      throw e;
+      throw;
     }
 #endif
 

--- a/sdk/databaselayer/src/dblayer/MysqlDatabaseLayer.cpp
+++ b/sdk/databaselayer/src/dblayer/MysqlDatabaseLayer.cpp
@@ -499,7 +499,7 @@ bool MysqlDatabaseLayer::TableExists(const wxString& table)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -580,7 +580,7 @@ bool MysqlDatabaseLayer::ViewExists(const wxString& view)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -629,7 +629,7 @@ wxArrayString MysqlDatabaseLayer::GetTables()
         pResult = NULL;
       }
 
-      throw e;
+      throw;
     }
 #endif
 
@@ -688,7 +688,7 @@ wxArrayString MysqlDatabaseLayer::GetViews()
         pResult = NULL;
       }
 
-      throw e;
+      throw;
     }
 #endif
 
@@ -729,7 +729,7 @@ wxArrayString MysqlDatabaseLayer::GetColumns(const wxString& table)
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 

--- a/sdk/databaselayer/src/dblayer/PostgresDatabaseLayer.cpp
+++ b/sdk/databaselayer/src/dblayer/PostgresDatabaseLayer.cpp
@@ -394,7 +394,7 @@ bool PostgresDatabaseLayer::TableExists(const wxString& table)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -459,7 +459,7 @@ bool PostgresDatabaseLayer::ViewExists(const wxString& view)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -504,7 +504,7 @@ wxArrayString PostgresDatabaseLayer::GetTables()
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -543,7 +543,7 @@ wxArrayString PostgresDatabaseLayer::GetViews()
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -600,7 +600,7 @@ wxArrayString PostgresDatabaseLayer::GetColumns(const wxString& table)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 

--- a/sdk/databaselayer/src/dblayer/SqliteDatabaseLayer.cpp
+++ b/sdk/databaselayer/src/dblayer/SqliteDatabaseLayer.cpp
@@ -326,7 +326,7 @@ bool SqliteDatabaseLayer::TableExists(const wxString& table)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -391,7 +391,7 @@ bool SqliteDatabaseLayer::ViewExists(const wxString& view)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -436,7 +436,7 @@ wxArrayString SqliteDatabaseLayer::GetTables()
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -475,7 +475,7 @@ wxArrayString SqliteDatabaseLayer::GetViews()
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -529,7 +529,7 @@ wxArrayString SqliteDatabaseLayer::GetColumns(const wxString& table)
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 

--- a/sdk/databaselayer/src/dblayer/TdsDatabaseLayer.cpp
+++ b/sdk/databaselayer/src/dblayer/TdsDatabaseLayer.cpp
@@ -613,7 +613,7 @@ bool TdsDatabaseLayer::TableExists(const wxString& table)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -678,7 +678,7 @@ bool TdsDatabaseLayer::ViewExists(const wxString& view)
       pStatement = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -724,7 +724,7 @@ wxArrayString TdsDatabaseLayer::GetTables()
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -764,7 +764,7 @@ wxArrayString TdsDatabaseLayer::GetViews()
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 
@@ -861,7 +861,7 @@ wxArrayString TdsDatabaseLayer::GetColumns(const wxString& table)
       pResult = NULL;
     }
 
-    throw e;
+    throw;
   }
 #endif
 

--- a/sdk/wxconfig/wx-config-win.cpp
+++ b/sdk/wxconfig/wx-config-win.cpp
@@ -347,7 +347,7 @@ protected:
             m_libs.push_back(lib);
     }
 
-    void parseLibs(const std::string libs) {
+    void parseLibs(const std::string& libs) {
         std::string param = libs;
 
         // if the last parameter doesn't haves a -- switch


### PR DESCRIPTION
Hello

Mostly this patch should improve compatibility with C++11 (Dynamic exception specifications were deprecated in C++11) and should fix object slicing in exception handles.


Also I spotted several places with potential issues. It can be great if you can check it:

_Uninitialized function parameter:_
PHPLint/lintoptions.cpp:24  'size_t **m_flags** = oldJson.namedObject("m_flags").toSize_t(**m_flags**) & (1 << 1)'

_Member variable is not assigned a value in operator=:_
    CodeLite/parse_thread.cpp:543(m_definitions, _uid, (+4))    (didn't get why method looks like)
    sdk/codelite_cppcheck/externals/simplecpp/simplecpp.cpp(:205 files), (:970 files, usageList)    (same)

_Called C++ object pointer is null:_
    sdk/wxshapeframework/src/ShapeCanvas.cpp:1565
    SnipWiz/swStringDb.cpp:253

_Found duplicate branches for 'if' and 'else':_
    LiteEditor/mainbook.cpp:377
    Plugin/art_metro.cpp:345 (& 399 with TODO)
    codelitephp/php-plugin/php_workspace_view.cpp:978
    sdk/databaselayer/src/dblayer/PostgresResultSet.cpp:141

_Known conditions:_
    LiteEditor/new_build_tab.cpp:1046 (isWarning dead assigned, initialized only)
    SpellChecker/IHunSpell.cpp:221 (same)
    SpellChecker/hunspell/affixmgr.cxx:3028,3035,3072   ('1 == 0'  three times)
    sdk/codelite_indexer/libctags/verilog.c:241 (false)
    sdk/codelite_indexer/libctags/eiffel.c:534 (false)

_Checking if unsigned variable is less than zero:_
    /home/hard/src/codelite/LiteEditor/fileview.cpp:601

_3rd party:_
    sqlite3.c:16982  'for(iBin=iLogsize; mem5.aiFreelist[iBin]<0 && iBin<=LOGMAX; iBin++)'  should check iBin<=LOGMAX first

-M