### PR TITLE
Fix Issue  #1847.

### DIFF
--- a/codelite_vim/vimCommands.cpp
+++ b/codelite_vim/vimCommands.cpp
@@ -345,6 +345,7 @@ bool VimCommand::Command_call()
         break;
     case COMMANDVI::_$:
         m_ctrl->LineEnd();
+        m_ctrl->CharLeft();
         this->m_saveCommand = false;
         break;
     case COMMANDVI::w:


### PR DESCRIPTION
Fix issue #1847:

In vim editor, if we press "$" in a line, the cursor will move to the last charactor. But in codelite with vim plugin enabled, it will move to the next position after the last charactor.



