### PR TITLE
lldb: added some features

### DIFF
--- a/LLDBDebugger/LLDBCallStack.cpp
+++ b/LLDBDebugger/LLDBCallStack.cpp
@@ -26,14 +26,16 @@
 #include "LLDBCallStack.h"
 #include "LLDBProtocol/LLDBEvent.h"
 #include "LLDBProtocol/LLDBConnector.h"
+#include "LLDBPlugin.h"
 #include <wx/wupdlock.h>
 #include "macros.h"
 #include "globals.h"
 #include "file_logger.h"
 
-LLDBCallStackPane::LLDBCallStackPane(wxWindow* parent, LLDBConnector* connector)
+LLDBCallStackPane::LLDBCallStackPane(wxWindow* parent, LLDBPlugin& plugin)
     : LLDBCallStackBase(parent)
-    , m_connector(connector)
+    , m_plugin(plugin)
+    , m_connector(plugin.GetLLDB())
     , m_selectedFrame(0)
 {
     m_connector->Bind(wxEVT_LLDB_STOPPED, &LLDBCallStackPane::OnBacktrace, this);
@@ -65,7 +67,7 @@ void LLDBCallStackPane::OnBacktrace(LLDBEvent& event)
         const LLDBBacktrace::Entry& entry = entries.at(i);
         cols.push_back(wxString::Format("%d", entry.id));
         cols.push_back(entry.functionName);
-        cols.push_back(entry.filename);
+        cols.push_back(m_plugin.GetFilenameForDisplay(entry.filename));
         cols.push_back(wxString::Format("%d", (int)(entry.line + 1)));
         m_dvListCtrlBacktrace->AppendItem(cols);
     }
@@ -99,7 +101,7 @@ bool CallstackModel::GetAttr(const wxDataViewItem& item, unsigned int col, wxDat
 void LLDBCallStackPane::OnContextMenu(wxDataViewEvent& event)
 {
     wxMenu menu;
-    
+
     menu.Append(11981, _("Copy backtrace"), _("Copy backtrace"));
     int selection = GetPopupMenuSelectionFromUser(menu);
     switch(selection) {

--- a/LLDBDebugger/LLDBCallStack.h
+++ b/LLDBDebugger/LLDBCallStack.h
@@ -32,6 +32,7 @@
 
 class LLDBCallStackPane;
 class LLDBConnector;
+class LLDBPlugin;
 
 class CallstackModel : public wxDataViewListStore
 {
@@ -46,6 +47,7 @@ public:
 
 class LLDBCallStackPane : public LLDBCallStackBase
 {
+    LLDBPlugin& m_plugin;
     LLDBConnector* m_connector;
     int m_selectedFrame;
     wxObjectDataPtr<CallstackModel> m_model;
@@ -59,7 +61,7 @@ protected:
     void OnRunning(LLDBEvent &event);
 
 public:
-    LLDBCallStackPane(wxWindow* parent, LLDBConnector* connector);
+    LLDBCallStackPane(wxWindow* parent, LLDBPlugin& plugin);
     virtual ~LLDBCallStackPane();
     
     void SetSelectedFrame(int selectedFrame) {

--- a/LLDBDebugger/LLDBLocalsView.h
+++ b/LLDBDebugger/LLDBLocalsView.h
@@ -49,6 +49,7 @@ private:
     void Cleanup();
     void GetWatchesFromSelections(wxArrayTreeItemIds& items);
     wxString GetItemPath(const wxTreeItemId& item);
+    void DoDelete();
 
 protected:
     virtual void OnDelete(wxCommandEvent& event);

--- a/LLDBDebugger/LLDBLocalsView.h
+++ b/LLDBDebugger/LLDBLocalsView.h
@@ -45,6 +45,7 @@ class LLDBLocalsView : public LLDBLocalsViewBase
 
 private:
     void DoAddVariableToView(const LLDBVariable::Vect_t& variables, wxTreeItemId parent);
+    void ExpandPreviouslyExpandedItems();
     LLDBVariableClientData* GetItemData(const wxTreeItemId& id);
     void Cleanup();
     void GetWatchesFromSelections(wxArrayTreeItemIds& items);
@@ -64,6 +65,7 @@ protected:
 
     // UI events
     void OnItemExpanding(wxTreeEvent& event);
+    void OnItemCollapsed(wxTreeEvent& event);
     void OnLocalsContextMenu(wxTreeEvent& event);
 
 public:

--- a/LLDBDebugger/LLDBOutputView.cpp
+++ b/LLDBDebugger/LLDBOutputView.cpp
@@ -102,7 +102,7 @@ void LLDBOutputView::Initialize()
         wxVector<wxVariant> cols;
         LLDBBreakpoint::Ptr_t bp = breakpoints.at(i);
         cols.push_back(wxString() << bp->GetId());
-        cols.push_back(bp->GetFilename());
+        cols.push_back(m_plugin->GetFilenameForDisplay(bp->GetFilename()));
         cols.push_back(wxString() << bp->GetLineNumber());
         cols.push_back(bp->GetName());
         wxDataViewItem parent =
@@ -115,7 +115,7 @@ void LLDBOutputView::Initialize()
                 cols.clear();
                 LLDBBreakpoint::Ptr_t breakpoint = children.at(i);
                 cols.push_back("");
-                cols.push_back(breakpoint->GetFilename());
+                cols.push_back(m_plugin->GetFilenameForDisplay(breakpoint->GetFilename()));
                 cols.push_back(wxString() << breakpoint->GetLineNumber());
                 cols.push_back(breakpoint->GetName());
                 m_dataviewModel->AppendItem(parent, cols, new LLDBBreakpointClientData(breakpoint));
@@ -237,7 +237,7 @@ void LLDBOutputView::OnConsoleOutput(LLDBEvent& event)
     m_stcConsole->SetSelectionStart(lastPos);
     m_stcConsole->SetSelectionEnd(lastPos);
     m_stcConsole->ScrollToEnd();
-    
+
     // give the focus back to the console text control
     m_textCtrlConsoleSend->CallAfter(&wxTextCtrl::SetFocus);
 }

--- a/LLDBDebugger/LLDBOutputView.cpp
+++ b/LLDBDebugger/LLDBOutputView.cpp
@@ -102,9 +102,9 @@ void LLDBOutputView::Initialize()
         wxVector<wxVariant> cols;
         LLDBBreakpoint::Ptr_t bp = breakpoints.at(i);
         cols.push_back(wxString() << bp->GetId());
+        cols.push_back(bp->GetName());
         cols.push_back(m_plugin->GetFilenameForDisplay(bp->GetFilename()));
         cols.push_back(wxString() << bp->GetLineNumber());
-        cols.push_back(bp->GetName());
         wxDataViewItem parent =
             m_dataviewModel->AppendItem(wxDataViewItem(NULL), cols, new LLDBBreakpointClientData(bp));
 
@@ -115,9 +115,9 @@ void LLDBOutputView::Initialize()
                 cols.clear();
                 LLDBBreakpoint::Ptr_t breakpoint = children.at(i);
                 cols.push_back("");
+                cols.push_back(breakpoint->GetName());
                 cols.push_back(m_plugin->GetFilenameForDisplay(breakpoint->GetFilename()));
                 cols.push_back(wxString() << breakpoint->GetLineNumber());
-                cols.push_back(breakpoint->GetName());
                 m_dataviewModel->AppendItem(parent, cols, new LLDBBreakpointClientData(breakpoint));
             }
         }

--- a/LLDBDebugger/LLDBPlugin.cpp
+++ b/LLDBDebugger/LLDBPlugin.cpp
@@ -228,6 +228,11 @@ void LLDBPlugin::UnPlug()
 
 LLDBPlugin::~LLDBPlugin() {}
 
+bool LLDBPlugin::ShowThreadNames() const
+{
+    return m_showThreadNames;
+}
+
 clToolBar* LLDBPlugin::CreateToolBar(wxWindow* parent)
 {
     // Create the toolbar to be used by the plugin
@@ -505,6 +510,10 @@ void LLDBPlugin::OnLLDBExited(LLDBEvent& event)
 void LLDBPlugin::OnLLDBStarted(LLDBEvent& event)
 {
     event.Skip();
+
+    const auto settings = LLDBSettings().Load();
+    m_showThreadNames = settings.HasFlag(kLLDBOptionShowThreadNames);
+
     InitializeUI();
     LoadLLDBPerspective();
 
@@ -516,16 +525,14 @@ void LLDBPlugin::OnLLDBStarted(LLDBEvent& event)
         break;
 
     case kDebugSessionTypeAttach: {
-        LLDBSettings settings;
-        m_raisOnBpHit = settings.Load().IsRaiseWhenBreakpointHit();
+        m_raisOnBpHit = settings.IsRaiseWhenBreakpointHit();
         CL_DEBUG("CODELITE>> LLDB started (attached)");
         m_connector.SetAttachedToProcess(event.GetSessionType() == kDebugSessionTypeAttach);
         // m_connector.Continue();
         break;
     }
     case kDebugSessionTypeNormal: {
-        LLDBSettings settings;
-        m_raisOnBpHit = settings.Load().IsRaiseWhenBreakpointHit();
+        m_raisOnBpHit = settings.IsRaiseWhenBreakpointHit();
         CL_DEBUG("CODELITE>> LLDB started (normal)");
         m_connector.Run();
         break;

--- a/LLDBDebugger/LLDBPlugin.cpp
+++ b/LLDBDebugger/LLDBPlugin.cpp
@@ -233,6 +233,15 @@ bool LLDBPlugin::ShowThreadNames() const
     return m_showThreadNames;
 }
 
+wxString LLDBPlugin::GetFilenameForDisplay(const wxString& fileName) const
+{
+    if(m_showFileNamesOnly) {
+	    return wxFileName(fileName).GetFullName();
+	} else {
+        return fileName;
+    }
+}
+
 clToolBar* LLDBPlugin::CreateToolBar(wxWindow* parent)
 {
     // Create the toolbar to be used by the plugin
@@ -513,6 +522,7 @@ void LLDBPlugin::OnLLDBStarted(LLDBEvent& event)
 
     const auto settings = LLDBSettings().Load();
     m_showThreadNames = settings.HasFlag(kLLDBOptionShowThreadNames);
+    m_showFileNamesOnly = settings.HasFlag(kLLDBOptionShowFileNamesOnly);
 
     InitializeUI();
     LoadLLDBPerspective();
@@ -755,7 +765,7 @@ void LLDBPlugin::InitializeUI()
                                                                    .Name(LLDB_BREAKPOINTS_PANE_NAME));
     }
     if(!m_callstack) {
-        m_callstack = new LLDBCallStackPane(parent, &m_connector);
+        m_callstack = new LLDBCallStackPane(parent, *this);
         m_mgr->GetDockingManager()->AddPane(m_callstack, wxAuiPaneInfo()
                                                              .MinSize(200, 200)
                                                              .Right()

--- a/LLDBDebugger/LLDBPlugin.h
+++ b/LLDBDebugger/LLDBPlugin.h
@@ -112,6 +112,8 @@ protected:
     void OnDebugShowCursor(clDebugEvent& event);
 
     void OnBuildStarting(clBuildEvent& event);
+    void OnRunToCursor(wxCommandEvent& event);
+    void OnJumpToCursor(wxCommandEvent& event);
 
     // LLDB events
     void OnLLDBCrashed(LLDBEvent& event);

--- a/LLDBDebugger/LLDBPlugin.h
+++ b/LLDBDebugger/LLDBPlugin.h
@@ -59,6 +59,7 @@ class LLDBPlugin : public IPlugin
     LLDBTooltip* m_tooltip;
     bool m_isPerspectiveLoaded;
     bool m_showThreadNames;
+    bool m_showFileNamesOnly;
 
     friend class LLDBTooltip;
 
@@ -74,6 +75,11 @@ public:
      * @brief Should thread name column be shown in thread pane?
      */
     bool ShowThreadNames() const;
+
+    /**
+     * @brief Maybe convert a path to filename only for display.
+     */
+    wxString GetFilenameForDisplay(const wxString& fileName) const;
 
 private:
     void TerminateTerminal();

--- a/LLDBDebugger/LLDBPlugin.h
+++ b/LLDBDebugger/LLDBPlugin.h
@@ -58,6 +58,8 @@ class LLDBPlugin : public IPlugin
     bool m_raisOnBpHit;
     LLDBTooltip* m_tooltip;
     bool m_isPerspectiveLoaded;
+    bool m_showThreadNames;
+
     friend class LLDBTooltip;
 
 public:
@@ -67,6 +69,11 @@ public:
     LLDBConnector* GetLLDB() { return &m_connector; }
 
     IManager* GetManager() { return m_mgr; }
+
+    /**
+     * @brief Should thread name column be shown in thread pane?
+     */
+    bool ShowThreadNames() const;
 
 private:
     void TerminateTerminal();

--- a/LLDBDebugger/LLDBPlugin.h
+++ b/LLDBDebugger/LLDBPlugin.h
@@ -112,7 +112,7 @@ protected:
     void OnDebugStepIn(clDebugEvent& event);
     void OnDebugStepOut(clDebugEvent& event);
     void OnToggleBreakpoint(clDebugEvent& event);
-    void OnToggleInerrupt(clDebugEvent& event);
+    void OnToggleInterrupt(clDebugEvent& event);
     void OnDebugTooltip(clDebugEvent& event);
     void OnDebugQuickDebug(clDebugEvent& event);
     void OnDebugCoreFile(clDebugEvent& event);
@@ -127,6 +127,8 @@ protected:
     void OnBuildStarting(clBuildEvent& event);
     void OnRunToCursor(wxCommandEvent& event);
     void OnJumpToCursor(wxCommandEvent& event);
+
+    void OnAddWatch(wxCommandEvent& event);
 
     // LLDB events
     void OnLLDBCrashed(LLDBEvent& event);

--- a/LLDBDebugger/LLDBProtocol/LLDBConnector.cpp
+++ b/LLDBDebugger/LLDBProtocol/LLDBConnector.cpp
@@ -247,6 +247,28 @@ void LLDBConnector::Continue()
     SendCommand(command);
 }
 
+void LLDBConnector::RunTo(const wxFileName& filename, int line)
+{
+    SendSingleBreakpointCommand(kCommandRunTo, filename, line);
+}
+
+void LLDBConnector::JumpTo(const wxFileName& filename, int line)
+{
+    SendSingleBreakpointCommand(kCommandJumpTo, filename, line);
+}
+
+void LLDBConnector::SendSingleBreakpointCommand(const eCommandType commandType, const wxFileName& filename, const int line)
+{
+    if(!IsCanInteract()) {
+        return;
+    }
+
+    LLDBCommand lldbCommand;
+    lldbCommand.SetCommandType(commandType);
+    lldbCommand.SetBreakpoints(LLDBBreakpoint::Vec_t { LLDBBreakpoint::Ptr_t(new LLDBBreakpoint(filename, line)) });
+    SendCommand(lldbCommand);
+}
+
 void LLDBConnector::Stop()
 {
     if(IsAttachedToProcess()) {
@@ -293,7 +315,7 @@ void LLDBConnector::DeleteBreakpoints()
         command.SetCommandType(kCommandDeleteBreakpoint);
         command.SetBreakpoints(m_pendingDeletionBreakpoints);
         SendCommand(command);
-        CL_DEBUGS(wxString() << "codelite: DeleteBreakpoints celar pending deletionbreakpoints queue");
+        CL_DEBUGS(wxString() << "codelite: DeleteBreakpoints clear pending deletionbreakpoints queue");
         m_pendingDeletionBreakpoints.clear();
 
     } else {

--- a/LLDBDebugger/LLDBProtocol/LLDBConnector.h
+++ b/LLDBDebugger/LLDBProtocol/LLDBConnector.h
@@ -213,6 +213,16 @@ public:
     void Continue();
 
     /**
+     * @brief Run and break on a specific file and line.
+     */
+    void RunTo(const wxFileName& filename, int line);
+
+    /**
+     * @brief Jump the program counter to a specific file and line.
+     */
+    void JumpTo(const wxFileName& filename, int line);
+
+    /**
      * @brief send request to the debugger to request the local varibles
      */
     void RequestLocals();
@@ -235,6 +245,7 @@ public:
      * at the debug server side
      */
     void RequestVariableChildren(int lldbId);
+
     /**
      * @brief stop the debugger
      */
@@ -342,6 +353,14 @@ protected:
      * @return true on success, false otherwise
      */
     bool ConnectToRemoteDebugger(const wxString& ip, int port, LLDBConnectReturnObject& ret, int timeout = 10);
+
+    /**
+     * @brief Send a breakpoint command with a single breakpoint location to codelite-lldb.
+     * @param commandType the command to send.
+     * @param filename the file to break on.
+     * @param line the line in @a file to break on.
+     */
+    void SendSingleBreakpointCommand(const eCommandType commandType, const wxFileName& filename, const int line);
 };
 
 #endif // LLDBCONNECTOR_H

--- a/LLDBDebugger/LLDBProtocol/LLDBEnums.h
+++ b/LLDBDebugger/LLDBProtocol/LLDBEnums.h
@@ -98,7 +98,8 @@ enum eCommandType {
 enum eLLDBOptions {
     kLLDBOptionRaiseCodeLite = 0x00000001,
     kLLDBOptionUseRemoteProxy = 0x00000002,
-    kLLDBOptionShowThreadNames = 0x00000004
+    kLLDBOptionShowThreadNames = 0x00000004,
+    kLLDBOptionShowFileNamesOnly = 0x00000008
 };
 
 enum eLLDBDebugSessionType {

--- a/LLDBDebugger/LLDBProtocol/LLDBEnums.h
+++ b/LLDBDebugger/LLDBProtocol/LLDBEnums.h
@@ -91,6 +91,8 @@ enum eCommandType {
     kCommandAddWatch,
     kCommandDeleteWatch,
     kCommandInterperterCommand,
+    kCommandRunTo,
+    kCommandJumpTo
 };
 
 enum eLLDBOptions {

--- a/LLDBDebugger/LLDBProtocol/LLDBEnums.h
+++ b/LLDBDebugger/LLDBProtocol/LLDBEnums.h
@@ -98,6 +98,7 @@ enum eCommandType {
 enum eLLDBOptions {
     kLLDBOptionRaiseCodeLite = 0x00000001,
     kLLDBOptionUseRemoteProxy = 0x00000002,
+    kLLDBOptionShowThreadNames = 0x00000004
 };
 
 enum eLLDBDebugSessionType {

--- a/LLDBDebugger/LLDBProtocol/LLDBThread.cpp
+++ b/LLDBDebugger/LLDBProtocol/LLDBThread.cpp
@@ -47,6 +47,7 @@ void LLDBThread::FromJSON(const JSONElement& json)
     m_active = json.namedObject("m_active").toBool();
     m_stopReason = json.namedObject("m_stopReason").toInt();
     m_stopReasonString = json.namedObject("m_stopReasonString").toString();
+    m_name = json.namedObject("m_name").toString();
 }
 
 JSONElement LLDBThread::ToJSON() const
@@ -59,6 +60,7 @@ JSONElement LLDBThread::ToJSON() const
     json.addProperty("m_active", m_active);
     json.addProperty("m_stopReason", m_stopReason);
     json.addProperty("m_stopReasonString", m_stopReasonString);
+    json.addProperty("m_name", m_name);
     return json;
 }
 

--- a/LLDBDebugger/LLDBProtocol/LLDBThread.h
+++ b/LLDBDebugger/LLDBProtocol/LLDBThread.h
@@ -39,6 +39,7 @@ class LLDBThread
     bool     m_active;
     int      m_stopReason;
     wxString m_stopReasonString;
+    wxString m_name;
 
 public:
     typedef std::vector<LLDBThread> Vect_t;
@@ -91,6 +92,18 @@ public:
     bool IsActive() const {
         return m_active;
     }
+
+    void SetName(const char *name) {
+        if(nullptr != name) {
+            this->m_name = name;
+        } else {
+            m_name.Clear();
+        }
+    }
+    const wxString &GetName() const {
+        return m_name;
+    }
+
     // Serialization API
     JSONElement ToJSON() const;
     void FromJSON(const JSONElement& json);

--- a/LLDBDebugger/LLDBSettingDialog.cpp
+++ b/LLDBDebugger/LLDBSettingDialog.cpp
@@ -38,6 +38,7 @@ LLDBSettingDialog::LLDBSettingDialog(wxWindow* parent)
     m_pgPropCallStackSize->SetValue((int)settings.GetMaxCallstackFrames());
     m_pgPropRaiseCodeLite->SetValue(settings.IsRaiseWhenBreakpointHit());
     m_pgShowThreadNames->SetValue(settings.HasFlag(kLLDBOptionShowThreadNames));
+    m_pgShowFileNamesOnly->SetValue(settings.HasFlag(kLLDBOptionShowFileNamesOnly));
     m_pgPropProxyPort->SetValue(settings.GetProxyPort());
     m_pgPropProxyIP->SetValue(settings.GetProxyIp());
     m_pgPropProxyType->SetChoiceSelection(settings.IsUsingRemoteProxy() ? 1 : 0);
@@ -58,6 +59,7 @@ void LLDBSettingDialog::Save()
     settings.SetMaxCallstackFrames(m_pgPropCallStackSize->GetValue().GetInteger());
     settings.EnableFlag(kLLDBOptionRaiseCodeLite, m_pgPropRaiseCodeLite->GetValue().GetBool());
     settings.EnableFlag(kLLDBOptionShowThreadNames, m_pgShowThreadNames->GetValue().GetBool());
+    settings.EnableFlag(kLLDBOptionShowFileNamesOnly, m_pgShowFileNamesOnly->GetValue().GetBool());
     settings.SetUseRemoteProxy(m_pgPropProxyType->GetChoiceSelection() == 1 ? true : false);
     settings.SetProxyIp(m_pgPropProxyIP->GetValue().GetString());
     settings.SetProxyPort(m_pgPropProxyPort->GetValue().GetInteger());

--- a/LLDBDebugger/LLDBSettingDialog.cpp
+++ b/LLDBDebugger/LLDBSettingDialog.cpp
@@ -37,6 +37,7 @@ LLDBSettingDialog::LLDBSettingDialog(wxWindow* parent)
     m_pgPropArraySize->SetValue((int)settings.GetMaxArrayElements());
     m_pgPropCallStackSize->SetValue((int)settings.GetMaxCallstackFrames());
     m_pgPropRaiseCodeLite->SetValue(settings.IsRaiseWhenBreakpointHit());
+    m_pgShowThreadNames->SetValue(settings.HasFlag(kLLDBOptionShowThreadNames));
     m_pgPropProxyPort->SetValue(settings.GetProxyPort());
     m_pgPropProxyIP->SetValue(settings.GetProxyIp());
     m_pgPropProxyType->SetChoiceSelection(settings.IsUsingRemoteProxy() ? 1 : 0);
@@ -56,6 +57,7 @@ void LLDBSettingDialog::Save()
     settings.SetMaxArrayElements(m_pgPropArraySize->GetValue().GetInteger());
     settings.SetMaxCallstackFrames(m_pgPropCallStackSize->GetValue().GetInteger());
     settings.EnableFlag(kLLDBOptionRaiseCodeLite, m_pgPropRaiseCodeLite->GetValue().GetBool());
+    settings.EnableFlag(kLLDBOptionShowThreadNames, m_pgShowThreadNames->GetValue().GetBool());
     settings.SetUseRemoteProxy(m_pgPropProxyType->GetChoiceSelection() == 1 ? true : false);
     settings.SetProxyIp(m_pgPropProxyIP->GetValue().GetString());
     settings.SetProxyPort(m_pgPropProxyPort->GetValue().GetInteger());

--- a/LLDBDebugger/LLDBThreadsView.cpp
+++ b/LLDBDebugger/LLDBThreadsView.cpp
@@ -38,7 +38,7 @@ LLDBThreadsView::LLDBThreadsView(wxWindow* parent, LLDBPlugin* plugin)
     m_plugin->GetLLDB()->Bind(wxEVT_LLDB_STOPPED, &LLDBThreadsView::OnLLDBStopped, this);
     m_plugin->GetLLDB()->Bind(wxEVT_LLDB_EXITED,  &LLDBThreadsView::OnLLDBExited,  this);
     m_plugin->GetLLDB()->Bind(wxEVT_LLDB_STARTED, &LLDBThreadsView::OnLLDBStarted, this);
-    
+
     const auto nameColumn = m_dvListCtrlThreads->GetColumn(1);
     if(nameColumn) {
         nameColumn->SetHidden(!m_plugin->ShowThreadNames());
@@ -99,7 +99,7 @@ void LLDBThreadsView::OnLLDBStopped(LLDBEvent& event)
         cols.push_back( thr.GetName() );
         cols.push_back( thr.GetStopReasonString() );
         cols.push_back( thr.GetFunc() );
-        cols.push_back( thr.GetFile() );
+        cols.push_back( m_plugin->GetFilenameForDisplay(thr.GetFile()) );
         cols.push_back( thr.GetLine() == wxNOT_FOUND ? wxString() : wxString() << thr.GetLine() );
         m_dvListCtrlThreads->AppendItem( cols, (wxUIntPtr) new LLDBThreadViewClientData(thr) );
     }

--- a/LLDBDebugger/LLDBThreadsView.cpp
+++ b/LLDBDebugger/LLDBThreadsView.cpp
@@ -39,6 +39,11 @@ LLDBThreadsView::LLDBThreadsView(wxWindow* parent, LLDBPlugin* plugin)
     m_plugin->GetLLDB()->Bind(wxEVT_LLDB_EXITED,  &LLDBThreadsView::OnLLDBExited,  this);
     m_plugin->GetLLDB()->Bind(wxEVT_LLDB_STARTED, &LLDBThreadsView::OnLLDBStarted, this);
     
+    const auto nameColumn = m_dvListCtrlThreads->GetColumn(1);
+    if(nameColumn) {
+        nameColumn->SetHidden(!m_plugin->ShowThreadNames());
+    }
+
     m_model.reset( new ThreadsModel( m_dvListCtrlThreads ) );
     m_dvListCtrlThreads->AssociateModel( m_model.get() );
 }
@@ -91,6 +96,7 @@ void LLDBThreadsView::OnLLDBStopped(LLDBEvent& event)
         }
         wxVector<wxVariant> cols;
         cols.push_back( thr.GetId() == wxNOT_FOUND ? wxString() : wxString() << thr.GetId() );
+        cols.push_back( thr.GetName() );
         cols.push_back( thr.GetStopReasonString() );
         cols.push_back( thr.GetFunc() );
         cols.push_back( thr.GetFile() );

--- a/LLDBDebugger/UI.cpp
+++ b/LLDBDebugger/UI.cpp
@@ -383,6 +383,9 @@ LLDBSettingDialogBase::LLDBSettingDialogBase(wxWindow* parent, wxWindowID id, co
     m_pgPropCallStackSize = m_pgMgrDisplayProperties->AppendIn( m_pgProp138,  new wxIntProperty( _("Backtrace frames"), wxPG_LABEL, 100) );
     m_pgPropCallStackSize->SetHelpString(_("Maximum number of frames to show in the callstack window"));
     
+    m_pgShowThreadNames = m_pgMgrDisplayProperties->AppendIn( m_pgProp138,  new wxBoolProperty( _("Show thread names"), wxPG_LABEL, 0) );
+    m_pgShowThreadNames->SetHelpString(_("Whether to show thread names in the thread pane (thread names can be set with, for example, pthread_setname_np() on Linux)."));
+    
     m_panel91 = new wxPanel(m_notebook87, wxID_ANY, wxDefaultPosition, wxDLG_UNIT(m_notebook87, wxSize(-1,-1)), wxTAB_TRAVERSAL);
     m_notebook87->AddPage(m_panel91, _("Types"), false);
     
@@ -564,6 +567,7 @@ LLDBThreadsViewBase::LLDBThreadsViewBase(wxWindow* parent, wxWindowID id, const 
     boxSizer115->Add(m_dvListCtrlThreads, 1, wxALL|wxEXPAND, WXC_FROM_DIP(2));
     
     m_dvListCtrlThreads->AppendTextColumn(_("#"), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(70), wxALIGN_LEFT);
+    m_dvListCtrlThreads->AppendTextColumn(_("Name"), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(-1), wxALIGN_LEFT);
     m_dvListCtrlThreads->AppendTextColumn(_("Stop Reason"), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(100), wxALIGN_LEFT);
     m_dvListCtrlThreads->AppendTextColumn(_("Function"), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(150), wxALIGN_LEFT);
     m_dvListCtrlThreads->AppendTextColumn(_("File"), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(200), wxALIGN_LEFT);

--- a/LLDBDebugger/UI.cpp
+++ b/LLDBDebugger/UI.cpp
@@ -386,6 +386,9 @@ LLDBSettingDialogBase::LLDBSettingDialogBase(wxWindow* parent, wxWindowID id, co
     m_pgShowThreadNames = m_pgMgrDisplayProperties->AppendIn( m_pgProp138,  new wxBoolProperty( _("Show thread names"), wxPG_LABEL, 0) );
     m_pgShowThreadNames->SetHelpString(_("Whether to show thread names in the thread pane (thread names can be set with, for example, pthread_setname_np() on Linux)."));
     
+    m_pgShowFileNamesOnly = m_pgMgrDisplayProperties->AppendIn( m_pgProp138,  new wxBoolProperty( _("Show filenames only"), wxPG_LABEL, 0) );
+    m_pgShowFileNamesOnly->SetHelpString(_("Whether to show complete file paths or just file names in the callstack, breakpoint and thread panes"));
+    
     m_panel91 = new wxPanel(m_notebook87, wxID_ANY, wxDefaultPosition, wxDLG_UNIT(m_notebook87, wxSize(-1,-1)), wxTAB_TRAVERSAL);
     m_notebook87->AddPage(m_panel91, _("Types"), false);
     

--- a/LLDBDebugger/UI.cpp
+++ b/LLDBDebugger/UI.cpp
@@ -102,9 +102,9 @@ LLDBOutputViewBase::LLDBOutputViewBase(wxWindow* parent, wxWindowID id, const wx
     boxSizer211->Add(m_dataview, 1, wxALL|wxEXPAND, WXC_FROM_DIP(2));
     
     m_dataview->AppendTextColumn(_("#"), m_dataview->GetColumnCount(), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(40), wxALIGN_LEFT);
+    m_dataview->AppendTextColumn(_("Function"), m_dataview->GetColumnCount(), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(200), wxALIGN_LEFT);
     m_dataview->AppendTextColumn(_("File"), m_dataview->GetColumnCount(), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(200), wxALIGN_LEFT);
     m_dataview->AppendTextColumn(_("Line"), m_dataview->GetColumnCount(), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(40), wxALIGN_LEFT);
-    m_dataview->AppendTextColumn(_("Function"), m_dataview->GetColumnCount(), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(200), wxALIGN_LEFT);
     m_panelConsole = new wxPanel(m_notebook205, wxID_ANY, wxDefaultPosition, wxDLG_UNIT(m_notebook205, wxSize(-1,-1)), wxTAB_TRAVERSAL);
     int m_panelConsoleImgIndex;
     m_panelConsoleImgIndex = m_notebook205_il->Add(wxXmlResource::Get()->LoadBitmap(wxT("16-console")));

--- a/LLDBDebugger/UI.h
+++ b/LLDBDebugger/UI.h
@@ -160,6 +160,7 @@ protected:
     wxPGProperty* m_pgProp138;
     wxPGProperty* m_pgPropArraySize;
     wxPGProperty* m_pgPropCallStackSize;
+    wxPGProperty* m_pgShowThreadNames;
     wxPanel* m_panel91;
     wxStyledTextCtrl* m_stcTypes;
     wxHyperlinkCtrl* m_hyperLink111;

--- a/LLDBDebugger/UI.h
+++ b/LLDBDebugger/UI.h
@@ -161,6 +161,7 @@ protected:
     wxPGProperty* m_pgPropArraySize;
     wxPGProperty* m_pgPropCallStackSize;
     wxPGProperty* m_pgShowThreadNames;
+    wxPGProperty* m_pgShowFileNamesOnly;
     wxPanel* m_panel91;
     wxStyledTextCtrl* m_stcTypes;
     wxHyperlinkCtrl* m_hyperLink111;

--- a/LLDBDebugger/UI.wxcp
+++ b/LLDBDebugger/UI.wxcp
@@ -1,7 +1,7 @@
 {
 	"metadata":	{
 		"m_generatedFilesDir":	".",
-		"m_objCounter":	221,
+		"m_objCounter":	223,
 		"m_includeFiles":	[],
 		"m_bitmapFunction":	"wxCrafternz79PnInitBitmapResources",
 		"m_bitmapsFile":	"UI_lldbdebugger_bitmaps.cpp",
@@ -3216,6 +3216,71 @@
 																			"type":	"multi-string",
 																			"m_label":	"Tooltip:",
 																			"m_value":	"Whether to show thread names in the thread pane (thread names can be set with, for example, pthread_setname_np() on Linux)."
+																		}, {
+																			"type":	"colour",
+																			"m_label":	"Bg Colour:",
+																			"colour":	"<Default>"
+																		}, {
+																			"type":	"choice",
+																			"m_label":	"Property Editor Control",
+																			"m_selection":	0,
+																			"m_options":	["", "TextCtrl", "Choice", "ComboBox", "CheckBox", "TextCtrlAndButton", "ChoiceAndButton", "SpinCtrl", "DatePickerCtrl"]
+																		}, {
+																			"type":	"choice",
+																			"m_label":	"Kind:",
+																			"m_selection":	3,
+																			"m_options":	["wxPropertyCategory", "wxIntProperty", "wxFloatProperty", "wxBoolProperty", "wxStringProperty", "wxLongStringProperty", "wxDirProperty", "wxArrayStringProperty", "wxFileProperty", "wxEnumProperty", "wxEditEnumProperty", "wxFlagsProperty", "wxDateProperty", "wxImageFileProperty", "wxFontProperty", "wxSystemColourProperty"]
+																		}, {
+																			"type":	"string",
+																			"m_label":	"String Value",
+																			"m_value":	""
+																		}, {
+																			"type":	"multi-string",
+																			"m_label":	"Choices:",
+																			"m_value":	""
+																		}, {
+																			"type":	"multi-string",
+																			"m_label":	"Array Integer Values",
+																			"m_value":	""
+																		}, {
+																			"type":	"bool",
+																			"m_label":	"Bool Value",
+																			"m_value":	false
+																		}, {
+																			"type":	"string",
+																			"m_label":	"Wildcard",
+																			"m_value":	""
+																		}, {
+																			"type":	"font",
+																			"m_label":	"Font:",
+																			"m_value":	""
+																		}, {
+																			"type":	"colour",
+																			"m_label":	"Initial Colour",
+																			"colour":	"<Default>"
+																		}],
+																	"m_events":	[],
+																	"m_children":	[]
+																}, {
+																	"m_type":	4486,
+																	"proportion":	0,
+																	"border":	5,
+																	"gbSpan":	"1,1",
+																	"gbPosition":	"0,0",
+																	"m_styles":	[],
+																	"m_sizerFlags":	[],
+																	"m_properties":	[{
+																			"type":	"string",
+																			"m_label":	"Name:",
+																			"m_value":	"m_pgShowFileNamesOnly"
+																		}, {
+																			"type":	"string",
+																			"m_label":	"Label:",
+																			"m_value":	"Show filenames only"
+																		}, {
+																			"type":	"multi-string",
+																			"m_label":	"Tooltip:",
+																			"m_value":	"Whether to show complete file paths or just file names in the callstack, breakpoint and thread panes"
 																		}, {
 																			"type":	"colour",
 																			"m_label":	"Bg Colour:",

--- a/LLDBDebugger/UI.wxcp
+++ b/LLDBDebugger/UI.wxcp
@@ -1,7 +1,7 @@
 {
 	"metadata":	{
 		"m_generatedFilesDir":	".",
-		"m_objCounter":	219,
+		"m_objCounter":	221,
 		"m_includeFiles":	[],
 		"m_bitmapFunction":	"wxCrafternz79PnInitBitmapResources",
 		"m_bitmapsFile":	"UI_lldbdebugger_bitmaps.cpp",
@@ -3196,6 +3196,71 @@
 																		}],
 																	"m_events":	[],
 																	"m_children":	[]
+																}, {
+																	"m_type":	4486,
+																	"proportion":	0,
+																	"border":	5,
+																	"gbSpan":	"1,1",
+																	"gbPosition":	"0,0",
+																	"m_styles":	[],
+																	"m_sizerFlags":	[],
+																	"m_properties":	[{
+																			"type":	"string",
+																			"m_label":	"Name:",
+																			"m_value":	"m_pgShowThreadNames"
+																		}, {
+																			"type":	"string",
+																			"m_label":	"Label:",
+																			"m_value":	"Show thread names"
+																		}, {
+																			"type":	"multi-string",
+																			"m_label":	"Tooltip:",
+																			"m_value":	"Whether to show thread names in the thread pane (thread names can be set with, for example, pthread_setname_np() on Linux)."
+																		}, {
+																			"type":	"colour",
+																			"m_label":	"Bg Colour:",
+																			"colour":	"<Default>"
+																		}, {
+																			"type":	"choice",
+																			"m_label":	"Property Editor Control",
+																			"m_selection":	0,
+																			"m_options":	["", "TextCtrl", "Choice", "ComboBox", "CheckBox", "TextCtrlAndButton", "ChoiceAndButton", "SpinCtrl", "DatePickerCtrl"]
+																		}, {
+																			"type":	"choice",
+																			"m_label":	"Kind:",
+																			"m_selection":	3,
+																			"m_options":	["wxPropertyCategory", "wxIntProperty", "wxFloatProperty", "wxBoolProperty", "wxStringProperty", "wxLongStringProperty", "wxDirProperty", "wxArrayStringProperty", "wxFileProperty", "wxEnumProperty", "wxEditEnumProperty", "wxFlagsProperty", "wxDateProperty", "wxImageFileProperty", "wxFontProperty", "wxSystemColourProperty"]
+																		}, {
+																			"type":	"string",
+																			"m_label":	"String Value",
+																			"m_value":	""
+																		}, {
+																			"type":	"multi-string",
+																			"m_label":	"Choices:",
+																			"m_value":	""
+																		}, {
+																			"type":	"multi-string",
+																			"m_label":	"Array Integer Values",
+																			"m_value":	""
+																		}, {
+																			"type":	"bool",
+																			"m_label":	"Bool Value",
+																			"m_value":	false
+																		}, {
+																			"type":	"string",
+																			"m_label":	"Wildcard",
+																			"m_value":	""
+																		}, {
+																			"type":	"font",
+																			"m_label":	"Font:",
+																			"m_value":	""
+																		}, {
+																			"type":	"colour",
+																			"m_label":	"Initial Colour",
+																			"colour":	"<Default>"
+																		}],
+																	"m_events":	[],
+																	"m_children":	[]
 																}]
 														}]
 												}]
@@ -4478,6 +4543,44 @@
 											"type":	"string",
 											"m_label":	"Width:",
 											"m_value":	"70"
+										}, {
+											"type":	"choice",
+											"m_label":	"Column Type",
+											"m_selection":	2,
+											"m_options":	["bitmap", "check", "text", "icontext", "progress", "choice"]
+										}, {
+											"type":	"multi-string",
+											"m_label":	"Choices:",
+											"m_value":	""
+										}, {
+											"type":	"choice",
+											"m_label":	"Alignment",
+											"m_selection":	0,
+											"m_options":	["wxALIGN_LEFT", "wxALIGN_RIGHT", "wxALIGN_CENTER"]
+										}, {
+											"type":	"choice",
+											"m_label":	"Cell Mode",
+											"m_selection":	0,
+											"m_options":	["wxDATAVIEW_CELL_INERT", "wxDATAVIEW_CELL_ACTIVATABLE", "wxDATAVIEW_CELL_EDITABLE"]
+										}],
+									"m_events":	[],
+									"m_children":	[]
+								}, {
+									"m_type":	4472,
+									"proportion":	0,
+									"border":	5,
+									"gbSpan":	"1,1",
+									"gbPosition":	"0,0",
+									"m_styles":	[],
+									"m_sizerFlags":	[],
+									"m_properties":	[{
+											"type":	"string",
+											"m_label":	"Name:",
+											"m_value":	"Name"
+										}, {
+											"type":	"string",
+											"m_label":	"Width:",
+											"m_value":	"-1"
 										}, {
 											"type":	"choice",
 											"m_label":	"Column Type",

--- a/LLDBDebugger/UI.wxcp
+++ b/LLDBDebugger/UI.wxcp
@@ -1002,6 +1002,44 @@
 															"m_properties":	[{
 																	"type":	"string",
 																	"m_label":	"Name:",
+																	"m_value":	"Function"
+																}, {
+																	"type":	"string",
+																	"m_label":	"Width:",
+																	"m_value":	"200"
+																}, {
+																	"type":	"choice",
+																	"m_label":	"Column Type",
+																	"m_selection":	2,
+																	"m_options":	["bitmap", "check", "text", "icontext", "progress", "choice"]
+																}, {
+																	"type":	"multi-string",
+																	"m_label":	"Choices:",
+																	"m_value":	""
+																}, {
+																	"type":	"choice",
+																	"m_label":	"Alignment",
+																	"m_selection":	0,
+																	"m_options":	["wxALIGN_LEFT", "wxALIGN_RIGHT", "wxALIGN_CENTER"]
+																}, {
+																	"type":	"choice",
+																	"m_label":	"Cell Mode",
+																	"m_selection":	0,
+																	"m_options":	["wxDATAVIEW_CELL_INERT", "wxDATAVIEW_CELL_ACTIVATABLE", "wxDATAVIEW_CELL_EDITABLE"]
+																}],
+															"m_events":	[],
+															"m_children":	[]
+														}, {
+															"m_type":	4472,
+															"proportion":	0,
+															"border":	5,
+															"gbSpan":	"1,1",
+															"gbPosition":	"0,0",
+															"m_styles":	[],
+															"m_sizerFlags":	[],
+															"m_properties":	[{
+																	"type":	"string",
+																	"m_label":	"Name:",
 																	"m_value":	"File"
 																}, {
 																	"type":	"string",
@@ -1045,44 +1083,6 @@
 																	"type":	"string",
 																	"m_label":	"Width:",
 																	"m_value":	"40"
-																}, {
-																	"type":	"choice",
-																	"m_label":	"Column Type",
-																	"m_selection":	2,
-																	"m_options":	["bitmap", "check", "text", "icontext", "progress", "choice"]
-																}, {
-																	"type":	"multi-string",
-																	"m_label":	"Choices:",
-																	"m_value":	""
-																}, {
-																	"type":	"choice",
-																	"m_label":	"Alignment",
-																	"m_selection":	0,
-																	"m_options":	["wxALIGN_LEFT", "wxALIGN_RIGHT", "wxALIGN_CENTER"]
-																}, {
-																	"type":	"choice",
-																	"m_label":	"Cell Mode",
-																	"m_selection":	0,
-																	"m_options":	["wxDATAVIEW_CELL_INERT", "wxDATAVIEW_CELL_ACTIVATABLE", "wxDATAVIEW_CELL_EDITABLE"]
-																}],
-															"m_events":	[],
-															"m_children":	[]
-														}, {
-															"m_type":	4472,
-															"proportion":	0,
-															"border":	5,
-															"gbSpan":	"1,1",
-															"gbPosition":	"0,0",
-															"m_styles":	[],
-															"m_sizerFlags":	[],
-															"m_properties":	[{
-																	"type":	"string",
-																	"m_label":	"Name:",
-																	"m_value":	"Function"
-																}, {
-																	"type":	"string",
-																	"m_label":	"Width:",
-																	"m_value":	"200"
 																}, {
 																	"type":	"choice",
 																	"m_label":	"Column Type",

--- a/LLDBDebugger/codelite-lldb/CodeLiteLLDBApp.cpp
+++ b/LLDBDebugger/codelite-lldb/CodeLiteLLDBApp.cpp
@@ -412,6 +412,7 @@ void CodeLiteLLDBApp::NotifyStopped()
         t.SetStopReason(thr.GetStopReason());
         t.SetId(thr.GetThreadID());
         t.SetActive(selectedThreadId == (int)thr.GetThreadID());
+        t.SetName(thr.GetName());
         lldb::SBFrame frame = thr.GetSelectedFrame();
         t.SetFunc(frame.GetFunctionName() ? frame.GetFunctionName() : "");
         lldb::SBLineEntry lineEntry = frame.GetLineEntry();

--- a/LLDBDebugger/codelite-lldb/CodeLiteLLDBApp.h
+++ b/LLDBDebugger/codelite-lldb/CodeLiteLLDBApp.h
@@ -47,7 +47,7 @@ struct VariableWrapper
     lldb::SBValue value;
     bool isWatch;
     wxString expression;
-    
+
     VariableWrapper() : isWatch(false) {}
 };
 
@@ -133,6 +133,8 @@ public:
     void StartDebugger(const LLDBCommand& command);
     void RunDebugger(const LLDBCommand& command);
     void Continue(const LLDBCommand& command);
+    void RunTo(const LLDBCommand& command);
+    void JumpTo(const LLDBCommand& command);
     void ApplyBreakpoints(const LLDBCommand& command);
     void StopDebugger(const LLDBCommand& command);
     void DetachDebugger(const LLDBCommand& command);

--- a/LLDBDebugger/codelite-lldb/LLDBNetworkServerThread.cpp
+++ b/LLDBDebugger/codelite-lldb/LLDBNetworkServerThread.cpp
@@ -66,7 +66,7 @@ void* LLDBNetworkServerThread::Entry()
                 case kCommandInterperterCommand:
                     m_app->CallAfter(&CodeLiteLLDBApp::ExecuteInterperterCommand, command);
                     break;
-                    
+
                 case kCommandAddWatch:
                     m_app->CallAfter(&CodeLiteLLDBApp::AddWatch, command);
                     break;
@@ -156,6 +156,14 @@ void* LLDBNetworkServerThread::Entry()
 
                 case kCommandEvalExpression:
                     m_app->CallAfter(&CodeLiteLLDBApp::EvalExpression, command);
+                    break;
+
+                case kCommandRunTo:
+                    m_app->CallAfter(&CodeLiteLLDBApp::RunTo, command);
+                    break;
+
+                case kCommandJumpTo:
+                    m_app->CallAfter(&CodeLiteLLDBApp::JumpTo, command);
                     break;
 
                 default:

--- a/LiteEditor/frame.cpp
+++ b/LiteEditor/frame.cpp
@@ -3553,7 +3553,7 @@ void clMainFrame::OnDebugCmd(wxCommandEvent& e)
         eventId = wxEVT_DBG_UI_NEXT_INST;
     }
 
-    // ALlow the plugins to handle this command first
+    // Allow the plugins to handle this command first
     clDebugEvent evnt(eventId);
     if(EventNotifier::Get()->ProcessEvent(evnt)) {
         return;
@@ -6186,6 +6186,11 @@ void clMainFrame::OnDebugShowCursorUI(wxUpdateUIEvent& e)
 
 void clMainFrame::OnDebugRunToCursor(wxCommandEvent& e)
 {
+    // Allow the plugins to handle this command first
+    if(EventNotifier::Get()->ProcessEvent(e)) {
+        return;
+    }
+
     IDebugger* dbgr = DebuggerMgr::Get().GetActiveDebugger();
     IEditor* editor = clGetManager()->GetActiveEditor();
     if(editor && dbgr && dbgr->IsRunning() && ManagerST::Get()->DbgCanInteract()) {
@@ -6200,6 +6205,11 @@ void clMainFrame::OnDebugRunToCursor(wxCommandEvent& e)
 
 void clMainFrame::OnDebugJumpToCursor(wxCommandEvent& e)
 {
+    // Allow the plugins to handle this command first
+    if(EventNotifier::Get()->ProcessEvent(e)) {
+        return;
+    }
+
     IDebugger* dbgr = DebuggerMgr::Get().GetActiveDebugger();
     IEditor* editor = clGetManager()->GetActiveEditor();
     if(editor && dbgr && dbgr->IsRunning() && ManagerST::Get()->DbgCanInteract()) {


### PR DESCRIPTION
Hello Eran

Here's a few features for lldb that can hopefully be integrated. A few notes:

- lukester1975/codelite@0331d6d: I use prctl(PR_SET_NAME, gettid(), "nice name") to set per-thread names, so it's nice (essential really) to see them in the debugger.
- lukester1975/codelite@3e25771: If you've expand a variable quite deep to get to some "interesting" fields, it's a shame to lose that expansion after stepping. So this just adds expansion beyond top-level (and handles collapsing).
- lukester1975/codelite@b2a5a0a: This might be controversial so I can remove it from the PR if you prefer. It's just my personal opinion that the columns should have the same order in each pane :smile:

Oh I guess the only other controversial thing might be the use of anonymous namespaces for a few file-scope things, since I read in the style guide you don't use namespaces. Anonymous ones are a slightly different case though I imagine...

Let me know if there's anything that needs fixing up to make it good to merge!

Thanks

Luke.
