### PR TITLE
lldb: fix crash when fast stepping with expanded variables

### DIFF
--- a/LLDBDebugger/LLDBLocalsView.cpp
+++ b/LLDBDebugger/LLDBLocalsView.cpp
@@ -107,6 +107,7 @@ void LLDBLocalsView::OnLLDBLocalsUpdated(LLDBEvent& event)
     wxWindowUpdateLocker locker(m_treeList);
     Enable(true);
 
+    m_pendingExpandItems.clear();
     m_treeList->DeleteChildren(m_treeList->GetRootItem());
     m_pathToItem.clear();
 


### PR DESCRIPTION
I've been getting some crashes using lldb with expanded variables and fast stepping. This is the smallest repro I can get it down to:

```
class A
{
	int	m_a;
};

int main()
{
start:
	A a, b;
	goto start;
	return 0;
}
```
Expand a and b and then just hold down F10, it should segfault after a while.

Simple mod here seems to do the trick!

Thanks

Luke.