### PR TITLE
Fix compilation issue with GCC 8.x

### DIFF
--- a/Plugin/clGenericSTCStyler.h
+++ b/Plugin/clGenericSTCStyler.h
@@ -4,6 +4,7 @@
 #include "codelite_exports.h"
 #include <tuple>
 #include <vector>
+#include <algorithm>
 #include <wx/event.h>
 #include <wx/sharedptr.h>
 #include <wx/stc/stc.h>


### PR DESCRIPTION
```#include <algorithm>``` to fix compilation with GCC 8.x.

Without this, I get

```
../Plugin/clGenericSTCStyler.cpp:98:10: error: ‘for_each’ is not a member of ‘std’
     std::for_each(m_styleInfo.begin(), m_styleInfo.end(), [&](const std::tuple<int, wxColour, wxColour>& t) {
          ^~~~~~~~
../Plugin/clGenericSTCStyler.cpp:98:10: note: suggested alternative: ‘forward’
     std::for_each(m_styleInfo.begin(), m_styleInfo.end(), [&](const std::tuple<int, wxColour, wxColour>& t) {
          ^~~~~~~~
          forward
```