### PR TITLE
[Mac] add missing libraries  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ endif()
 message("-- OS name ${OS_NAME}")
 
 if ( APPLE )
-  set(WX_COMPONENTS "std")
+  set(WX_COMPONENTS "std aui propgrid ribbon")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
 else ( APPLE )
   set(WX_COMPONENTS "std aui propgrid stc ribbon")

--- a/codelite_terminal/CMakeLists.txt
+++ b/codelite_terminal/CMakeLists.txt
@@ -8,7 +8,7 @@ project(codelite-terminal)
 if ( UNIX OR MINGW AND NOT APPLE )
     find_package(wxWidgets COMPONENTS std stc aui REQUIRED)
 else ( UNIX AND NOT APPLE )
-    find_package(wxWidgets REQUIRED)
+    find_package(wxWidgets COMPONENTS std stc REQUIRED)
 endif ( UNIX OR MINGW AND NOT APPLE )
 
 # we need wxWidgets flags to be set only for the c++ files, so we do it like this


### PR DESCRIPTION
https://github.com/eranif/codelite/issues/1284  is caused from lacking of some libraries required to link. And I encountered similar case of the following errors.
[bagreport-codelite-11.txt](https://github.com/eranif/codelite/files/1416004/bagreport-codelite-11.txt)
So please add required libraries. 