### PR TITLE
spellcheck: a bit more false positive reduction in continuous mode

### DIFF
--- a/SpellChecker/IHunSpell.h
+++ b/SpellChecker/IHunSpell.h
@@ -108,8 +108,10 @@ public:
     void CloseEngine();
     /// changes the engines language. Must be in format like 'en_US'. No Close, Init necessary
     bool ChangeLanguage(const wxString& language);
-    /// check spelling for one word. Return 0 if the word was not found, otherwise != 0.
-    int CheckWord(const wxString& word);
+    /// check spelling for one word. Return true if the word was found.
+    bool CheckWord(const wxString& word) const;
+	/// is a word in the tags database?
+    bool IsTag(const wxString& word) const;
     /// returns an array with suggestions for the misspelled word.
     wxArrayString GetSuggestions(const wxString& misspelled);
     /// makes a spell check for the given cpp text. Canceled is set to true when the user cancels.
@@ -130,10 +132,12 @@ public:
     void SetDictionary(const wxString& dictionary) { m_dictionary = dictionary; }
     /// returns the current dictionary base filename
     const wxString& GetDictionary() const { return m_dictionary; }
-    /// sets whether user dictionary and ignored words are case sensitive
     void SetCaseSensitiveUserDictionary(const bool caseSensitiveUserDictionary);
     /// gets whether user dictionary and ignored words are case sensitive
     bool GetCaseSensitiveUserDictionary() const { return m_caseSensitiveUserDictionary; }
+    void SetIgnoreSymbolsInTagsDatabase(const bool ignoreSymbolsInTagsDatabase) { m_ignoreSymbolsInTagsDatabase = ignoreSymbolsInTagsDatabase; }
+    /// gets whether to ignore words that match ctags symbols
+    bool GetIgnoreSymbolsInTagsDatabase() const { return m_ignoreSymbolsInTagsDatabase; }
     ///
     void AddWord(const wxString& word) ;
 
@@ -187,6 +191,7 @@ protected:
     wxString m_dictionary;      // dictionary base filename
     wxString m_userDictPath;    // path to save user dictionary
     bool m_caseSensitiveUserDictionary;
+    bool m_ignoreSymbolsInTagsDatabase;
     Hunhandle* m_pSpell;        // pointer to hunspell
     CustomDictionary m_ignoreList; // ignore list
     CustomDictionary m_userDict;   // user words

--- a/SpellChecker/SpellCheckerSettings.cpp
+++ b/SpellChecker/SpellCheckerSettings.cpp
@@ -63,6 +63,7 @@ void SpellCheckerSettings::OnInitDialog(wxInitDialogEvent& event)
     event.Skip();
 
 	m_pCaseSensitiveUserDictionary->SetValue(m_caseSensitiveUserDictionary);
+	m_pIgnoreSymbolsInTagsDatabase->SetValue(m_ignoreSymbolsInTagsDatabase);
 
     if(m_pHunspell) {
         m_pDirPicker->SetPath(m_dictionaryPath);
@@ -104,6 +105,7 @@ void SpellCheckerSettings::OnOk(wxCommandEvent& event)
     event.Skip();
     m_dictionaryPath = m_pDirPicker->GetPath();
 	m_caseSensitiveUserDictionary = m_pCaseSensitiveUserDictionary->GetValue();
+    m_ignoreSymbolsInTagsDatabase = m_pIgnoreSymbolsInTagsDatabase->GetValue();
 
     if(!wxEndsWithPathSeparator(m_dictionaryPath)) m_dictionaryPath += wxFILE_SEP_PATH;
     ;

--- a/SpellChecker/SpellCheckerSettings.h
+++ b/SpellChecker/SpellCheckerSettings.h
@@ -63,6 +63,7 @@ protected:
     bool       m_scanD1;
     bool       m_scanD2;
     bool       m_caseSensitiveUserDictionary;
+    bool       m_ignoreSymbolsInTagsDatabase;
 
 public:
     const wxString& GetDictionaryPath() const {
@@ -95,6 +96,9 @@ public:
     }
     void            SetCaseSensitiveUserDictionary( const bool& caseSensitiveUserDictionary ) {
         this->m_caseSensitiveUserDictionary = caseSensitiveUserDictionary;
+	}
+    void            SetIgnoreSymbolsInTagsDatabase( const bool& ignoreSymbolsInTagsDatabase ) {
+        this->m_ignoreSymbolsInTagsDatabase = ignoreSymbolsInTagsDatabase;
     }
 
     bool GetScanC() const {
@@ -114,6 +118,9 @@ public:
     }
     bool GetCaseSensitiveUserDictionary() const {
         return m_caseSensitiveUserDictionary;
+	}
+    bool GetIgnoreSymbolsInTagsDatabase() const {
+        return m_ignoreSymbolsInTagsDatabase;
     }
     /** Constructor */
     SpellCheckerSettings( wxWindow* parent );

--- a/SpellChecker/spellcheck.cpp
+++ b/SpellChecker/spellcheck.cpp
@@ -250,6 +250,7 @@ void SpellCheck::OnSettings(wxCommandEvent& e)
     dlg.SetDictionaryFileName(m_pEngine->GetDictionary());
     dlg.SetDictionaryPath(m_pEngine->GetDictionaryPath());
     dlg.SetCaseSensitiveUserDictionary(m_pEngine->GetCaseSensitiveUserDictionary());
+    dlg.SetIgnoreSymbolsInTagsDatabase(m_pEngine->GetIgnoreSymbolsInTagsDatabase());
 
     if(dlg.ShowModal() == wxID_OK) {
         m_pEngine->EnableScannerType(IHunSpell::kString, dlg.GetScanStrings());
@@ -260,6 +261,7 @@ void SpellCheck::OnSettings(wxCommandEvent& e)
         m_pEngine->SetDictionaryPath(dlg.GetDictionaryPath());
         m_pEngine->ChangeLanguage(dlg.GetDictionaryFileName());
         m_pEngine->SetCaseSensitiveUserDictionary(dlg.GetCaseSensitiveUserDictionary());
+        m_pEngine->SetIgnoreSymbolsInTagsDatabase(dlg.GetIgnoreSymbolsInTagsDatabase());
         SaveSettings();
     }
 }
@@ -313,6 +315,7 @@ void SpellCheck::LoadSettings()
     m_pEngine->EnableScannerType(IHunSpell::kDox1, m_options.GetScanD1());
     m_pEngine->EnableScannerType(IHunSpell::kDox2, m_options.GetScanD2());
     m_pEngine->SetCaseSensitiveUserDictionary(m_options.GetCaseSensitiveUserDictionary());
+    m_pEngine->SetIgnoreSymbolsInTagsDatabase(m_options.GetIgnoreSymbolsInTagsDatabase());
 }
 // ------------------------------------------------------------
 void SpellCheck::SaveSettings()
@@ -325,6 +328,7 @@ void SpellCheck::SaveSettings()
     m_options.SetScanD1(m_pEngine->IsScannerType(IHunSpell::kDox1));
     m_options.SetScanD2(m_pEngine->IsScannerType(IHunSpell::kDox2));
     m_options.SetCaseSensitiveUserDictionary(m_pEngine->GetCaseSensitiveUserDictionary());
+    m_options.SetIgnoreSymbolsInTagsDatabase(m_pEngine->GetIgnoreSymbolsInTagsDatabase());
     m_mgr->GetConfigTool()->WriteObject(s_spOptions, &m_options);
 }
 // ------------------------------------------------------------
@@ -471,14 +475,6 @@ void SpellCheck::SetCheckContinuous(bool value)
             m_pToolbar->Refresh();
         }
     }
-}
-
-// ------------------------------------------------------------
-bool SpellCheck::IsTag(const wxString& token)
-{
-    std::vector<TagEntryPtr> tags;
-    m_mgr->GetTagsManager()->FindSymbol(token, tags);
-    return (tags.size() == 0) ? false : true;
 }
 // ------------------------------------------------------------
 void SpellCheck::OnWspLoaded(wxCommandEvent& e)

--- a/SpellChecker/spellcheck.h
+++ b/SpellChecker/spellcheck.h
@@ -49,7 +49,6 @@ public:
 
     void SetCheckContinuous(bool value);
     bool GetCheckContinuous() const { return m_options.GetCheckContinuous(); }
-    bool IsTag(const wxString& token);
     IEditor* GetEditor();
     wxMenu* CreateSubMenu();
 

--- a/SpellChecker/spellcheckeroptions.cpp
+++ b/SpellChecker/spellcheckeroptions.cpp
@@ -46,6 +46,7 @@ SpellCheckerOptions::SpellCheckerOptions()
     m_scanD2  = false;
     m_checkContinuous = false;
     m_caseSensitiveUserDictionary = true;
+    m_ignoreSymbolsInTagsDatabase = false;
 
     wxString defaultDicsDir;
     defaultDicsDir << clStandardPaths::Get().GetDataDir() << wxFILE_SEP_PATH << "dics";
@@ -69,6 +70,7 @@ void SpellCheckerOptions::DeSerialize( Archive& arch )
     arch.Read( wxT( "m_scanD2" ), m_scanD2 );
     arch.Read( wxT( "m_checkContinuous" ), m_checkContinuous );
     arch.Read( wxT( "m_caseSensitiveUserDictionary" ), m_caseSensitiveUserDictionary );
+    arch.Read( wxT( "m_ignoreSymbolsInTagsDatabase" ), m_ignoreSymbolsInTagsDatabase );
 }
 
 // ------------------------------------------------------------
@@ -83,5 +85,6 @@ void SpellCheckerOptions::Serialize( Archive& arch )
     arch.Write( wxT( "m_scanD2" ), m_scanD2 );
     arch.Write( wxT( "m_checkContinuous" ), m_checkContinuous );
     arch.Write( wxT( "m_caseSensitiveUserDictionary" ), m_caseSensitiveUserDictionary );
+    arch.Write( wxT( "m_ignoreSymbolsInTagsDatabase" ), m_ignoreSymbolsInTagsDatabase );
 }
 // ------------------------------------------------------------

--- a/SpellChecker/spellcheckeroptions.h
+++ b/SpellChecker/spellcheckeroptions.h
@@ -56,6 +56,7 @@ public:
 	void            SetScanStr( const bool& scanStr ) { this->m_scanStr = scanStr; }
     void            SetCheckContinuous( const bool& checkContinuous ) { this->m_checkContinuous = checkContinuous; }
     void            SetCaseSensitiveUserDictionary( const bool& caseSensitiveUserDictionary ) { this->m_caseSensitiveUserDictionary = caseSensitiveUserDictionary; }
+    void            SetIgnoreSymbolsInTagsDatabase( const bool& ignoreSymbolsInTagsDatabase ) { this->m_ignoreSymbolsInTagsDatabase = ignoreSymbolsInTagsDatabase; }
 	bool            GetScanC() const { return m_scanC; }
 	bool            GetScanCPP() const { return m_scanCPP; }
 	bool            GetScanD1() const { return m_scanD1; }
@@ -65,6 +66,7 @@ public:
 	const wxString& GetDictionaryFileName() const { return m_dictionary; }
     bool            GetCheckContinuous() const { return m_checkContinuous; }
     bool            GetCaseSensitiveUserDictionary() const { return m_caseSensitiveUserDictionary; }
+    bool            GetIgnoreSymbolsInTagsDatabase() const { return m_ignoreSymbolsInTagsDatabase; }
 
 protected:
 	wxString m_dictionary;
@@ -76,6 +78,7 @@ protected:
 	bool     m_scanD2;
     bool     m_checkContinuous;
     bool     m_caseSensitiveUserDictionary;
+    bool     m_ignoreSymbolsInTagsDatabase;
 };
 //------------------------------------------------------------
 #endif // __spellcheckeroptions__

--- a/SpellChecker/wxcrafter.cpp
+++ b/SpellChecker/wxcrafter.cpp
@@ -108,6 +108,12 @@ SpellCheckerSettings_base::SpellCheckerSettings_base(wxWindow* parent, wxWindowI
 
     bSizer5->Add(m_pCaseSensitiveUserDictionary, 0, wxALL, 5);
 
+    m_pIgnoreSymbolsInTagsDatabase = new wxCheckBox(this, wxID_ANY, _("Ignore symbols in tags database"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1,-1)), 0);
+    m_pIgnoreSymbolsInTagsDatabase->SetValue(false);
+    m_pIgnoreSymbolsInTagsDatabase->SetToolTip(_("Don't mark words in the project's tags database as spelling errors"));
+
+    bSizer5->Add(m_pIgnoreSymbolsInTagsDatabase, 0, wxALL, 5);
+
     m_buttonClearIgnoreList = new wxButton(this, wxID_CLEAR, _("Clear ignore list"), wxDefaultPosition, wxSize(-1,-1), 0);
     m_buttonClearIgnoreList->SetToolTip(_("Clear the ignore list"));
 

--- a/SpellChecker/wxcrafter.h
+++ b/SpellChecker/wxcrafter.h
@@ -44,6 +44,7 @@ protected:
     wxCheckBox* m_pDox1;
     wxCheckBox* m_pDox2;
     wxCheckBox* m_pCaseSensitiveUserDictionary;
+    wxCheckBox* m_pIgnoreSymbolsInTagsDatabase;
     wxButton* m_buttonClearIgnoreList;
     wxStdDialogButtonSizer* m_stdBtnSizer12;
     wxButton* m_buttonOK;
@@ -70,6 +71,7 @@ public:
     wxCheckBox* GetPDox1() { return m_pDox1; }
     wxCheckBox* GetPDox2() { return m_pDox2; }
     wxCheckBox* GetPCaseSensitiveUserDictionary() { return m_pCaseSensitiveUserDictionary; }
+    wxCheckBox* GetPIgnoreSymbolsInTagsDatabase() { return m_pIgnoreSymbolsInTagsDatabase; }
     wxButton* GetButtonClearIgnoreList() { return m_buttonClearIgnoreList; }
     SpellCheckerSettings_base(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("SpellChecker Settings"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(-1, -1), long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
     virtual ~SpellCheckerSettings_base();

--- a/SpellChecker/wxcrafter.wxcp
+++ b/SpellChecker/wxcrafter.wxcp
@@ -1,7 +1,7 @@
 {
 	"metadata":	{
 		"m_generatedFilesDir":	".",
-		"m_objCounter":	31,
+		"m_objCounter":	33,
 		"m_includeFiles":	[],
 		"m_bitmapFunction":	"wxC9A94InitBitmapResources",
 		"m_bitmapsFile":	"wxcrafter_bitmaps.cpp",
@@ -1237,6 +1237,81 @@
 									"type":	"bool",
 									"m_label":	"Value:",
 									"m_value":	true
+								}],
+							"m_events":	[],
+							"m_children":	[]
+						}, {
+							"m_type":	4415,
+							"proportion":	0,
+							"border":	5,
+							"gbSpan":	"1,1",
+							"gbPosition":	"0,0",
+							"m_styles":	[],
+							"m_sizerFlags":	["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
+							"m_properties":	[{
+									"type":	"winid",
+									"m_label":	"ID:",
+									"m_winid":	"wxID_ANY"
+								}, {
+									"type":	"string",
+									"m_label":	"Size:",
+									"m_value":	"-1,-1"
+								}, {
+									"type":	"string",
+									"m_label":	"Minimum Size:",
+									"m_value":	"-1,-1"
+								}, {
+									"type":	"string",
+									"m_label":	"Name:",
+									"m_value":	"m_pIgnoreSymbolsInTagsDatabase"
+								}, {
+									"type":	"multi-string",
+									"m_label":	"Tooltip:",
+									"m_value":	"Don't mark words in the project's tags database as spelling errors"
+								}, {
+									"type":	"colour",
+									"m_label":	"Bg Colour:",
+									"colour":	"<Default>"
+								}, {
+									"type":	"colour",
+									"m_label":	"Fg Colour:",
+									"colour":	"<Default>"
+								}, {
+									"type":	"font",
+									"m_label":	"Font:",
+									"m_value":	""
+								}, {
+									"type":	"bool",
+									"m_label":	"Hidden",
+									"m_value":	false
+								}, {
+									"type":	"bool",
+									"m_label":	"Disabled",
+									"m_value":	false
+								}, {
+									"type":	"bool",
+									"m_label":	"Focused",
+									"m_value":	false
+								}, {
+									"type":	"string",
+									"m_label":	"Class Name:",
+									"m_value":	""
+								}, {
+									"type":	"string",
+									"m_label":	"Include File:",
+									"m_value":	""
+								}, {
+									"type":	"string",
+									"m_label":	"Style:",
+									"m_value":	""
+								}, {
+									"type":	"string",
+									"m_label":	"Label:",
+									"m_value":	"Ignore symbols in tags database"
+								}, {
+									"type":	"bool",
+									"m_label":	"Value:",
+									"m_value":	false
 								}],
 							"m_events":	[],
 							"m_children":	[]


### PR DESCRIPTION
Hi

I thought it might help to ignore words in the tags database in the continuous spell check mode, so I wrote something to do it. Then I noticed there was actually already some code in there commented out to do the same!

Anyway I added it as an option in this branch as it helps reduce false positives for me quite a bit. Hopefully useful?

Thanks

Luke.
