### PR TITLE
Keyword "wxOVERRIDE" cannot be compiled under wxWidgets 3.0

### DIFF
--- a/Plugin/clToolBar.h
+++ b/Plugin/clToolBar.h
@@ -28,7 +28,7 @@ protected:
     void OnMotion(wxMouseEvent& event);
     void OnEnterWindow(wxMouseEvent& event);
     void OnLeaveWindow(wxMouseEvent& event);
-    virtual void UpdateWindowUI(long flags = wxUPDATE_UI_NONE) wxOVERRIDE;
+    virtual void UpdateWindowUI(long flags = wxUPDATE_UI_NONE) override;
     void DoIdleUpdate();
     wxRect CalculateRect(wxDC& dc) const;
     void EnableFlag(eFlags f, bool b)

--- a/Plugin/clToolBarButtonBase.h
+++ b/Plugin/clToolBarButtonBase.h
@@ -5,6 +5,7 @@
 #include <wx/bitmap.h>
 #include <wx/dc.h>
 #include <wx/string.h>
+#include <wx/settings.h>
 
 #define CL_TOOL_BAR_X_MARGIN 5
 #define CL_TOOL_BAR_Y_MARGIN 5


### PR DESCRIPTION
I believe that we don't need to adapt to compiler without C++11 support, because lambda expression has used in many place of this repository, which is also not able to be compiled by non-C++11.