### PR TITLE
Make overriding search string with selection optional?

### DIFF
--- a/LiteEditor/editor_options_docking_windows.wxcp
+++ b/LiteEditor/editor_options_docking_windows.wxcp
@@ -1,7 +1,7 @@
 {
 	"metadata":	{
 		"m_generatedFilesDir":	".",
-		"m_objCounter":	65,
+		"m_objCounter":	67,
 		"m_includeFiles":	[],
 		"m_bitmapFunction":	"wxCrafterKZwxilInitBitmapResources",
 		"m_bitmapsFile":	"editor_options_docking_windows_liteeditor_bitmaps.cpp",
@@ -2123,6 +2123,81 @@
 															"type":	"string",
 															"m_label":	"Label:",
 															"m_value":	"Don't automatically fold Search results"
+														}, {
+															"type":	"bool",
+															"m_label":	"Value:",
+															"m_value":	false
+														}],
+													"m_events":	[],
+													"m_children":	[]
+												}, {
+													"m_type":	4415,
+													"proportion":	0,
+													"border":	5,
+													"gbSpan":	",",
+													"gbPosition":	",",
+													"m_styles":	[],
+													"m_sizerFlags":	["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
+													"m_properties":	[{
+															"type":	"winid",
+															"m_label":	"ID:",
+															"m_winid":	"wxID_ANY"
+														}, {
+															"type":	"string",
+															"m_label":	"Size:",
+															"m_value":	""
+														}, {
+															"type":	"string",
+															"m_label":	"Minimum Size:",
+															"m_value":	""
+														}, {
+															"type":	"string",
+															"m_label":	"Name:",
+															"m_value":	"m_checkBoxDontOverrideSearchStringWithSelection"
+														}, {
+															"type":	"multi-string",
+															"m_label":	"Tooltip:",
+															"m_value":	"By default, the search string is overridden by the current text selection in the editor when doing a find next/previous. Tick this box to prevent this"
+														}, {
+															"type":	"colour",
+															"m_label":	"Bg Colour:",
+															"colour":	"<Default>"
+														}, {
+															"type":	"colour",
+															"m_label":	"Fg Colour:",
+															"colour":	"<Default>"
+														}, {
+															"type":	"font",
+															"m_label":	"Font:",
+															"m_value":	""
+														}, {
+															"type":	"bool",
+															"m_label":	"Hidden",
+															"m_value":	false
+														}, {
+															"type":	"bool",
+															"m_label":	"Disabled",
+															"m_value":	false
+														}, {
+															"type":	"bool",
+															"m_label":	"Focused",
+															"m_value":	false
+														}, {
+															"type":	"string",
+															"m_label":	"Class Name:",
+															"m_value":	""
+														}, {
+															"type":	"string",
+															"m_label":	"Include File:",
+															"m_value":	""
+														}, {
+															"type":	"string",
+															"m_label":	"Style:",
+															"m_value":	""
+														}, {
+															"type":	"string",
+															"m_label":	"Label:",
+															"m_value":	"Don't override search string with current selection on find next/previous"
 														}, {
 															"type":	"bool",
 															"m_label":	"Value:",

--- a/LiteEditor/editorsettingsdockingwidows.cpp
+++ b/LiteEditor/editorsettingsdockingwidows.cpp
@@ -51,6 +51,7 @@ EditorSettingsDockingWindows::EditorSettingsDockingWindows(wxWindow* parent)
     m_checkBoxHideOutputPaneNotIfMemCheck->SetValue(options->GetHideOutputPaneNotIfMemCheck());
     m_checkBoxFindBarAtBottom->SetValue(options->GetFindBarAtBottom());
     m_checkBoxDontFoldSearchResults->SetValue(options->GetDontAutoFoldResults());
+    m_checkBoxDontOverrideSearchStringWithSelection->SetValue(options->GetDontOverrideSearchStringWithSelection());
     m_checkBoxShowDebugOnRun->SetValue(options->GetShowDebugOnRun());
     m_radioBoxHint->SetSelection(options->GetDockingStyle());
     m_checkBoxHideCaptions->SetValue(!options->IsShowDockingWindowCaption());
@@ -174,6 +175,7 @@ void EditorSettingsDockingWindows::Save(OptionsConfigPtr options)
     options->SetHideOutputPaneNotIfMemCheck(m_checkBoxHideOutputPaneNotIfMemCheck->IsChecked());
     options->SetFindBarAtBottom(m_checkBoxFindBarAtBottom->IsChecked());
     options->SetDontAutoFoldResults(m_checkBoxDontFoldSearchResults->IsChecked());
+    options->SetDontOverrideSearchStringWithSelection(m_checkBoxDontOverrideSearchStringWithSelection->IsChecked());
     options->SetShowDebugOnRun(m_checkBoxShowDebugOnRun->IsChecked());
     options->SetDockingStyle(m_radioBoxHint->GetSelection());
     options->SetShowDockingWindowCaption(!m_checkBoxHideCaptions->IsChecked());

--- a/LiteEditor/editorsettingsdockingwindowsbase.cpp
+++ b/LiteEditor/editorsettingsdockingwindowsbase.cpp
@@ -182,6 +182,12 @@ EditorSettingsDockingWindowsBase::EditorSettingsDockingWindowsBase(wxWindow* par
     
     boxSizer20->Add(m_checkBoxDontFoldSearchResults, 0, wxALL, WXC_FROM_DIP(5));
     
+    m_checkBoxDontOverrideSearchStringWithSelection = new wxCheckBox(m_panel14, wxID_ANY, _("Don't override search string with current selection on find next/previous"), wxDefaultPosition, wxDLG_UNIT(m_panel14, wxSize(-1, -1)), 0);
+    m_checkBoxDontOverrideSearchStringWithSelection->SetValue(false);
+    m_checkBoxDontOverrideSearchStringWithSelection->SetToolTip(_("By default, the search string is overridden by the current text selection in the editor when doing a find next/previous. Tick this box to prevent this"));
+    
+    boxSizer20->Add(m_checkBoxDontOverrideSearchStringWithSelection, 0, wxALL, WXC_FROM_DIP(5));
+    
     m_panel16 = new wxPanel(m_notebook10, wxID_ANY, wxDefaultPosition, wxDLG_UNIT(m_notebook10, wxSize(-1,-1)), wxTAB_TRAVERSAL);
     m_notebook10->AddPage(m_panel16, _("Debug / Output panes"), false);
     

--- a/LiteEditor/editorsettingsdockingwindowsbase.h
+++ b/LiteEditor/editorsettingsdockingwindowsbase.h
@@ -66,6 +66,7 @@ protected:
     wxPanel* m_panel14;
     wxCheckBox* m_checkBoxFindBarAtBottom;
     wxCheckBox* m_checkBoxDontFoldSearchResults;
+    wxCheckBox* m_checkBoxDontOverrideSearchStringWithSelection;
     wxPanel* m_panel16;
     wxCheckBox* m_checkBoxHideOutputPaneOnClick;
     wxCheckBox* m_checkBoxHideOutputPaneNotIfBuild;
@@ -111,6 +112,7 @@ public:
     wxPanel* GetPanel12() { return m_panel12; }
     wxCheckBox* GetCheckBoxFindBarAtBottom() { return m_checkBoxFindBarAtBottom; }
     wxCheckBox* GetCheckBoxDontFoldSearchResults() { return m_checkBoxDontFoldSearchResults; }
+    wxCheckBox* GetCheckBoxDontOverrideSearchStringWithSelection() { return m_checkBoxDontOverrideSearchStringWithSelection; }
     wxPanel* GetPanel14() { return m_panel14; }
     wxCheckBox* GetCheckBoxHideOutputPaneOnClick() { return m_checkBoxHideOutputPaneOnClick; }
     wxCheckBox* GetCheckBoxHideOutputPaneNotIfBuild() { return m_checkBoxHideOutputPaneNotIfBuild; }

--- a/LiteEditor/quickfindbar.cpp
+++ b/LiteEditor/quickfindbar.cpp
@@ -756,14 +756,16 @@ void QuickFindBar::OnFindNext(wxCommandEvent& e)
 {
     CHECK_FOCUS_WIN();
 
-    // Highlighted text takes precedence over the current search string
-    //    if(!IsShown()) {
-    wxString selectedText = DoGetSelectedText();
-    if(selectedText.IsEmpty() == false) {
-        m_findWhat->ChangeValue(selectedText);
-        m_findWhat->SelectAll();
-    }
-    //    }
+    if (!EditorConfigST::Get()->GetOptions()->GetDontOverrideSearchStringWithSelection()) {
+        // Highlighted text takes precedence over the current search string
+        //    if(!IsShown()) {
+        wxString selectedText = DoGetSelectedText();
+        if(selectedText.IsEmpty() == false) {
+            m_findWhat->ChangeValue(selectedText);
+            m_findWhat->SelectAll();
+        }
+        //    }
+   }
 
     DoSearch(kSearchForward);
 }
@@ -772,14 +774,16 @@ void QuickFindBar::OnFindPrevious(wxCommandEvent& e)
 {
     CHECK_FOCUS_WIN();
 
-    // Highlighted text takes precedence over the current search string
-    //    if(!IsShown()) {
-    wxString selectedText = DoGetSelectedText();
-    if(selectedText.IsEmpty() == false) {
-        m_findWhat->ChangeValue(selectedText);
-        m_findWhat->SelectAll();
+    if (!EditorConfigST::Get()->GetOptions()->GetDontOverrideSearchStringWithSelection()) {
+        // Highlighted text takes precedence over the current search string
+        //    if(!IsShown()) {
+        wxString selectedText = DoGetSelectedText();
+        if(selectedText.IsEmpty() == false) {
+            m_findWhat->ChangeValue(selectedText);
+            m_findWhat->SelectAll();
+        }
+        //    }
     }
-    //    }
 
     DoSearch(0);
 }

--- a/Plugin/optionsconfig.cpp
+++ b/Plugin/optionsconfig.cpp
@@ -112,6 +112,7 @@ OptionsConfig::OptionsConfig(wxXmlNode* node)
     , m_disableSemicolonShift(false)
     , m_caretLineAlpha(30)
     , m_dontAutoFoldResults(true)
+    , m_dontOverrideSearchStringWithSelection(false)
     , m_showDebugOnRun(true)
     , m_caretUseCamelCase(true)
     , m_wordWrap(false)
@@ -200,6 +201,7 @@ OptionsConfig::OptionsConfig(wxXmlNode* node)
         m_disableSemicolonShift = XmlUtils::ReadBool(node, wxT("DisableSemicolonShift"), m_disableSemicolonShift);
         m_caretLineAlpha = XmlUtils::ReadLong(node, wxT("CaretLineAlpha"), m_caretLineAlpha);
         m_dontAutoFoldResults = XmlUtils::ReadBool(node, wxT("DontAutoFoldResults"), m_dontAutoFoldResults);
+        m_dontOverrideSearchStringWithSelection = XmlUtils::ReadBool(node, wxT("DontOverrideSearchStringWithSelection"), m_dontOverrideSearchStringWithSelection);
         m_showDebugOnRun = XmlUtils::ReadBool(node, wxT("ShowDebugOnRun"), m_showDebugOnRun);
         m_caretUseCamelCase = XmlUtils::ReadBool(node, wxT("m_caretUseCamelCase"), m_caretUseCamelCase);
         m_wordWrap = XmlUtils::ReadBool(node, wxT("m_wordWrap"), m_wordWrap);
@@ -300,6 +302,7 @@ wxXmlNode* OptionsConfig::ToXml() const
     n->AddProperty(wxT("DisableSmartIndent"), BoolToString(m_disableSmartIndent));
     n->AddProperty(wxT("DisableSemicolonShift"), BoolToString(m_disableSemicolonShift));
     n->AddProperty(wxT("DontAutoFoldResults"), BoolToString(m_dontAutoFoldResults));
+    n->AddProperty(wxT("DontOverrideSearchStringWithSelection"), BoolToString(m_dontOverrideSearchStringWithSelection));
     n->AddProperty(wxT("ShowDebugOnRun"), BoolToString(m_showDebugOnRun));
     n->AddProperty(wxT("ConsoleCommand"), m_programConsoleCommand);
     n->AddProperty(wxT("EOLMode"), m_eolMode);

--- a/Plugin/optionsconfig.h
+++ b/Plugin/optionsconfig.h
@@ -135,6 +135,7 @@ protected:
     bool m_disableSemicolonShift;
     int m_caretLineAlpha;
     bool m_dontAutoFoldResults;
+    bool m_dontOverrideSearchStringWithSelection;
     bool m_showDebugOnRun;
     bool m_caretUseCamelCase;
     bool m_dontTrimCaretLine;
@@ -151,7 +152,7 @@ protected:
     wxDirection m_outputTabsDirection;    // Up/Down
     bool m_indentedComments;
     int m_nbTabHeight; // Should notebook tabs be too tall, too short or...
-    
+
 public:
     // Helpers
     void EnableOption(size_t flag, bool b)
@@ -219,6 +220,8 @@ public:
     bool GetCaretUseCamelCase() const { return m_caretUseCamelCase; }
     void SetDontAutoFoldResults(bool dontAutoFoldResults) { this->m_dontAutoFoldResults = dontAutoFoldResults; }
     bool GetDontAutoFoldResults() const { return m_dontAutoFoldResults; }
+    void SetDontOverrideSearchStringWithSelection(bool dontOverrideSearchStringWithSelection) { m_dontOverrideSearchStringWithSelection = dontOverrideSearchStringWithSelection; }
+    bool GetDontOverrideSearchStringWithSelection() const { return m_dontOverrideSearchStringWithSelection; }
     void SetShowDebugOnRun(bool showDebugOnRun) { this->m_showDebugOnRun = showDebugOnRun; }
     bool GetShowDebugOnRun() const { return m_showDebugOnRun; }
     bool GetDisableSemicolonShift() const { return m_disableSemicolonShift; }


### PR DESCRIPTION
Hi

I always comment out the code in QuickFindBar::OnFindNext/OnFindPrevious that overwrites the search string with any selection in the editor, so thought I'd tidy it up and and a settings option.

Personally I find if I'm refactoring the old fashioned way, overwriting the search string is the last thing I want. E.g. I'll do something like:

1. Ctrl-F and search for a string

1. Manually edit the found match, which may include highlighting some text to delete/alter it somehow

1. Hit F3 to find the next match of the original string ... except the search string has changed :(

Anyway here's my mod if it's any use.

Thanks!

Luke.