### PR TITLE
multiple cell selection in debug/watch

### DIFF
--- a/Interfaces/debugger.h
+++ b/Interfaces/debugger.h
@@ -441,7 +441,6 @@ public:
     bool charArrAsPtr;
     bool enableGDBPrettyPrinting;
     bool defaultHexDisplay;
-    
     size_t flags; // see eGdbFlags
 
 public:

--- a/LiteEditor.workspace
+++ b/LiteEditor.workspace
@@ -181,7 +181,7 @@
       <Project Name="codelite_vim" ConfigName="Win_x64_Debug"/>
       <Project Name="PHPRefactoring" ConfigName="Win_x64_Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="CMake_Debug" Selected="no">
+    <WorkspaceConfiguration Name="CMake_Debug" Selected="yes">
       <Environment/>
       <Project Name="ZoomNavigator" ConfigName="Win_x86_Release"/>
       <Project Name="wxsqlite3" ConfigName="Win_x86_Release"/>
@@ -346,7 +346,7 @@
       <Project Name="codelite_vim" ConfigName="Win_x64_Debug"/>
       <Project Name="PHPRefactoring" ConfigName="Win_x64_Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="Win_x64_Release" Selected="yes">
+    <WorkspaceConfiguration Name="Win_x64_Release" Selected="no">
       <Environment/>
       <Project Name="abbreviation" ConfigName="Win_x64_Release"/>
       <Project Name="AutoSave" ConfigName="Win_x64_Release"/>

--- a/LiteEditor/simpletable.cpp
+++ b/LiteEditor/simpletable.cpp
@@ -516,20 +516,7 @@ void WatchesTable::OnMenuDisplayFormat(wxCommandEvent& event)
             DoRefreshItem(dbgr, item, true);
         }       
     }
-#if 0
-    wxTreeItemId item = m_listTable->GetSelection();
-    IDebugger* dbgr = DoGetDebugger();
-    if(!dbgr || !item.IsOk()) {
-        return;
-    }
-
-    wxString gdbId = DoGetGdbId(item);
-    if(gdbId.IsEmpty() == false) {
-        dbgr->SetVariableObbjectDisplayFormat(gdbId, df);
-        dbgr->UpdateVariableObject(gdbId, m_DBG_USERR);
-        DoRefreshItem(dbgr, item, true);
-    }
-#endif 
+ 
 }
 
 void WatchesTable::OnUpdateVariableObject(const DebuggerEventData& event)

--- a/LiteEditor/simpletablebase.cpp
+++ b/LiteEditor/simpletablebase.cpp
@@ -137,7 +137,6 @@ void DebuggerTreeListCtrlBase::DoRefreshItemRecursively(IDebugger* dbgr,
             int where = itemsToRefresh.Index(data->_gdbId);
             if(where != wxNOT_FOUND) {
                 dbgr->EvaluateVariableObject(data->_gdbId, m_DBG_USERR);
-                dbgr->SetVariableObbjectDisplayFormat(data->_gdbId, DBG_DF_HEXADECIMAL);
                 m_gdbIdToTreeId[data->_gdbId] = exprItem;
                 itemsToRefresh.RemoveAt((size_t)where);
             }

--- a/Plugin/cProjectDependecySorter.cpp
+++ b/Plugin/cProjectDependecySorter.cpp
@@ -8,7 +8,7 @@ clProjectDependecySorter::clProjectDependecySorter() {}
 
 clProjectDependecySorter::~clProjectDependecySorter() {}
 
-void clProjectDependecySorter::Visit(clProjectDependecySorter::Node* node, wxArrayString& buildOrder) throw(clException)
+void clProjectDependecySorter::Visit(clProjectDependecySorter::Node* node, wxArrayString& buildOrder)
 {
     if(node->marker == kPerm) return;
     if(node->marker == kTemp) throw clException("Dependency loop found for node: " + node->name);
@@ -20,7 +20,7 @@ void clProjectDependecySorter::Visit(clProjectDependecySorter::Node* node, wxArr
 }
 
 void clProjectDependecySorter::GetProjectBuildOrder(const wxString& projectName, const wxString& configName,
-                                                    wxArrayString& buildOrder) throw(clException)
+                                                    wxArrayString& buildOrder)
 {
     Graph_t G;
     wxArrayString projects;
@@ -48,10 +48,11 @@ void clProjectDependecySorter::GetProjectBuildOrder(const wxString& projectName,
 
 clProjectDependecySorter::Node* clProjectDependecySorter::GetNodeCreateIfNeeded(Graph_t& G, const wxString& name)
 {
-    if(G.count(name) == 0) {
+    std::string key = name.mb_str(wxConvUTF8).data();
+    if(G.count(key) == 0) {
         clProjectDependecySorter::Node n;
-        n.name = name;
-        G[name] = n;
+        n.name = key;
+        G[key] = n;
     }
-    return &G[name];
+    return &G[key];
 }

--- a/Plugin/cProjectDependecySorter.h
+++ b/Plugin/cProjectDependecySorter.h
@@ -1,10 +1,10 @@
 #ifndef CPROJECTDEPENDECYSORTER_H
 #define CPROJECTDEPENDECYSORTER_H
 
-#include <vector>
 #include "codelite_exports.h"
 #include <wx/arrstr.h>
 #include <unordered_map>
+#include <vector>
 #include "cl_exception.h"
 
 class WXDLLIMPEXP_SDK clProjectDependecySorter
@@ -20,10 +20,10 @@ class WXDLLIMPEXP_SDK clProjectDependecySorter
         {
         }
     };
-    typedef std::unordered_map<wxString, clProjectDependecySorter::Node> Graph_t;
+    typedef std::unordered_map<std::string, clProjectDependecySorter::Node> Graph_t;
 
 protected:
-    void Visit(clProjectDependecySorter::Node* node, wxArrayString& buildOrder) throw(clException);
+    void Visit(clProjectDependecySorter::Node* node, wxArrayString& buildOrder);
     clProjectDependecySorter::Node* GetNodeCreateIfNeeded(Graph_t& G, const wxString& name);
 
 public:
@@ -37,7 +37,7 @@ public:
      * @return the build order. Throws clException in case of an error
      */
     void GetProjectBuildOrder(const wxString& projectName, const wxString& configName,
-                              wxArrayString& buildOrder) throw(clException);
+                              wxArrayString& buildOrder);
 };
 
 #endif // CPROJECTDEPENDECYSORTER_H

--- a/Plugin/cl_treelistctrl.h
+++ b/Plugin/cl_treelistctrl.h
@@ -167,7 +167,6 @@ public:
                const wxPoint& pos = wxDefaultPosition,
                const wxSize& size = wxDefaultSize,
                long style = wxTR_DEFAULT_STYLE,
-               //long style = wxTR_MULTIPLE,
                const wxValidator &validator = wxDefaultValidator,
                const wxString& name = clTreeListCtrlNameStr )
         : m_header_win(0), m_main_win(0), m_headerHeight(0)


### PR DESCRIPTION
Debugging micro-controller related projects requires to read watched variables in hex or bin format frequently. This pull request changed format changing in 'watches tab' to allow change of multiple cells once. Also added 'DefaultHexDisplay' checkbox in gdb settings -> display. 

Another recommendation is to autosave watch expressions, just like what is done with breakpoints.

Thanks.