### PR TITLE
Goto next function doesn't work if caret is before the first function in a file

### DIFF
--- a/CodeLite/ctags_manager.cpp
+++ b/CodeLite/ctags_manager.cpp
@@ -1769,7 +1769,7 @@ TagEntryPtr TagsManager::FunctionFromFileLine(const wxFileName& fileName, int li
             }
         }
     }
-    return NULL;
+    return foo;
 }
 
 void TagsManager::GetScopesFromFile(const wxFileName& fileName, std::vector<wxString>& scopes)


### PR DESCRIPTION
Simple fix!

Regards

Luke.
