### PR TITLE
Spellcheck context menu tweak

### DIFF
--- a/CallGraph/callgraph.cpp
+++ b/CallGraph/callgraph.cpp
@@ -205,25 +205,6 @@ void CallGraph::HookPopupMenu(wxMenu* menu, MenuType type)
 
 //-----------------------------------------------------------------------------
 
-void CallGraph::UnHookPopupMenu(wxMenu* menu, MenuType type)
-{
-    if(type == MenuTypeEditor) {
-        // TODO::Unhook items for the editor context menu
-    } else if(type == MenuTypeFileExplorer) {
-        // TODO::Unhook  items for the file explorer context menu
-    } else if(type == MenuTypeFileView_Workspace) {
-        // TODO::Unhook  items for the file view / workspace context menu
-    } else if(type == MenuTypeFileView_Project) {
-        // TODO::Unhook  items for the file view/Project context menu
-    } else if(type == MenuTypeFileView_Folder) {
-        // TODO::Unhook  items for the file view/Virtual folder context menu
-    } else if(type == MenuTypeFileView_File) {
-        // TODO::Unhook  items for the file view/file context menu
-    }
-}
-
-//-----------------------------------------------------------------------------
-
 void CallGraph::UnPlug()
 {
     // TODO:: perform the unplug action for this plugin

--- a/CallGraph/callgraph.h
+++ b/CallGraph/callgraph.h
@@ -85,9 +85,8 @@ public:
      * @brief Function unplug the plugin from CodeLite IDE.
      */
     virtual void UnPlug();
-    
+
     virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnHookPopupMenu(wxMenu* menu, MenuType type);
 
     /**
      * @brief Return string with value path for external application gprof which is stored in configuration data.

--- a/CodeLite/codelite_events.h
+++ b/CodeLite/codelite_events.h
@@ -439,7 +439,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_REBUILD_WORKSPACE_TREE, wxCommand
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_ACTIVE_PROJECT_CHANGED, clProjectSettingsEvent);
 
 // This event is fired by CodeLite before the find bar is shown
-// The handler can pass a wxStyledTextCtrl class pointer to be associated with the 
+// The handler can pass a wxStyledTextCtrl class pointer to be associated with the
 // find bar by using the clFindEvent::SetCtrl() method
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_FINDBAR_ABOUT_TO_SHOW, clFindEvent);
 
@@ -773,7 +773,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_PAGE_MODIFIED_UPDATE_UI, clComman
 // Send a clEditorConfig event. This event is sent whenever an editor requires
 // to update its properties (tabs vs spaces, EOL style etc)
 // A plugin may capture the event and send back EditorConfig data by doing the following:
-// Call: 
+// Call:
 // 1. event.Skip(false)
 // 2. Set the data using event.SetEditorConfig(...) method
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_EDITOR_CONFIG_LOADING, clEditorConfigEvent);

--- a/LLDBDebugger/LLDBPlugin.cpp
+++ b/LLDBDebugger/LLDBPlugin.cpp
@@ -332,12 +332,6 @@ void LLDBPlugin::HookPopupMenu(wxMenu* menu, MenuType type)
     }
 }
 
-void LLDBPlugin::UnHookPopupMenu(wxMenu* menu, MenuType type)
-{
-    wxUnusedVar(menu);
-    wxUnusedVar(type);
-}
-
 void LLDBPlugin::ClearDebuggerMarker()
 {
     IEditor::List_t editors;

--- a/LLDBDebugger/LLDBPlugin.h
+++ b/LLDBDebugger/LLDBPlugin.h
@@ -150,7 +150,6 @@ public:
     virtual clToolBar* CreateToolBar(wxWindow* parent);
     virtual void CreatePluginMenu(wxMenu* pluginsMenu);
     virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnHookPopupMenu(wxMenu* menu, MenuType type);
     virtual void UnPlug();
 };
 

--- a/MemCheck/memcheck.cpp
+++ b/MemCheck/memcheck.cpp
@@ -229,12 +229,6 @@ void MemCheckPlugin::HookPopupMenu(wxMenu* menu, MenuType type)
     }
 }
 
-void MemCheckPlugin::UnHookPopupMenu(wxMenu* menu, MenuType type)
-{
-    wxUnusedVar(menu);
-    wxUnusedVar(type);
-}
-
 void MemCheckPlugin::UnPlug()
 {
     m_tabHelper.reset(NULL);

--- a/MemCheck/memcheck.h
+++ b/MemCheck/memcheck.h
@@ -57,7 +57,6 @@ public:
     virtual clToolBar* CreateToolBar(wxWindow* parent);
     virtual void CreatePluginMenu(wxMenu* pluginsMenu);
     virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnHookPopupMenu(wxMenu* menu, MenuType type);
     virtual void UnPlug();
 
     MemCheckSettings* const GetSettings()

--- a/SFTP/sftp.cpp
+++ b/SFTP/sftp.cpp
@@ -201,12 +201,6 @@ bool SFTP::IsPaneDetached(const wxString& name) const
     return detachedPanes.Index(name) != wxNOT_FOUND;
 }
 
-void SFTP::UnHookPopupMenu(wxMenu* menu, MenuType type)
-{
-    wxUnusedVar(menu);
-    wxUnusedVar(type);
-}
-
 void SFTP::UnPlug()
 {
     // Find our page and release it

--- a/SFTP/sftp.h
+++ b/SFTP/sftp.h
@@ -104,12 +104,12 @@ protected:
     // e.GetLocalFile() -> the local file
     // e.GetRemoteFile() -> the target file
     void OnSaveFile(clSFTPEvent& e);
-    
+
     // Rename a remote file
     // e.GetRemoteFile() -> the "old" remote file path
     // e.GetNewRemoteFile() -> the "new" remote file path
     void OnRenameFile(clSFTPEvent& e);
-    
+
     // Delete a remote file
     // e.GetRemoteFile() -> the file to be deleted
     void OnDeleteFile(clSFTPEvent& e);
@@ -126,7 +126,6 @@ public:
     virtual clToolBar* CreateToolBar(wxWindow* parent);
     virtual void CreatePluginMenu(wxMenu* pluginsMenu);
     virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnHookPopupMenu(wxMenu* menu, MenuType type);
     virtual void UnPlug();
     IManager* GetManager() { return m_mgr; }
 

--- a/SpellChecker/spellcheck.cpp
+++ b/SpellChecker/spellcheck.cpp
@@ -56,9 +56,22 @@
 //#include "res/contCheck16.b2c"
 //#include "res/contCheck22.b2c"
 
-static SpellCheck* thePlugin = NULL;
-#define SPC_BASEID 10000
-#define PARSE_TIME 500
+namespace
+{
+
+SpellCheck* thePlugin = NULL;
+
+constexpr size_t maxSuggestions = 15;
+
+const int SPC_IGNORE_WORD = XRCID("spellcheck_ignore_word");
+const int SPC_ADD_WORD = XRCID("spellcheck_add_word");
+const int SPC_SUGGESTION_ID = wxWindow::NewControlId(maxSuggestions);
+const int IDM_SETTINGS = XRCID("spellcheck_settings");
+
+constexpr int PARSE_TIME = 500;
+
+}
+
 // ------------------------------------------------------------
 // Define the plugin entry point
 CL_PLUGIN_API IPlugin* CreatePlugin(IManager* manager)
@@ -90,21 +103,19 @@ SpellCheck::SpellCheck(IManager* manager)
 // ------------------------------------------------------------
 SpellCheck::~SpellCheck()
 {
-    m_topWin->Disconnect(
-        IDM_SETTINGS, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(SpellCheck::OnSettings), NULL, this);
-    m_topWin->Disconnect(XRCID(s_doCheckID.ToUTF8()),
-                         wxEVT_COMMAND_MENU_SELECTED,
-                         wxCommandEventHandler(SpellCheck::OnCheck),
-                         NULL,
-                         this);
-    m_topWin->Disconnect(XRCID(s_contCheckID.ToUTF8()),
-                         wxEVT_COMMAND_MENU_SELECTED,
-                         wxCommandEventHandler(SpellCheck::OnContinousCheck),
-                         NULL,
-                         this);
-    m_timer.Disconnect(wxEVT_TIMER, wxTimerEventHandler(SpellCheck::OnTimer), NULL, this);
-    m_topWin->Disconnect(wxEVT_CMD_EDITOR_CONTEXT_MENU, wxCommandEventHandler(SpellCheck::OnContextMenu), NULL, this);
-    m_topWin->Disconnect(wxEVT_WORKSPACE_CLOSED, wxCommandEventHandler(SpellCheck::OnWspClosed), NULL, this);
+    m_timer.Unbind(wxEVT_TIMER, &SpellCheck::OnTimer, this);
+
+    m_topWin->Unbind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnSettings, this, IDM_SETTINGS);
+    m_topWin->Unbind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnCheck, this, XRCID(s_doCheckID.ToUTF8()));
+    m_topWin->Unbind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnContinousCheck, this, XRCID(s_contCheckID.ToUTF8()));
+    m_topWin->Unbind(wxEVT_CONTEXT_MENU_EDITOR, &SpellCheck::OnContextMenu, this);
+    m_topWin->Unbind(wxEVT_WORKSPACE_LOADED, &SpellCheck::OnWspLoaded, this);
+    m_topWin->Unbind(wxEVT_WORKSPACE_CLOSED, &SpellCheck::OnWspClosed, this);
+
+    m_topWin->Unbind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnSuggestion, this, SPC_SUGGESTION_ID,
+        SPC_SUGGESTION_ID + maxSuggestions - 1);
+    m_topWin->Unbind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnAddWord, this, SPC_ADD_WORD);
+    m_topWin->Unbind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnIgnoreWord, this, SPC_IGNORE_WORD);
 
     if(m_pEngine != NULL) {
         SaveSettings();
@@ -137,11 +148,15 @@ void SpellCheck::Init()
 
         if(!m_options.GetDictionaryFileName().IsEmpty()) m_pEngine->InitEngine();
     }
-    m_timer.Connect(wxEVT_TIMER, wxTimerEventHandler(SpellCheck::OnTimer), NULL, this);
-    m_topWin->Connect(wxEVT_CMD_EDITOR_CONTEXT_MENU, wxCommandEventHandler(SpellCheck::OnContextMenu), NULL, this);
-    m_topWin->Connect(wxEVT_WORKSPACE_LOADED, wxCommandEventHandler(SpellCheck::OnWspLoaded), NULL, this);
-    m_topWin->Connect(wxEVT_WORKSPACE_CLOSED, wxCommandEventHandler(SpellCheck::OnWspClosed), NULL, this);
-    EventNotifier::Get()->Bind(wxEVT_CONTEXT_MENU_EDITOR, &SpellCheck::OnEditorContextMenuShowing, this);
+    m_timer.Bind(wxEVT_TIMER, &SpellCheck::OnTimer, this);
+    m_topWin->Bind(wxEVT_CONTEXT_MENU_EDITOR, &SpellCheck::OnContextMenu, this);
+    m_topWin->Bind(wxEVT_WORKSPACE_LOADED, &SpellCheck::OnWspLoaded, this);
+    m_topWin->Bind(wxEVT_WORKSPACE_CLOSED, &SpellCheck::OnWspClosed, this);
+
+    m_topWin->Bind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnSuggestion, this, SPC_SUGGESTION_ID,
+        SPC_SUGGESTION_ID + maxSuggestions - 1);
+    m_topWin->Bind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnAddWord, this, SPC_ADD_WORD);
+    m_topWin->Bind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnIgnoreWord, this, SPC_IGNORE_WORD);
 }
 // ------------------------------------------------------------
 clToolBar* SpellCheck::CreateToolBar(wxWindow* parent)
@@ -157,20 +172,12 @@ clToolBar* SpellCheck::CreateToolBar(wxWindow* parent)
         m_pToolbar->AddTool(XRCID(s_contCheckID.ToUTF8()),
                             _("Check continuous"),
                             m_mgr->GetStdIcons()->LoadBitmap("repeat", size),
-                            _("Run continuous check"),
+                            _("Run continuous spell-check"),
                             wxITEM_CHECK);
         m_pToolbar->Realize();
     }
-    parent->Connect(XRCID(s_doCheckID.ToUTF8()),
-                    wxEVT_COMMAND_MENU_SELECTED,
-                    wxCommandEventHandler(SpellCheck::OnCheck),
-                    NULL,
-                    this);
-    parent->Connect(XRCID(s_contCheckID.ToUTF8()),
-                    wxEVT_COMMAND_MENU_SELECTED,
-                    wxCommandEventHandler(SpellCheck::OnContinousCheck),
-                    NULL,
-                    this);
+    parent->Bind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnCheck, this, XRCID(s_doCheckID.ToUTF8()));
+    parent->Bind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnContinousCheck, this, XRCID(s_contCheckID.ToUTF8()));
 
     SetCheckContinuous(GetCheckContinuous());
 
@@ -186,40 +193,66 @@ void SpellCheck::CreatePluginMenu(wxMenu* pluginsMenu)
     pMenu->Append(pItem);
     pluginsMenu->Append(wxID_ANY, s_plugName, pMenu);
 
-    m_topWin->Connect(
-        IDM_SETTINGS, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(SpellCheck::OnSettings), NULL, this);
+    m_topWin->Bind(wxEVT_COMMAND_MENU_SELECTED, &SpellCheck::OnSettings, this, IDM_SETTINGS);
 }
 // ------------------------------------------------------------
-wxMenu* SpellCheck::CreateSubMenu()
+void SpellCheck::OnContextMenu(clContextMenuEvent& e)
 {
-    wxMenu* menu = new wxMenu();
+    const auto editor = GetEditor();
+    const auto menu = e.GetMenu();
+    if(!editor || !menu) {
+        return;
+    }
 
-    wxMenuItem* pItem(NULL);
-    pItem = new wxMenuItem(menu, XRCID(s_doCheckID.ToUTF8()), _("Check..."), _("Check..."), wxITEM_NORMAL);
-    menu->Append(pItem);
-    pItem = new wxMenuItem(
-        menu, XRCID(s_contCheckID.ToUTF8()), _("Check continuous"), _("Start continuous check"), wxITEM_CHECK);
-    menu->Append(pItem);
-    return menu;
+    const auto subMenuName(_("Spell Checker"));
+    auto pSubMenu(new wxMenu);
+
+    wxPoint pt = wxGetMousePosition();
+    pt = editor->GetCtrl()->ScreenToClient(pt);
+    const int pos = editor->GetCtrl()->PositionFromPoint(pt);
+
+    if(editor->GetCtrl()->IndicatorValueAt(3, pos) == 1) {
+        m_pLastEditor = nullptr;
+
+        int start = editor->WordStartPos(pos, true);
+        editor->SelectText(start, editor->WordEndPos(pos, true) - start);
+        wxString sel = editor->GetSelection();
+        wxArrayString sugg = m_pEngine->GetSuggestions(sel);
+
+        for(size_t i = 0; i < std::min<>(sugg.GetCount(), size_t(maxSuggestions)); i++) {
+            pSubMenu->Append(SPC_SUGGESTION_ID + i, sugg[i], "");
+        }
+
+        if(sugg.GetCount() != 0) {
+            pSubMenu->AppendSeparator();
+        }
+
+        pSubMenu->Append(SPC_IGNORE_WORD, _("Ignore"), "");
+        pSubMenu->Append(SPC_ADD_WORD, _("Add"), "");
+
+        pSubMenu->AppendSeparator();
+        AppendSubMenuItems(*pSubMenu);
+
+        // Place at top of context menu for ease of access.
+        menu->PrependSeparator();
+        menu->Prepend(wxID_ANY, subMenuName, pSubMenu);
+    }
+    else {
+        AppendSubMenuItems(*pSubMenu);
+        menu->Append(wxID_ANY, subMenuName, pSubMenu);
+    }
 }
 // ------------------------------------------------------------
-void SpellCheck::HookPopupMenu(wxMenu* menu, MenuType type)
+void SpellCheck::AppendSubMenuItems(wxMenu& subMenu)
 {
-    wxUnusedVar(menu);
-    wxUnusedVar(type);
+    subMenu.Append(XRCID(s_doCheckID.ToUTF8()), _("Check..."), _("Check..."));
+    subMenu.Append(XRCID(s_contCheckID.ToUTF8()), _("Check continuous"), _("Start continuous check"), wxITEM_CHECK);
+    subMenu.Check(XRCID(s_contCheckID.ToUTF8()), GetCheckContinuous());
+    subMenu.Append(IDM_SETTINGS, _("Settings..."), _("Settings..."), wxITEM_NORMAL);
 }
-
-// ------------------------------------------------------------
-void SpellCheck::UnHookPopupMenu(wxMenu* menu, MenuType type)
-{
-    wxUnusedVar(menu);
-    wxUnusedVar(type);
-}
-
 // ------------------------------------------------------------
 void SpellCheck::UnPlug()
 {
-    EventNotifier::Get()->Unbind(wxEVT_CONTEXT_MENU_EDITOR, &SpellCheck::OnEditorContextMenuShowing, this);
     if(m_timer.IsRunning()) m_timer.Stop();
 }
 
@@ -275,8 +308,10 @@ void SpellCheck::OnCheck(wxCommandEvent& e)
     text += wxT(" "); // prevents indicator flickering at end of file
 
     if(m_pEngine != NULL) {
-        if(GetCheckContinuous()) // switch continuous search off if running
+        if(GetCheckContinuous()) {
+            // switch continuous search off if running
             SetCheckContinuous(false);
+        }
 
         // if we don't have a dictionary yet, open settings
         if(!m_pEngine->GetDictionary()) {
@@ -285,7 +320,7 @@ void SpellCheck::OnCheck(wxCommandEvent& e)
         }
 
         switch(editor->GetLexerId()) {
-        case 3: { // wxSCI_LEX_CPP
+        case wxSTC_LEX_CPP: {
             if(m_mgr->IsWorkspaceOpen()) {
                 m_pEngine->CheckCppSpelling(text);
 
@@ -294,7 +329,7 @@ void SpellCheck::OnCheck(wxCommandEvent& e)
                 }
             }
         } break;
-        case 1: { // wxSCI_LEX_NULL
+        case wxSTC_LEX_NULL: {
             m_pEngine->CheckSpelling(text);
             if(!GetCheckContinuous()) {
                 editor->ClearUserIndicators();
@@ -355,12 +390,12 @@ void SpellCheck::OnContinousCheck(wxCommandEvent& e)
             wxString text = editor->GetEditorText();
 
             switch(editor->GetLexerId()) {
-            case 3: { // wxSCI_LEX_CPP
+            case wxSTC_LEX_CPP: {
                 if(m_mgr->IsWorkspaceOpen()) {
                     m_pEngine->CheckCppSpelling(text);
                 }
             } break;
-            default: { // wxSCI_LEX_NULL
+            default: {
                 m_pEngine->CheckSpelling(text);
             } break;
             }
@@ -382,77 +417,24 @@ void SpellCheck::OnTimer(wxTimerEvent& e)
     if(GetCheckContinuous()) {
         // Only run the checks if we've not run them or the file is modified.
         const auto modificationCount(editor->GetModificationCount());
-        if ((editor == m_pLastEditor) && (m_lastModificationCount == modificationCount))
+        if((editor == m_pLastEditor) && (m_lastModificationCount == modificationCount)) {
             return;
+        }
 
         m_pLastEditor = editor;
         m_lastModificationCount = modificationCount;
 
         switch(editor->GetLexerId()) {
-        case 3: { // wxSCI_LEX_CPP
+        case wxSTC_LEX_CPP: {
             if(m_mgr->IsWorkspaceOpen()) {
                 m_pEngine->CheckCppSpelling(editor->GetEditorText());
             }
         } break;
-        default: { // wxSCI_LEX_NULL
+        default: {
             m_pEngine->CheckSpelling(editor->GetEditorText());
         } break;
         }
     }
-}
-// ------------------------------------------------------------
-void SpellCheck::OnContextMenu(wxCommandEvent& e)
-{
-    m_pLastEditor = nullptr;
-
-    IEditor* editor = GetEditor();
-
-    if(!editor) {
-        e.Skip();
-        return;
-    }
-
-    wxPoint pt = wxGetMousePosition();
-    pt = editor->GetCtrl()->ScreenToClient(pt);
-    int pos = editor->GetCtrl()->PositionFromPoint(pt);
-
-    if(editor->GetCtrl()->IndicatorValueAt(3, pos) == 1) {
-        wxMenu popUp;
-        m_timer.Stop();
-
-        int start = editor->WordStartPos(pos, true);
-        editor->SelectText(start, editor->WordEndPos(pos, true) - start);
-        wxString sel = editor->GetSelection();
-        wxArrayString sugg = m_pEngine->GetSuggestions(sel);
-
-        for(wxUint32 i = 0; i < sugg.GetCount(); i++) {
-            popUp.Append(SPC_BASEID + i, sugg[i], "");
-        }
-
-        if(sugg.GetCount() == 0)
-            popUp.SetTitle(_("No suggestions"));
-        else
-            popUp.AppendSeparator();
-
-        popUp.Append(SPC_BASEID - 1, _("Ignore"), "");
-        popUp.Append(SPC_BASEID - 2, _("Add"), "");
-
-        int index = editor->GetCtrl()->GetPopupMenuSelectionFromUser(popUp);
-
-        if(index != wxID_NONE) {
-            if(index >= SPC_BASEID) {
-                index -= SPC_BASEID;
-                editor->ReplaceSelection(sugg[index]);
-            } else {
-                if(index == SPC_BASEID - 1)
-                    m_pEngine->AddWordToIgnoreList(sel);
-                else if(index == SPC_BASEID - 2)
-                    m_pEngine->AddWordToUserDict(sel);
-            }
-        }
-        m_timer.Start(PARSE_TIME);
-    } else
-        e.Skip();
 }
 // ------------------------------------------------------------
 void SpellCheck::SetCheckContinuous(bool value)
@@ -481,17 +463,60 @@ void SpellCheck::OnWspLoaded(wxCommandEvent& e)
 {
     m_currentWspPath = e.GetString();
     e.Skip();
-} // ------------------------------------------------------------
-void SpellCheck::OnWspClosed(wxCommandEvent& e) { e.Skip(); }
-
-void SpellCheck::OnEditorContextMenuShowing(clContextMenuEvent& e)
-{
-    e.Skip();
-    wxMenu* menu = CreateSubMenu();
-    menu->Check(XRCID(s_contCheckID.ToUTF8()), GetCheckContinuous());
-    e.GetMenu()->Append(IDM_BASE, _("Spell Checker"), menu);
 }
+// ------------------------------------------------------------
+void SpellCheck::OnWspClosed(wxCommandEvent& e) { e.Skip(); }
+// ------------------------------------------------------------
+void SpellCheck::OnSuggestion(wxCommandEvent& e)
+{
+    const auto editor = GetEditor();
+    if(!editor) {
+        return;
+    }
 
+    const auto pMenu = dynamic_cast<wxMenu *>(e.GetEventObject());
+    if(!pMenu) {
+        return;
+    }
+
+    const auto pMenuItem = pMenu->FindItem(e.GetId());
+    if(!pMenuItem) {
+        return;
+    }
+
+    editor->ReplaceSelection(pMenuItem->GetText());
+}
+// ------------------------------------------------------------
+void SpellCheck::OnIgnoreWord(wxCommandEvent& e)
+{
+    const auto editor = GetEditor();
+    if(!editor) {
+        return;
+    }
+
+    const auto selection = editor->GetSelection();
+    if(selection.IsEmpty()) {
+        return;
+    }
+
+    m_pEngine->AddWordToIgnoreList(selection);
+}
+// ------------------------------------------------------------
+void SpellCheck::OnAddWord(wxCommandEvent& e)
+{
+    const auto editor = GetEditor();
+    if(!editor) {
+        return;
+    }
+
+    const auto selection = editor->GetSelection();
+    if(selection.IsEmpty()) {
+        return;
+    }
+
+    m_pEngine->AddWordToUserDict(selection);
+}
+// ------------------------------------------------------------
 void SpellCheck::ClearIndicatorsFromEditors()
 {
     // Remove the indicators from all the editors

--- a/SpellChecker/spellcheck.h
+++ b/SpellChecker/spellcheck.h
@@ -50,7 +50,6 @@ public:
     void SetCheckContinuous(bool value);
     bool GetCheckContinuous() const { return m_options.GetCheckContinuous(); }
     IEditor* GetEditor();
-    wxMenu* CreateSubMenu();
 
     SpellCheck(IManager* manager);
     ~SpellCheck();
@@ -58,32 +57,32 @@ public:
     // --------------------------------------------
     // Abstract methods
     // --------------------------------------------
-    virtual clToolBar* CreateToolBar(wxWindow* parent);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnHookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    virtual clToolBar* CreateToolBar(wxWindow* parent) override;
+    virtual void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    virtual void UnPlug() override;
 
     void OnSettings(wxCommandEvent& e);
     void OnCheck(wxCommandEvent& e);
     void OnContinousCheck(wxCommandEvent& e);
-    void OnContextMenu(wxCommandEvent& e);
     void OnTimer(wxTimerEvent& e);
     void OnWspLoaded(wxCommandEvent& e);
     void OnWspClosed(wxCommandEvent& e);
-    void OnEditorContextMenuShowing(clContextMenuEvent& e);
+    void OnSuggestion(wxCommandEvent& e);
+    void OnIgnoreWord(wxCommandEvent& e);
+    void OnAddWord(wxCommandEvent& e);
 
     wxMenuItem* m_sepItem;
     wxEvtHandler* m_topWin;
     SpellCheckerOptions m_options;
     wxWindow* GetTopWnd() { return m_mgr->GetTheApp()->GetTopWindow(); }
-    enum { IDM_BASE = 20500, IDM_SETTINGS };
 
 protected:
     void Init();
     void LoadSettings();
     void SaveSettings();
     void ClearIndicatorsFromEditors();
+    void OnContextMenu(clContextMenuEvent& e);
+    void AppendSubMenuItems(wxMenu& subMenu);
 
 protected:
     IHunSpell* m_pEngine;

--- a/Tweaks/tweaks.cpp
+++ b/Tweaks/tweaks.cpp
@@ -123,12 +123,6 @@ void Tweaks::HookPopupMenu(wxMenu* menu, MenuType type)
     wxUnusedVar(type);
 }
 
-void Tweaks::UnHookPopupMenu(wxMenu* menu, MenuType type)
-{
-    wxUnusedVar(menu);
-    wxUnusedVar(type);
-}
-
 void Tweaks::OnSettings(wxCommandEvent& e)
 {
     wxUnusedVar(e);

--- a/Tweaks/tweaks.h
+++ b/Tweaks/tweaks.h
@@ -36,10 +36,10 @@ class Tweaks : public IPlugin
     typedef std::map<wxString, int> ProjectIconMap_t;
     TweaksSettings m_settings;
     ProjectIconMap_t m_project2Icon;
-    
+
 protected:
     IEditor* FindEditorByPage( wxWindow* page );
-    
+
 public:
     Tweaks(IManager *manager);
     ~Tweaks();
@@ -50,9 +50,8 @@ public:
     virtual clToolBar *CreateToolBar(wxWindow *parent);
     virtual void CreatePluginMenu(wxMenu *pluginsMenu);
     virtual void HookPopupMenu(wxMenu *menu, MenuType type);
-    virtual void UnHookPopupMenu(wxMenu *menu, MenuType type);
     virtual void UnPlug();
-    
+
     // Event handlers
     void OnSettings(wxCommandEvent &e);
     void OnColourTab(clColourEvent& e);

--- a/ZoomNavigator/zoomnavigator.cpp
+++ b/ZoomNavigator/zoomnavigator.cpp
@@ -247,8 +247,6 @@ void ZoomNavigator::PatchUpHighlights(const int first, const int last)
 
 void ZoomNavigator::HookPopupMenu(wxMenu* menu, MenuType type) {}
 
-void ZoomNavigator::UnHookPopupMenu(wxMenu* menu, MenuType type) {}
-
 void ZoomNavigator::OnPreviewClicked(wxMouseEvent& e)
 {
     IEditor* curEditor = m_mgr->GetActiveEditor();

--- a/ZoomNavigator/zoomnavigator.h
+++ b/ZoomNavigator/zoomnavigator.h
@@ -76,7 +76,6 @@ public:
     virtual clToolBar* CreateToolBar(wxWindow* parent);
     virtual void CreatePluginMenu(wxMenu* pluginsMenu);
     virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnHookPopupMenu(wxMenu* menu, MenuType type);
     virtual void UnPlug();
 
     void OnIdle(wxIdleEvent& e);

--- a/codelitephp/php-plugin/php.cpp
+++ b/codelitephp/php-plugin/php.cpp
@@ -214,12 +214,6 @@ void PhpPlugin::HookPopupMenu(wxMenu* menu, MenuType type)
     wxUnusedVar(type);
 }
 
-void PhpPlugin::UnHookPopupMenu(wxMenu* menu, MenuType type)
-{
-    wxUnusedVar(menu);
-    wxUnusedVar(type);
-}
-
 void PhpPlugin::UnPlug()
 {
 #if USE_SFTP

--- a/codelitephp/php-plugin/php.h
+++ b/codelitephp/php-plugin/php.h
@@ -91,7 +91,6 @@ public:
     virtual clToolBar* CreateToolBar(wxWindow* parent);
     virtual void CreatePluginMenu(wxMenu* pluginsMenu);
     virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnHookPopupMenu(wxMenu* menu, MenuType type);
     virtual void UnPlug();
     void RunXDebugDiagnostics();
 


### PR DESCRIPTION
Hi

I realised after making the continuous spell check option more persistent that if a word is misspelled, the editor context menu is completely replaced with the spell check context "suggestions" menu when right-clicking on that word - which is a bit unhelpful if you want to leave the word as-is but do something else from the regular context menu.

So here's a mod to make the suggestions appear in the regular spell-check content menu. I had to add UnHookPopupMenu() support (6c22d66) in order to be able to re-start the spell-check timer.

If there are spelling suggestions then the spell-check sub-menu gets put at the top of the context menu (or the top until some other plugin puts something else on top of it...). I don't know if that's controversial or not :smile:

Also, because of using HookPopupMenu() rather than hooking wxEVT_CONTEXT_MENU_EDITOR, the spell-check sub-menu will appear in a slightly different place when there are no suggestions. I guess it could use wxEVT_CONTEXT_MENU_EDITOR and not HookPopupMenu() but leave UnHookPopupMenu() in order to reset the timer if that's a concern. It just didn't seem very symmetrical that way! 

Anyway, if you think it's a good idea and there are any tweaks needed let me know...

Thanks

Luke.
