### PR TITLE
Fix generating __destruct() in new php classes

### DIFF
--- a/codelitephp/PHPParser/PHPSetterGetterEntry.cpp
+++ b/codelitephp/PHPParser/PHPSetterGetterEntry.cpp
@@ -35,7 +35,8 @@ wxString PHPSetterGetterEntry::GetGetter(size_t flags) const
     }
 
     wxString body;
-    body << "    /**\n"
+    body << "\n"
+         << "    /**\n"
          << "     * @return " << m_entry->Cast<PHPEntityVariable>()->GetTypeHint() << "\n"
          << "     */\n"
          << "    public function " << functionName << "() {\n"
@@ -61,7 +62,8 @@ wxString PHPSetterGetterEntry::GetSetter(const wxString& scope, size_t flags) co
     }
 
     wxString body;
-    body << "    /**\n"
+    body << "\n"
+         << "    /**\n"
          << "     * @param " << m_entry->Cast<PHPEntityVariable>()->GetTypeHint() << " " << m_entry->GetShortName()
          << "\n";
 
@@ -72,7 +74,8 @@ wxString PHPSetterGetterEntry::GetSetter(const wxString& scope, size_t flags) co
          << "    public function " << functionName << "(" << nameWithDollar << ") {\n"
          << "        $this->" << nameNoDollar << " = " << nameWithDollar << ";\n";
     if(flags & kSG_ReturnThis) {
-        body << "        return $this;\n";
+        body << "\n"
+             << "        return $this;\n";
     }
     body << "    }";
     return body;

--- a/codelitephp/PHPParser/PHPSetterGetterEntry.cpp
+++ b/codelitephp/PHPParser/PHPSetterGetterEntry.cpp
@@ -39,7 +39,8 @@ wxString PHPSetterGetterEntry::GetGetter(size_t flags) const
          << "    /**\n"
          << "     * @return " << m_entry->Cast<PHPEntityVariable>()->GetTypeHint() << "\n"
          << "     */\n"
-         << "    public function " << functionName << "() {\n"
+         << "    public function " << functionName << "()\n"
+         << "    {\n"
          << "        return $this->" << nameNoDollar << ";\n"
          << "    }";
     return body;
@@ -71,7 +72,8 @@ wxString PHPSetterGetterEntry::GetSetter(const wxString& scope, size_t flags) co
         body << "     * @return " << scope << "\n";
     }
     body << "     */\n"
-         << "    public function " << functionName << "(" << nameWithDollar << ") {\n"
+         << "    public function " << functionName << "(" << nameWithDollar << ")\n"
+         << "    {\n"
          << "        $this->" << nameNoDollar << " = " << nameWithDollar << ";\n";
     if(flags & kSG_ReturnThis) {
         body << "\n"

--- a/codelitephp/php-plugin/NewPHPClass.cpp
+++ b/codelitephp/php-plugin/NewPHPClass.cpp
@@ -119,8 +119,8 @@ wxString PHPClassDetails::ToString(const wxString& EOL, const wxString& indent) 
     classString << "{" << EOL;
 
     if(IsClass() && (GetFlags() & GEN_SINGLETON)) {
-        classString << indent << indent << "/** @var " << GetNamespace() << "\\" << GetName() << "*/" << EOL;
-        classString << indent << indent << "protected static $instance = null;" << EOL;
+        classString << indent << indent << "/** @var self */" << EOL;
+        classString << indent << indent << "protected static $instance;" << EOL;
     }
 
     if(IsClass() && (GetFlags() & GEN_CTOR)) {
@@ -144,21 +144,10 @@ wxString PHPClassDetails::ToString(const wxString& EOL, const wxString& indent) 
     }
 
     if(IsClass() && (GetFlags() & GEN_SINGLETON)) {
-        wxString returnType;
-        if(GetNamespace().IsEmpty()) {
-            returnType = GetName();
-        } else {
-            // user provided a namespace
-            returnType << GetNamespace() << "\\" << GetName();
-        }
-
-        // Remove duplicate backslahes
-        while(returnType.Replace("\\\\", "\\")) {
-        }
-        classString << indent << "/** @return " << returnType << " **/" << EOL;
+        classString << indent << "/** @return self **/" << EOL;
         classString << indent << "static public function getInstance() {" << EOL;
-        classString << indent << indent << "if (is_null(self::$instance)) {" << EOL;
-        classString << indent << indent << indent << "self::$instance = new " << GetName() << "();" << EOL;
+        classString << indent << indent << "if (null === self::$instance) {" << EOL;
+        classString << indent << indent << indent << "self::$instance = new self();" << EOL;
         classString << indent << indent << "}" << EOL;
         classString << indent << indent << "return self::$instance;" << EOL;
         classString << indent << "}" << EOL << EOL;

--- a/codelitephp/php-plugin/NewPHPClass.cpp
+++ b/codelitephp/php-plugin/NewPHPClass.cpp
@@ -123,7 +123,7 @@ wxString PHPClassDetails::ToString(const wxString& EOL, const wxString& indent) 
         classString << indent << indent << "protected static $instance;" << EOL;
     }
 
-    if(IsClass() && (GetFlags() & GEN_CTOR)) {
+    if(IsClass() && (GetFlags() & (GEN_CTOR | GEN_SINGLETON))) {
         if(GetFlags() & GEN_SINGLETON) {
             classString << indent << "protected function __construct() {" << EOL;
         } else {

--- a/codelitephp/php-plugin/NewPHPClass.cpp
+++ b/codelitephp/php-plugin/NewPHPClass.cpp
@@ -134,11 +134,10 @@ wxString PHPClassDetails::ToString(const wxString& EOL, const wxString& indent) 
     }
 
     if(IsClass() && (GetFlags() & GEN_DTOR)) {
-        if(GetFlags() & GEN_SINGLETON) {
-            classString << indent << "protected function __destruct() {" << EOL;
-        } else {
-            classString << indent << "public function __destruct() {" << EOL;
+        if (GetFlags() & (GEN_CTOR | GEN_SINGLETON)) {
+            classString << EOL;
         }
+        classString << indent << "public function __destruct()" << EOL;
         classString << indent << indent << EOL;
         classString << indent << "}" << EOL << EOL;
     }

--- a/codelitephp/php-plugin/NewPHPClass.cpp
+++ b/codelitephp/php-plugin/NewPHPClass.cpp
@@ -116,21 +116,27 @@ wxString PHPClassDetails::ToString(const wxString& EOL, const wxString& indent) 
         classString.RemoveLast(2).Append(" ");
     }
 
-    classString << "{" << EOL;
+    classString  << EOL << "{" << EOL;
 
     if(IsClass() && (GetFlags() & GEN_SINGLETON)) {
-        classString << indent << indent << "/** @var self */" << EOL;
-        classString << indent << indent << "protected static $instance;" << EOL;
+        classString << indent << "/** @var self */" << EOL;
+        classString << indent << "protected static $instance;" << EOL;
     }
 
     if(IsClass() && (GetFlags() & (GEN_CTOR | GEN_SINGLETON))) {
         if(GetFlags() & GEN_SINGLETON) {
-            classString << indent << "protected function __construct() {" << EOL;
-        } else {
-            classString << indent << "public function __construct() {" << EOL;
+            classString << EOL;
         }
-        classString << indent << indent << EOL;
-        classString << indent << "}" << EOL << EOL;
+        if(GetFlags() & GEN_SINGLETON) {
+            classString << indent << "protected function __construct()" << EOL;
+        } else {
+            classString << indent << "public function __construct()" << EOL;
+        }
+        classString << indent << "{" << EOL;
+        if(!(GetFlags() & GEN_SINGLETON)) {
+            classString << indent << indent << EOL;
+        }
+        classString << indent << "}" << EOL;
     }
 
     if(IsClass() && (GetFlags() & GEN_DTOR)) {
@@ -138,18 +144,24 @@ wxString PHPClassDetails::ToString(const wxString& EOL, const wxString& indent) 
             classString << EOL;
         }
         classString << indent << "public function __destruct()" << EOL;
+        classString << indent << "{" << EOL;
         classString << indent << indent << EOL;
-        classString << indent << "}" << EOL << EOL;
+        classString << indent << "}" << EOL;
     }
 
     if(IsClass() && (GetFlags() & GEN_SINGLETON)) {
-        classString << indent << "/** @return self **/" << EOL;
-        classString << indent << "static public function getInstance() {" << EOL;
-        classString << indent << indent << "if (null === self::$instance) {" << EOL;
+        classString << EOL;
+        classString << indent << "/**" << EOL;
+        classString << indent << " * @return self" << EOL;
+        classString << indent << " */" << EOL;
+        classString << indent << "static public function getInstance()" << EOL;
+        classString << indent << "{" << EOL;
+        classString << indent << indent << "if (!self::$instance) {" << EOL;
         classString << indent << indent << indent << "self::$instance = new self();" << EOL;
         classString << indent << indent << "}" << EOL;
+        classString << EOL;
         classString << indent << indent << "return self::$instance;" << EOL;
-        classString << indent << "}" << EOL << EOL;
+        classString << indent << "}" << EOL;
     }
     classString << "}" << EOL;
     return classString;

--- a/codelitephp/php-plugin/NewPHPClass.cpp
+++ b/codelitephp/php-plugin/NewPHPClass.cpp
@@ -117,12 +117,12 @@ wxString PHPClassDetails::ToString(const wxString& EOL, const wxString& indent) 
     }
 
     classString << "{" << EOL;
-    
+
     if(IsClass() && (GetFlags() & GEN_SINGLETON)) {
         classString << indent << indent << "/** @var " << GetNamespace() << "\\" << GetName() << "*/" << EOL;
         classString << indent << indent << "protected static $instance = null;" << EOL;
     }
-    
+
     if(IsClass() && (GetFlags() & GEN_CTOR)) {
         if(GetFlags() & GEN_SINGLETON) {
             classString << indent << "protected function __construct() {" << EOL;
@@ -132,14 +132,13 @@ wxString PHPClassDetails::ToString(const wxString& EOL, const wxString& indent) 
         classString << indent << indent << EOL;
         classString << indent << "}" << EOL << EOL;
     }
-    
+
     if(IsClass() && (GetFlags() & GEN_DTOR)) {
         if(GetFlags() & GEN_SINGLETON) {
             classString << indent << "protected function __destruct() {" << EOL;
         } else {
             classString << indent << "public function __destruct() {" << EOL;
         }
-        classString << indent << "public function __destruct() {" << EOL;
         classString << indent << indent << EOL;
         classString << indent << "}" << EOL << EOL;
     }

--- a/codelitephp/php-plugin/php_workspace_view.cpp
+++ b/codelitephp/php-plugin/php_workspace_view.cpp
@@ -337,7 +337,7 @@ void PHPWorkspaceView::OnMenu(wxTreeEvent& event)
                 menu.Append(XRCID("php_new_folder"), _("New Folder..."));
                 menu.Append(XRCID("php_new_file"), _("New File..."));
                 menu.AppendSeparator();
-                
+
                 menuItem = new wxMenuItem(NULL, XRCID("php_folder_find_in_files"), _("Find In Files"));
                 menuItem->SetBitmap(bmpFiF);
                 menu.Append(menuItem);
@@ -354,7 +354,7 @@ void PHPWorkspaceView::OnMenu(wxTreeEvent& event)
                 menu.Append(XRCID("php_run_project"), _("Run project..."));
                 menu.AppendSeparator();
                 menu.Append(XRCID("php_project_settings"), _("Project settings..."));
-                
+
                 // Let other plugins add content here
                 clContextMenuEvent folderMenuEvent(wxEVT_CONTEXT_MENU_FOLDER);
                 folderMenuEvent.SetMenu(&menu);
@@ -990,7 +990,7 @@ void PHPWorkspaceView::OnNewClass(wxCommandEvent& e)
 
         wxString fileContent;
         wxString eolString = EditorConfigST::Get()->GetOptions()->GetEOLAsString();
-        fileContent << "<?php" << eolString << pcd.ToString(eolString, " ");
+        fileContent << "<?php" << eolString << eolString << pcd.ToString(eolString, "    ");
 
         // Beautify the file
         clSourceFormatEvent event(wxEVT_FORMAT_STRING);


### PR DESCRIPTION
The function line was added twice:
```
protected function __destruct() {
public function __destruct() {
}
```
or
```
public function __destruct() {
public function __destruct() {
}
```