### PR TITLE
Optional copying entire line with empty selection?

### DIFF
--- a/LiteEditor/EditorOptionsGeneralEdit.cpp
+++ b/LiteEditor/EditorOptionsGeneralEdit.cpp
@@ -11,6 +11,7 @@ EditorOptionsGeneralEdit::EditorOptionsGeneralEdit(wxWindow* parent)
     m_pgPropSmartCurly->SetValue(options->GetAutoAddMatchedCurlyBraces());
     m_pgPropSmartParentheses->SetValue(options->GetAutoAddMatchedNormalBraces());
     m_pgPropSmartQuotes->SetValue(options->GetAutoCompleteDoubleQuotes());
+    m_pgPropCopyLineEmptySelection->SetValue(options->GetCopyLineEmptySelection());
     m_pgPropWrapBrackets->SetValue(options->IsWrapSelectionBrackets());
     m_pgPropWrapQuotes->SetValue(options->IsWrapSelectionWithQuotes());
     m_pgPropZoomUsingCtrlScroll->SetValue(options->IsMouseZoomEnabled());
@@ -31,6 +32,7 @@ void EditorOptionsGeneralEdit::Save(OptionsConfigPtr options)
     options->SetAutoAddMatchedCurlyBraces(m_pgPropSmartCurly->GetValue().GetBool());
     options->SetAutoAddMatchedNormalBraces(m_pgPropSmartParentheses->GetValue().GetBool());
     options->SetAutoCompleteDoubleQuotes(m_pgPropSmartQuotes->GetValue().GetBool());
+    options->SetCopyLineEmptySelection(m_pgPropCopyLineEmptySelection->GetValue().GetBool());
     options->SetWrapSelectionBrackets(m_pgPropWrapBrackets->GetValue().GetBool());
     options->SetWrapSelectionWithQuotes(m_pgPropWrapQuotes->GetValue().GetBool());
     options->SetMouseZoomEnabled(m_pgPropZoomUsingCtrlScroll->GetValue().GetBool());

--- a/LiteEditor/editor_options_guides.wxcp
+++ b/LiteEditor/editor_options_guides.wxcp
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "m_generatedFilesDir": ".",
-  "m_objCounter": 60,
+  "m_objCounter": 62,
   "m_includeFiles": [],
   "m_bitmapFunction": "wxC77E7InitBitmapResources",
   "m_bitmapsFile": "editor_options_guides_liteeditor_bitmaps.cpp",
@@ -1698,6 +1698,71 @@
             }],
            "m_events": [],
            "m_children": []
+		}, {
+			"m_type":	4486,
+			"proportion":	0,
+			"border":	5,
+			"gbSpan":	"1,1",
+			"gbPosition":	"0,0",
+			"m_styles":	[],
+			"m_sizerFlags":	[],
+			"m_properties":	[{
+					"type":	"string",
+					"m_label":	"Name:",
+					"m_value":	"m_pgPropCopyLineEmptySelection"
+				}, {
+					"type":	"string",
+					"m_label":	"Label:",
+					"m_value":	"Copying empty selection copies caret line"
+				}, {
+					"type":	"multi-string",
+					"m_label":	"Tooltip:",
+					"m_value":	"Whether copying an empty selection to the clipboard copies the entire contents of the caret line, or nothing"
+				}, {
+					"type":	"colour",
+					"m_label":	"Bg Colour:",
+					"colour":	"<Default>"
+				}, {
+					"type":	"choice",
+					"m_label":	"Property Editor Control",
+					"m_selection":	0,
+					"m_options":	["", "TextCtrl", "Choice", "ComboBox", "CheckBox", "TextCtrlAndButton", "ChoiceAndButton", "SpinCtrl", "DatePickerCtrl"]
+				}, {
+					"type":	"choice",
+					"m_label":	"Kind:",
+					"m_selection":	3,
+					"m_options":	["wxPropertyCategory", "wxIntProperty", "wxFloatProperty", "wxBoolProperty", "wxStringProperty", "wxLongStringProperty", "wxDirProperty", "wxArrayStringProperty", "wxFileProperty", "wxEnumProperty", "wxEditEnumProperty", "wxFlagsProperty", "wxDateProperty", "wxImageFileProperty", "wxFontProperty", "wxSystemColourProperty"]
+				}, {
+					"type":	"string",
+					"m_label":	"String Value",
+					"m_value":	""
+				}, {
+					"type":	"multi-string",
+					"m_label":	"Choices:",
+					"m_value":	""
+				}, {
+					"type":	"multi-string",
+					"m_label":	"Array Integer Values",
+					"m_value":	""
+				}, {
+					"type":	"bool",
+					"m_label":	"Bool Value",
+					"m_value":	true
+				}, {
+					"type":	"string",
+					"m_label":	"Wildcard",
+					"m_value":	""
+				}, {
+					"type":	"font",
+					"m_label":	"Font:",
+					"m_value":	""
+				}, {
+					"type":	"colour",
+					"m_label":	"Initial Colour",
+					"colour":	"<Default>"
+				}],
+			"m_events":	[],
+			"m_children":	[]
           }]
         }, {
          "m_type": 4486,

--- a/LiteEditor/editoroptionsgeneralguidespanelbase.cpp
+++ b/LiteEditor/editoroptionsgeneralguidespanelbase.cpp
@@ -138,6 +138,9 @@ EditorOptionsGeneralEditBase::EditorOptionsGeneralEditBase(wxWindow* parent, wxW
     m_pgPropSmartQuotes = m_pgMgrEdit->AppendIn( m_pgProp8,  new wxBoolProperty( _("Smart quotes"), wxPG_LABEL, 1) );
     m_pgPropSmartQuotes->SetHelpString(_("When typing \" or ', automatically add another one to the right, unless one already exists (in this case, simply move the caret one position to the right)"));
     
+    m_pgPropCopyLineEmptySelection = m_pgMgrEdit->AppendIn( m_pgProp8,  new wxBoolProperty( _("Copying empty selection copies caret line"), wxPG_LABEL, 1) );
+    m_pgPropCopyLineEmptySelection->SetHelpString(_("Whether copying an empty selection to the clipboard copies the entire contents of the caret line, or nothing"));
+    
     m_pgProp16 = m_pgMgrEdit->Append(  new wxPropertyCategory( _("Typing in selection") ) );
     m_pgProp16->SetHelpString(wxT(""));
     

--- a/LiteEditor/editoroptionsgeneralguidespanelbase.h
+++ b/LiteEditor/editoroptionsgeneralguidespanelbase.h
@@ -71,6 +71,7 @@ protected:
     wxPGProperty* m_pgPropSmartCurly;
     wxPGProperty* m_pgPropSmartParentheses;
     wxPGProperty* m_pgPropSmartQuotes;
+    wxPGProperty* m_pgPropCopyLineEmptySelection;
     wxPGProperty* m_pgProp16;
     wxPGProperty* m_pgPropWrapQuotes;
     wxPGProperty* m_pgPropWrapBrackets;

--- a/LiteEditor/menu_event_handlers.cpp
+++ b/LiteEditor/menu_event_handlers.cpp
@@ -40,7 +40,10 @@ void EditHandler::ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event)
 
     OptionsConfigPtr options = editor->GetOptions();
     if(event.GetId() == wxID_COPY) {
-        editor->CopyAllowLine();
+        if(options->GetCopyLineEmptySelection())
+            editor->CopyAllowLine();
+        else
+            editor->Copy();
 
     } else if(event.GetId() == wxID_CUT) {
         editor->Cut();

--- a/Plugin/optionsconfig.cpp
+++ b/Plugin/optionsconfig.cpp
@@ -86,6 +86,7 @@ OptionsConfig::OptionsConfig(wxXmlNode* node)
     , m_autoAdjustHScrollBarWidth(false)
     , m_caretWidth(1)
     , m_caretBlinkPeriod(500)
+    , m_copyLineEmptySelection(true)
     , m_programConsoleCommand(TERMINAL_CMD)
     , m_eolMode(wxT("Default"))
     , m_hideChangeMarkerMargin(false)
@@ -176,6 +177,7 @@ OptionsConfig::OptionsConfig(wxXmlNode* node)
             XmlUtils::ReadBool(node, wxT("AutoAdjustHScrollBarWidth"), m_autoAdjustHScrollBarWidth);
         m_caretBlinkPeriod = XmlUtils::ReadLong(node, wxT("CaretBlinkPeriod"), m_caretBlinkPeriod);
         m_caretWidth = XmlUtils::ReadLong(node, wxT("CaretWidth"), m_caretWidth);
+        m_copyLineEmptySelection = XmlUtils::ReadBool(node, wxT("CopyLineEmptySelection"), m_copyLineEmptySelection);
         m_programConsoleCommand = XmlUtils::ReadString(node, wxT("ConsoleCommand"), m_programConsoleCommand);
         m_eolMode = XmlUtils::ReadString(node, wxT("EOLMode"), m_eolMode);
         m_hideChangeMarkerMargin = XmlUtils::ReadBool(node, wxT("HideChangeMarkerMargin"));
@@ -318,6 +320,7 @@ wxXmlNode* OptionsConfig::ToXml() const
     n->AddProperty(wxT("OutputTabsDirection"), wxString() << (int)m_outputTabsDirection);
     n->AddProperty(wxT("WorkspaceTabsDirection"), wxString() << (int)m_workspaceTabsDirection);
     n->AddProperty(wxT("IndentedComments"), BoolToString(m_indentedComments));
+    n->AddProperty(wxT("CopyLineEmptySelection"), BoolToString(m_copyLineEmptySelection));
 
     wxString tmp;
     tmp << m_indentWidth;

--- a/Plugin/optionsconfig.h
+++ b/Plugin/optionsconfig.h
@@ -110,6 +110,7 @@ protected:
     bool m_autoAdjustHScrollBarWidth;
     int m_caretWidth;
     int m_caretBlinkPeriod;
+    bool m_copyLineEmptySelection;
     wxString m_programConsoleCommand;
     wxString m_eolMode;
     bool m_hideChangeMarkerMargin;
@@ -423,6 +424,9 @@ public:
     void SetCaretWidth(const int& caretWidth) { this->m_caretWidth = caretWidth; }
     const int& GetCaretBlinkPeriod() const { return m_caretBlinkPeriod; }
     const int& GetCaretWidth() const { return m_caretWidth; }
+
+    void SetCopyLineEmptySelection(const bool copyLineEmptySelection) { m_copyLineEmptySelection = copyLineEmptySelection; }
+    bool GetCopyLineEmptySelection() const { return m_copyLineEmptySelection; }
 
     void SetProgramConsoleCommand(const wxString& programConsoleCommand)
     {


### PR DESCRIPTION
Hello again

Being fat-fingered, I'm often hitting ctrl-c when I mean ctrl-v. That is unfortunate as it replaces the clipboard contents with the current line (well, if not pasting in to a selection).

I've generally just hacked CopyAllowLine() -> Copy() in EditHandler::ProcessCommandEvent() but thought I'd tidy it up and make it a proper option like with #1927.

Sorry the menu_event_handlers.cpp diff is the whole file - I guess line endings have been normalized or something. It's just:

```
    if(event.GetId() == wxID_COPY) {
        if(options->GetCopyLineEmptySelection())
            editor->CopyAllowLine();
        else
            editor->Copy();
```

instead of always CopyAllowLine().

Thanks!

Luke.