### PR TITLE
spellcheck: reduce continuous spell checking

### DIFF
--- a/Interfaces/ieditor.h
+++ b/Interfaces/ieditor.h
@@ -96,6 +96,11 @@ public:
     virtual bool IsModified() = 0;
 
     /**
+	 * @brief Get the editor's modification count
+	 */
+    virtual wxUint64 GetModificationCount() const = 0;
+
+    /**
      * \brief return the current editor content
      */
     virtual wxString GetEditorText() = 0;
@@ -135,7 +140,7 @@ public:
      * to the  current file
      */
     virtual void OpenFile() = 0;
-    
+
     /**
      * @brief reload file content from the disk
      * @param keepUndoHistory
@@ -145,12 +150,12 @@ public:
      * @brief save the editor
      */
     virtual bool Save() = 0;
-    
+
     /**
      * @brief save the current editor with a different name
      */
     virtual bool SaveAs(const wxString& defaultName = wxEmptyString, const wxString& savePath = wxEmptyString) = 0;
-    
+
     /**
      * \brief return the current position of the caret
      */
@@ -499,17 +504,17 @@ public:
      * @brief return a string representing all the local variables coloured by this editor
      */
     virtual const wxString& GetKeywordLocals() const = 0;
-    
+
     /**
      * @brief get the options associated with this editor
      */
     virtual OptionsConfigPtr GetOptions() = 0;
-    
+
     /**
      * @brief apply editor configuration (TAB vs SPACES, tab size, EOL mode etc)
      */
     virtual void ApplyEditorConfig() = 0;
-    
+
     /**
      * @brief return list of bookmarks for a given editor
      * @param editor the editor

--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -318,6 +318,7 @@ LEditor::LEditor(wxWindow* parent)
     , m_popupIsOn(false)
     , m_isDragging(false)
     , m_modifyTime(0)
+    , m_modificationCount(0)
     , m_isVisible(true)
     , m_hyperLinkIndicatroStart(wxNOT_FOUND)
     , m_hyperLinkIndicatroEnd(wxNOT_FOUND)
@@ -512,7 +513,7 @@ void LEditor::SetProperties()
 #else
     UsePopUp(0);
 #endif
-    
+
     SetRectangularSelectionModifier(wxSTC_KEYMOD_CTRL);
     SetAdditionalSelectionTyping(true);
     OptionsConfigPtr options = GetOptions();
@@ -4175,6 +4176,8 @@ void LEditor::SetEOL()
 void LEditor::OnChange(wxStyledTextEvent& event)
 {
     event.Skip();
+    ++m_modificationCount;
+
     bool isCoalesceStart = event.GetModificationType() & wxSTC_STARTACTION;
     bool isInsert = event.GetModificationType() & wxSTC_MOD_INSERTTEXT;
     bool isDelete = event.GetModificationType() & wxSTC_MOD_DELETETEXT;

--- a/LiteEditor/cl_editor.h
+++ b/LiteEditor/cl_editor.h
@@ -218,6 +218,7 @@ protected:
     bool m_popupIsOn;
     bool m_isDragging;
     time_t m_modifyTime;
+    wxUint64 m_modificationCount;
     std::map<int, wxString> m_customCmds;
     bool m_isVisible;
     int m_hyperLinkIndicatroStart;
@@ -747,6 +748,11 @@ public:
      */
     time_t GetEditorLastModifiedTime() const { return m_modifyTime; }
     void SetEditorLastModifiedTime(time_t modificationTime) { m_modifyTime = modificationTime; }
+
+    /**
+	 * @brief Get the editor's modification count
+	 */
+    virtual wxUint64 GetModificationCount() const { return m_modificationCount; }
 
     /**
      * \brief run through the file content and update colours for the

--- a/SpellChecker/spellcheck.cpp
+++ b/SpellChecker/spellcheck.cpp
@@ -83,6 +83,7 @@ CL_PLUGIN_API int GetPluginInterfaceVersion() { return PLUGIN_INTERFACE_VERSION;
 // ------------------------------------------------------------
 SpellCheck::SpellCheck(IManager* manager)
     : IPlugin(manager)
+    , m_pLastEditor(nullptr)
 {
     Init();
 }
@@ -237,6 +238,8 @@ IEditor* SpellCheck::GetEditor()
 // ------------------------------------------------------------
 void SpellCheck::OnSettings(wxCommandEvent& e)
 {
+    m_pLastEditor = nullptr;
+
     SpellCheckerSettings dlg(m_mgr->GetTheApp()->GetTopWindow());
     dlg.SetHunspell(m_pEngine);
     dlg.SetScanStrings(m_pEngine->IsScannerType(IHunSpell::kString));
@@ -369,6 +372,14 @@ void SpellCheck::OnTimer(wxTimerEvent& e)
     if(!editor) return;
 
     if(GetCheckContinuous()) {
+        // Only run the checks if we've not run them or the file is modified.
+        const auto modificationCount(editor->GetModificationCount());
+        if ((editor == m_pLastEditor) && (m_lastModificationCount == modificationCount))
+            return;
+
+        m_pLastEditor = editor;
+        m_lastModificationCount = modificationCount;
+
         switch(editor->GetLexerId()) {
         case 3: { // wxSCI_LEX_CPP
             if(m_mgr->IsWorkspaceOpen()) {
@@ -384,6 +395,8 @@ void SpellCheck::OnTimer(wxTimerEvent& e)
 // ------------------------------------------------------------
 void SpellCheck::OnContextMenu(wxCommandEvent& e)
 {
+    m_pLastEditor = nullptr;
+
     IEditor* editor = GetEditor();
 
     if(!editor) {
@@ -439,7 +452,9 @@ void SpellCheck::SetCheckContinuous(bool value)
     m_options.SetCheckContinuous(value);
 
     if(value) {
+        m_pLastEditor = nullptr;
         m_timer.Start(PARSE_TIME);
+
         if(m_pToolbar) {
             m_pToolbar->ToggleTool(XRCID(s_contCheckID.ToUTF8()), true);
             m_pToolbar->Refresh();

--- a/SpellChecker/spellcheck.h
+++ b/SpellChecker/spellcheck.h
@@ -91,6 +91,9 @@ protected:
     wxTimer m_timer;
     wxString m_currentWspPath;
     wxAuiToolBar* m_pToolbar;
+
+    IEditor* m_pLastEditor;             // The editor checked last time the spell check ran.
+    wxUint64 m_lastModificationCount;   // Modification count of the editor last time the spell check ran.
 };
 //------------------------------------------------------------
 #endif // SpellCheck


### PR DESCRIPTION
Hi 

The continuous spell check option can burn CPU time when it doesn't really need to, and then I made it worse with #1928 :blush: which I see you've merged (thanks!).

So I've had a go at reducing that CPU usage. There are two versions here: the first one simply doesn't run the check if the editor doesn't report IsModified() == true since the last time it ran. Very simple but obviously still wastes CPU time if the file stays unsaved but not further modified.

The second commit hooks in to wxEVT_STC_MODIFIED to store the time an actual modification was made, and only runs the spell checker if it hasn't run since the last modification.

I'm no GUI programmer let alone wxwidgets so I'm not sure if that's the best/only option; maybe there's a better way?

Thanks!

Luke.