### PR TITLE
Fix re-assigning accellerator when old accelerator is filtered out from list control

### DIFF
--- a/LiteEditor/acceltabledlg.cpp
+++ b/LiteEditor/acceltabledlg.cpp
@@ -153,12 +153,12 @@ void AccelTableDlg::DoItemActivated()
                     cd->m_menuItemData.accel.Clear();
                     int row = m_dvListCtrl->ItemToRow(oldItem);
                     m_dvListCtrl->SetValue(wxString(), row, 2);
-
-                    MenuItemDataMap_t::iterator iter = m_accelMap.find(cd->m_menuItemData.resourceID);
-                    if(iter != m_accelMap.end()) {
-                        iter->second.accel.Clear(); // Clear the accelerator
-                    }
                 }
+            }
+
+            MenuItemDataMap_t::iterator iter = m_accelMap.find(who.resourceID);
+            if(iter != m_accelMap.end()) {
+                iter->second.accel.Clear(); // Clear the accelerator
             }
         }
 


### PR DESCRIPTION
Hi

Just noticed that when re-assigning an accelerator, the old one will only be cleared if it is visible in the list control (i.e. not if it's filtered out).

Thanks!

Luke.
