### PR TITLE
Remember SpellCheck continuous option?

### DIFF
--- a/SpellChecker/spellcheck.cpp
+++ b/SpellChecker/spellcheck.cpp
@@ -104,7 +104,11 @@ SpellCheck::~SpellCheck()
     m_timer.Disconnect(wxEVT_TIMER, wxTimerEventHandler(SpellCheck::OnTimer), NULL, this);
     m_topWin->Disconnect(wxEVT_CMD_EDITOR_CONTEXT_MENU, wxCommandEventHandler(SpellCheck::OnContextMenu), NULL, this);
     m_topWin->Disconnect(wxEVT_WORKSPACE_CLOSED, wxCommandEventHandler(SpellCheck::OnWspClosed), NULL, this);
-    if(m_pEngine != NULL) wxDELETE(m_pEngine);
+
+    if(m_pEngine != NULL) {
+        SaveSettings();
+        wxDELETE(m_pEngine);
+    }
 }
 
 // ------------------------------------------------------------
@@ -117,7 +121,6 @@ void SpellCheck::Init()
     m_sepItem = NULL;
     m_pToolbar = NULL;
     m_topWin = wxTheApp;
-    m_checkContinuous = false;
     m_pEngine = new IHunSpell();
     m_currentWspPath = wxEmptyString;
 
@@ -167,6 +170,9 @@ clToolBar* SpellCheck::CreateToolBar(wxWindow* parent)
                     wxCommandEventHandler(SpellCheck::OnContinousCheck),
                     NULL,
                     this);
+
+    SetCheckContinuous(GetCheckContinuous());
+
     return m_pToolbar;
 }
 // ------------------------------------------------------------
@@ -223,8 +229,6 @@ IEditor* SpellCheck::GetEditor()
     IEditor* editor = m_mgr->GetActiveEditor();
 
     if(!editor) {
-        if(GetCheckContinuous()) // switch continuous search off if running
-            SetCheckContinuous(false);
         ::wxMessageBox(s_noEditor, s_codeLite, wxICON_WARNING | wxOK);
         return NULL;
     }
@@ -278,14 +282,14 @@ void SpellCheck::OnCheck(wxCommandEvent& e)
             if(m_mgr->IsWorkspaceOpen()) {
                 m_pEngine->CheckCppSpelling(text);
 
-                if(!m_checkContinuous) {
+                if(!GetCheckContinuous()) {
                     editor->ClearUserIndicators();
                 }
             }
         } break;
         case 1: { // wxSCI_LEX_NULL
             m_pEngine->CheckSpelling(text);
-            if(!m_checkContinuous) {
+            if(!GetCheckContinuous()) {
                 editor->ClearUserIndicators();
             }
         } break;
@@ -319,14 +323,6 @@ void SpellCheck::SaveSettings()
 // ------------------------------------------------------------
 void SpellCheck::OnContinousCheck(wxCommandEvent& e)
 {
-    IEditor* editor = m_mgr->GetActiveEditor();
-
-    if(!editor) { // no current editor, switch continuous search off
-
-        SetCheckContinuous(false);
-        return;
-    }
-
     if(m_pEngine != NULL) {
         if(e.GetInt() == 0) {
             SetCheckContinuous(false);
@@ -335,7 +331,6 @@ void SpellCheck::OnContinousCheck(wxCommandEvent& e)
         }
 
         SetCheckContinuous(true);
-        wxString text = editor->GetEditorText();
 
         // if we don't have a dictionary yet, open settings
         if(!m_pEngine->GetDictionary()) {
@@ -343,17 +338,23 @@ void SpellCheck::OnContinousCheck(wxCommandEvent& e)
             return;
         }
 
-        switch(editor->GetLexerId()) {
-        case 3: { // wxSCI_LEX_CPP
-            if(m_mgr->IsWorkspaceOpen()) {
-                m_pEngine->CheckCppSpelling(text);
+        IEditor* editor = m_mgr->GetActiveEditor();
+
+        if (editor) {
+            wxString text = editor->GetEditorText();
+
+            switch(editor->GetLexerId()) {
+            case 3: { // wxSCI_LEX_CPP
+                if(m_mgr->IsWorkspaceOpen()) {
+                    m_pEngine->CheckCppSpelling(text);
+                }
+            } break;
+            default: { // wxSCI_LEX_NULL
+                m_pEngine->CheckSpelling(text);
+            } break;
             }
-        } break;
-        default: { // wxSCI_LEX_NULL
-            m_pEngine->CheckSpelling(text);
-        } break;
+            m_timer.Start(PARSE_TIME);
         }
-        m_timer.Start(PARSE_TIME);
     }
 }
 // ------------------------------------------------------------
@@ -435,7 +436,7 @@ void SpellCheck::OnContextMenu(wxCommandEvent& e)
 // ------------------------------------------------------------
 void SpellCheck::SetCheckContinuous(bool value)
 {
-    m_checkContinuous = value;
+    m_options.SetCheckContinuous(value);
 
     if(value) {
         m_timer.Start(PARSE_TIME);
@@ -472,7 +473,7 @@ void SpellCheck::OnEditorContextMenuShowing(clContextMenuEvent& e)
 {
     e.Skip();
     wxMenu* menu = CreateSubMenu();
-    menu->Check(XRCID(s_contCheckID.ToUTF8()), m_checkContinuous);
+    menu->Check(XRCID(s_contCheckID.ToUTF8()), GetCheckContinuous());
     e.GetMenu()->Append(IDM_BASE, _("Spell Checker"), menu);
 }
 

--- a/SpellChecker/spellcheck.h
+++ b/SpellChecker/spellcheck.h
@@ -48,7 +48,7 @@ public:
     wxString GetCurrentWspPath() const { return m_currentWspPath; }
 
     void SetCheckContinuous(bool value);
-    bool GetCheckContinuous() const { return m_checkContinuous; }
+    bool GetCheckContinuous() const { return m_options.GetCheckContinuous(); }
     bool IsTag(const wxString& token);
     IEditor* GetEditor();
     wxMenu* CreateSubMenu();
@@ -87,7 +87,6 @@ protected:
     void ClearIndicatorsFromEditors();
 
 protected:
-    bool m_checkContinuous;
     IHunSpell* m_pEngine;
     wxTimer m_timer;
     wxString m_currentWspPath;

--- a/SpellChecker/spellcheckeroptions.cpp
+++ b/SpellChecker/spellcheckeroptions.cpp
@@ -44,7 +44,8 @@ SpellCheckerOptions::SpellCheckerOptions()
     m_scanC   = false;
     m_scanD1  = false;
     m_scanD2  = false;
-    
+    m_checkContinuous = false;
+
     wxString defaultDicsDir;
     defaultDicsDir << clStandardPaths::Get().GetDataDir() << wxFILE_SEP_PATH << "dics";
     m_dictionaryPath = defaultDicsDir;
@@ -65,6 +66,7 @@ void SpellCheckerOptions::DeSerialize( Archive& arch )
     arch.Read( wxT( "m_scanC" ), m_scanC );
     arch.Read( wxT( "m_scanD1" ), m_scanD1 );
     arch.Read( wxT( "m_scanD2" ), m_scanD2 );
+    arch.Read( wxT( "m_checkContinuous" ), m_checkContinuous );
 }
 
 // ------------------------------------------------------------
@@ -77,5 +79,6 @@ void SpellCheckerOptions::Serialize( Archive& arch )
     arch.Write( wxT( "m_scanC" ), m_scanC );
     arch.Write( wxT( "m_scanD1" ), m_scanD1 );
     arch.Write( wxT( "m_scanD2" ), m_scanD2 );
+    arch.Write( wxT( "m_checkContinuous" ), m_checkContinuous );
 }
 // ------------------------------------------------------------

--- a/SpellChecker/spellcheckeroptions.h
+++ b/SpellChecker/spellcheckeroptions.h
@@ -54,6 +54,7 @@ public:
 	void            SetScanD1( const bool& scanD1 ) { this->m_scanD1 = scanD1; }
 	void            SetScanD2( const bool& scanD2 ) { this->m_scanD2 = scanD2; }
 	void            SetScanStr( const bool& scanStr ) { this->m_scanStr = scanStr; }
+    void            SetCheckContinuous( const bool& checkContinuous ) { this->m_checkContinuous = checkContinuous; }
 	bool            GetScanC() const { return m_scanC; }
 	bool            GetScanCPP() const { return m_scanCPP; }
 	bool            GetScanD1() const { return m_scanD1; }
@@ -61,6 +62,7 @@ public:
 	bool            GetScanStr() const { return m_scanStr; }
 	const wxString& GetDictionaryPath() const { return m_dictionaryPath; }
 	const wxString& GetDictionaryFileName() const { return m_dictionary; }
+    bool            GetCheckContinuous() const { return m_checkContinuous; }
 
 protected:
 	wxString m_dictionary;
@@ -70,6 +72,7 @@ protected:
 	bool     m_scanC;
 	bool     m_scanD1;
 	bool     m_scanD2;
+    bool     m_checkContinuous;
 };
 //------------------------------------------------------------
 #endif // __spellcheckeroptions__


### PR DESCRIPTION
Hi

I find the SpellCheck continuous option far more useful that the dialog, given there will be a lot of false negatives. Much easier to have the potential misspellings just marked in the editor as I can just ignore the ones I know are correct.

Problem is, the setting isn't persisted and tends to turn itself off when there's no editor, so this mod changes that behaviour. It still turns off the setting when the dialog is opened though.

Any use?

Thanks

Luke.