### PR TITLE
lldb-fixes follow up

### DIFF
--- a/CodeLite/SocketAPI/clSocketBase.cpp
+++ b/CodeLite/SocketAPI/clSocketBase.cpp
@@ -27,6 +27,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <sstream>
+#include <memory>
 
 #ifndef _WIN32
 #include <fcntl.h>
@@ -54,7 +55,7 @@ void clSocketBase::Initialize()
 }
 
 // Read API
-int clSocketBase::Read(wxMemoryBuffer& content, long timeout) 
+int clSocketBase::Read(wxMemoryBuffer& content, long timeout)
 {
     content.Clear();
 
@@ -67,8 +68,12 @@ int clSocketBase::Read(wxMemoryBuffer& content, long timeout)
             memset(buffer, 0x0, sizeof(buffer));
             int bytesRead = recv(m_socket, buffer, sizeof(buffer), 0);
             if(bytesRead < 0) {
-                // Error
-                throw clSocketException("Read failed: " + error());
+                const int err = GetLastError();
+
+                if(eWouldBlock != err) {
+                    // Error
+                    throw clSocketException("Read failed: " + error(err));
+                }
 
             } else if(bytesRead == 0) {
                 // connection closed
@@ -88,7 +93,7 @@ int clSocketBase::Read(wxMemoryBuffer& content, long timeout)
     return kTimeout;
 }
 
-int clSocketBase::Read(wxString& content, const wxMBConv& conv, long timeout) 
+int clSocketBase::Read(wxString& content, const wxMBConv& conv, long timeout)
 {
     wxMemoryBuffer mb;
     int rc = Read(mb, timeout);
@@ -98,17 +103,31 @@ int clSocketBase::Read(wxString& content, const wxMBConv& conv, long timeout)
     return rc;
 }
 
-int clSocketBase::Read(char* buffer, size_t bufferSize, size_t& bytesRead, long timeout) 
+int clSocketBase::Read(char* buffer, size_t bufferSize, size_t& bytesRead, long timeout)
 {
     if(SelectRead(timeout) == kTimeout) {
         return kTimeout;
     }
     memset(buffer, 0, bufferSize);
-    bytesRead = recv(m_socket, buffer, bufferSize, 0);
+    const int res = recv(m_socket, buffer, bufferSize, 0);
+
+    if(res < 0) {
+        const int err = GetLastError();
+        if(eWouldBlock == err) {
+            return kTimeout;
+        }
+
+        throw clSocketException("Read failed: " + error(err));
+    }
+    else if(0 == res) {
+        throw clSocketException("Read failed: " + error());
+    }
+
+    bytesRead = static_cast<size_t>(res);
     return kSuccess;
 }
 
-int clSocketBase::SelectRead(long seconds) 
+int clSocketBase::SelectRead(long seconds)
 {
     if(seconds == -1) {
         return kSuccess;
@@ -139,7 +158,7 @@ int clSocketBase::SelectRead(long seconds)
 }
 
 // Send API
-void clSocketBase::Send(const wxString& msg, const wxMBConv& conv) 
+void clSocketBase::Send(const wxString& msg, const wxMBConv& conv)
 {
     if(m_socket == INVALID_SOCKET) {
         throw clSocketException("Invalid socket!");
@@ -150,7 +169,7 @@ void clSocketBase::Send(const wxString& msg, const wxMBConv& conv)
     Send(mb);
 }
 
-void clSocketBase::Send(const std::string& msg) 
+void clSocketBase::Send(const std::string& msg)
 {
     if(m_socket == INVALID_SOCKET) {
         throw clSocketException("Invalid socket!");
@@ -160,7 +179,7 @@ void clSocketBase::Send(const std::string& msg)
     Send(mb);
 }
 
-void clSocketBase::Send(const wxMemoryBuffer& msg) 
+void clSocketBase::Send(const wxMemoryBuffer& msg)
 {
     if(m_socket == INVALID_SOCKET) {
         throw clSocketException("Invalid socket!");
@@ -176,19 +195,32 @@ void clSocketBase::Send(const wxMemoryBuffer& msg)
     }
 }
 
-std::string clSocketBase::error() const
+int clSocketBase::GetLastError()
+{
+#ifdef _WIN32
+    return ::WSAGetLastError();
+#else
+    return errno;
+#endif
+}
+
+std::string clSocketBase::error()
+{
+    return error(GetLastError());
+}
+
+std::string clSocketBase::error(const int errorCode)
 {
     std::string err;
 #ifdef _WIN32
     // Get the error message, if any.
-    DWORD errorMessageID = ::WSAGetLastError();
-    if(errorMessageID == 0) return "No error message has been recorded";
+    if(errorCode == 0) return "No error message has been recorded";
 
     LPSTR messageBuffer = nullptr;
     size_t size =
         FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                        NULL,
-                       errorMessageID,
+                       errorCode,
                        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
                        (LPSTR)&messageBuffer,
                        0,
@@ -200,7 +232,7 @@ std::string clSocketBase::error() const
     LocalFree(messageBuffer);
     err = message;
 #else
-    err = strerror(errno);
+    err = strerror(errorCode);
 #endif
     return err;
 }
@@ -221,7 +253,7 @@ void clSocketBase::DestroySocket()
     m_socket = INVALID_SOCKET;
 }
 
-int clSocketBase::ReadMessage(wxString& message, int timeout) 
+int clSocketBase::ReadMessage(wxString& message, int timeout)
 {
     // send the length in string form to avoid binary / arch differences between remote and local machine
     char msglen[11];
@@ -239,22 +271,15 @@ int clSocketBase::ReadMessage(wxString& message, int timeout)
     message_len = ::atoi(msglen);
 
     bytesRead = 0;
-    char* buff = new char[message_len + 1];
-    memset(buff, 0, message_len + 1);
+    std::unique_ptr<char> pBuff(new char[message_len]);
 
     // read the entire amount we need
     int bytesLeft = message_len;
     int totalRead = 0;
     while(bytesLeft > 0) {
-        rc = Read(buff + totalRead, bytesLeft, bytesRead, timeout);
+        rc = Read(pBuff.get() + totalRead, bytesLeft, bytesRead, timeout);
         if(rc != kSuccess) {
-            wxDELETEA(buff);
             return rc;
-
-        } else if(rc == 0) {
-            // session was closed
-            wxDELETEA(buff);
-            throw clSocketException("connection closed by peer");
 
         } else {
             bytesLeft -= bytesRead;
@@ -263,12 +288,11 @@ int clSocketBase::ReadMessage(wxString& message, int timeout)
         }
     }
 
-    buff[message_len] = '\0';
-    message = buff;
+    message.assign(pBuff.get(), message_len);
     return kSuccess;
 }
 
-void clSocketBase::WriteMessage(const wxString& message) 
+void clSocketBase::WriteMessage(const wxString& message)
 {
     if(m_socket == INVALID_SOCKET) {
         throw clSocketException("Invalid socket!");
@@ -313,7 +337,7 @@ void clSocketBase::MakeSocketBlocking(bool blocking)
 #endif
 }
 
-int clSocketBase::SelectWriteMS(long milliSeconds) 
+int clSocketBase::SelectWriteMS(long milliSeconds)
 {
     if(milliSeconds == -1) {
         return kSuccess;
@@ -346,7 +370,7 @@ int clSocketBase::SelectWriteMS(long milliSeconds)
     }
 }
 
-int clSocketBase::SelectWrite(long seconds) 
+int clSocketBase::SelectWrite(long seconds)
 {
     if(seconds == -1) {
         return kSuccess;
@@ -377,7 +401,7 @@ int clSocketBase::SelectWrite(long seconds)
     }
 }
 
-int clSocketBase::SelectReadMS(long milliSeconds) 
+int clSocketBase::SelectReadMS(long milliSeconds)
 {
     if(milliSeconds == -1) {
         return kSuccess;

--- a/CodeLite/SocketAPI/clSocketBase.h
+++ b/CodeLite/SocketAPI/clSocketBase.h
@@ -72,7 +72,15 @@ public:
         kError = 3,
     };
 
-    std::string error() const;
+#ifdef _WIN32
+    static const int eWouldBlock = WSAEWOULDBLOCK;
+#else
+    static const int eWouldBlock = EWOULDBLOCK;
+#endif
+
+    static int GetLastError();
+    static std::string error();
+    static std::string error(const int errorCode);
 
 public:
     /**
@@ -117,7 +125,7 @@ public:
      * @param timeout seconds to wait
      */
     int Read(wxString& content, const wxMBConv& conv = wxConvUTF8, long timeout = -1) ;
-    
+
     /**
      * @brief read a buffer from the socket
      * @param content [output]
@@ -131,20 +139,20 @@ public:
      * @return
      */
     int SelectRead(long seconds = -1) ;
-    
+
     /**
      * @brief select for read. Same as above, but use milli seconds instead
      * @param milliSeconds number of _milliseconds_ to wait
-     * @return 
+     * @return
      */
     int SelectReadMS(long milliSeconds = -1) ;
-    
+
     /**
      * @brief select for write
      * @return
      */
     int SelectWrite(long seconds = -1) ;
-    
+
     /**
      * @brief select for write (milli seconds version)
      * @return

--- a/LLDBDebugger/LLDBPlugin.cpp
+++ b/LLDBDebugger/LLDBPlugin.cpp
@@ -822,9 +822,11 @@ void LLDBPlugin::OnLLDBCrashed(LLDBEvent& event)
     event.Skip();
     // Report it as crash only if not going down (i.e. we got an LLDBExit event)
     if(!m_connector.IsGoingDown()) {
+        // SetGoingDown() before displaying message box to cope with reentering this function whilst waiting for OK.
+        m_connector.SetGoingDown(true);
         ::wxMessageBox(_("LLDB crashed! Terminating debug session"), "CodeLite", wxOK | wxICON_ERROR | wxCENTER);
+        OnLLDBExited(event);
     }
-    OnLLDBExited(event);
 }
 
 void LLDBPlugin::OnToggleInerrupt(clDebugEvent& event)

--- a/LLDBDebugger/LLDBPlugin.cpp
+++ b/LLDBDebugger/LLDBPlugin.cpp
@@ -513,9 +513,7 @@ void LLDBPlugin::OnLLDBStopped(LLDBEvent& event)
         IEditor* editor = m_mgr->FindEditor(event.GetFileName());
         if(!editor && wxFileName::Exists(event.GetFileName())) {
             // Try to open the editor
-            if(m_mgr->OpenFile(event.GetFileName(), "", event.GetLinenumber() - 1)) {
-                editor = m_mgr->GetActiveEditor();
-            }
+            editor = m_mgr->OpenFile(event.GetFileName(), "", event.GetLinenumber() - 1);
         }
 
         if(editor) {

--- a/LLDBDebugger/LLDBPlugin.h
+++ b/LLDBDebugger/LLDBPlugin.h
@@ -33,7 +33,7 @@
 #include "LLDBProtocol/LLDBConnector.h"
 #include "LLDBProtocol/LLDBEvent.h"
 #include "LLDBProtocol/LLDBRemoteConnectReturnObject.h"
-#include "../Plugin/clDebuggerTerminal.h"
+#include "clDebuggerTerminal.h"
 
 class LLDBTooltip;
 class LLDBThreadsView;

--- a/LLDBDebugger/LLDBProtocol/LLDBConnector.cpp
+++ b/LLDBDebugger/LLDBProtocol/LLDBConnector.cpp
@@ -441,8 +441,7 @@ void LLDBConnector::OnProcessTerminated(clProcessEvent& event)
 {
     m_process = nullptr;
 
-    clDebugEvent e2(wxEVT_LLDB_CRASHED);
-    ProcessEvent(e2);
+    AddPendingEvent(LLDBEvent(wxEVT_LLDB_CRASHED));
 }
 
 void LLDBConnector::Interrupt(eInterruptReason reason)

--- a/LLDBDebugger/LLDBProtocol/LLDBConnector.cpp
+++ b/LLDBDebugger/LLDBProtocol/LLDBConnector.cpp
@@ -75,6 +75,7 @@ bool LLDBConnector::ConnectToLocalDebugger(LLDBConnectReturnObject& ret, int tim
 {
 
 #ifndef __WXMSW__
+    m_goingDown = false;
     clSocketClient* client = new clSocketClient();
     m_socket.reset(client);
     clDEBUG() << "Connecting to codelite-lldb on:" << GetDebugServerPath();
@@ -110,6 +111,7 @@ bool LLDBConnector::ConnectToLocalDebugger(LLDBConnectReturnObject& ret, int tim
 
 bool LLDBConnector::ConnectToRemoteDebugger(const wxString& ip, int port, LLDBConnectReturnObject& ret, int timeout)
 {
+    m_goingDown = false;
     m_socket.reset(NULL);
     clSocketClient* client = new clSocketClient();
     m_socket.reset(client);

--- a/LLDBDebugger/LLDBProtocol/LLDBConnector.h
+++ b/LLDBDebugger/LLDBProtocol/LLDBConnector.h
@@ -37,6 +37,8 @@
 #include "LLDBRemoteConnectReturnObject.h"
 #include "LLDBPivot.h"
 
+#include <memory>
+
 class LLDBConnector;
 class LLDBNetworkListenerThread;
 class LLDBTerminalCallback : public IProcessCallback
@@ -70,10 +72,10 @@ public:
 
 protected:
     clSocketClient::Ptr_t m_socket;
-    LLDBNetworkListenerThread* m_thread;
+    std::unique_ptr<LLDBNetworkListenerThread> m_thread;
     LLDBBreakpoint::Vec_t m_breakpoints;
     LLDBBreakpoint::Vec_t m_pendingDeletionBreakpoints;
-    IProcess* m_process;
+    std::unique_ptr<IProcess> m_process;
     bool m_isRunning;
     bool m_canInteract;
     LLDBCommand m_runCommand;

--- a/LiteEditor/mainbook.cpp
+++ b/LiteEditor/mainbook.cpp
@@ -70,8 +70,8 @@ void MainBook::CreateGuiControls()
 
     m_messagePane = new MessagePane(this);
     sz->Add(m_messagePane, 0, wxALL | wxEXPAND, 5, NULL);
-    
-    
+
+
 #if USE_AUI_NOTEBOOK
     long style = wxAUI_NB_TOP | wxAUI_NB_TAB_SPLIT | wxAUI_NB_TAB_MOVE | wxAUI_NB_CLOSE_ON_ACTIVE_TAB |
                  wxAUI_NB_WINDOWLIST_BUTTON | kNotebook_DynamicColours | kNotebook_MouseMiddleClickClosesTab;
@@ -94,7 +94,7 @@ void MainBook::CreateGuiControls()
     sz->Add(m_book, 1, wxEXPAND);
 
     DoPlaceNavigationBar();
-    
+
     m_quickFindBar = new QuickFindBar(this);
     DoPositionFindBar();
     sz->Layout();
@@ -612,11 +612,12 @@ LEditor* MainBook::OpenFile(const wxString& file_name, const wxString& projectNa
             AddPage(editor, fileName.GetFullName(), tooltip.IsEmpty() ? fileName.GetFullPath() : tooltip, bmp);
         }
         editor->SetSyntaxHighlight();
+        ManagerST::Get()->GetBreakpointsMgr()->RefreshBreakpointsForEditor(editor);
 
-        // mark the editor as read only if neede
+        // mark the editor as read only if needed
         MarkEditorReadOnly(editor);
 
-        // SHow the notebook
+        // Show the notebook
         if(hidden) GetSizer()->Show(m_book);
 
         if(position == wxNOT_FOUND && lineno == wxNOT_FOUND && editor->GetContext()->GetName() == wxT("C++")) {


### PR DESCRIPTION
Hi

I did a bit more looking in to the notification of codelite-lldb crashing thing. I noticed LLDBNetworkListenerThread had code to cope with losing the connection to codelite-lldb but it wasn't triggering - it looks like clSocketBase::ReadMessage() wasn't coping with 0 length recv()s for the header or body.

I also made a change here to have a separate clSocketBase::GetLastError() function and error(const int errorCode) to avoid having to worry about whether errno gets reset between reading it and wanting to convert it to a string (since the code now has a check for EWOULDBLOCK before calling error()). Not really an issue here since strerror() is presumably compliant on all platforms Codelite will run on, it's just my personal preference. Happy to back it out if you prefer :smile:

I thought fixing the socket error notification might mean the previous mod to send wxEVT_LLDB_CRASHED from LLDBConnector::OnProcessTerminated() wouldn't be needed, but it is due to racing between the socket notification and process termination. I think what's happening is if the process termination is received first and it just calls Cleanup(), that could terminate the LLDBNetworkListenerThread such that it never generates wxEVT_LLDB_CRASHED and then the debugger just closes with no message box. If the socket notification is received first, it was OK.

So I've left both sources of wxEVT_LLDB_CRASHED in (socket close and process termination) and made OnLLDBCrashed() a bit nicer with re-entracy (to avoid multiple message boxes). I also noticed LLDBConnector::m_goingDown was never reset so added that.

The include tidy up is also in here.

Anyway, see what you think!

Cheers

Luke.