### PR TITLE
Compiling error.

### DIFF
--- a/Plugin/unredobase.h
+++ b/Plugin/unredobase.h
@@ -28,8 +28,8 @@
 
 #include "codelite_exports.h"
 #include <vector>
-#include <wx/aui/auibar.h>
 #include <wx/bitmap.h>
+#include <wx/aui/auibar.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
 #include <wx/sharedptr.h>


### PR DESCRIPTION
auibar.h uses wxBitmap class that will depend on bitmap.h. So I've put bitmap.h in front of auibar.h.