### PR TITLE
Fix wxSimpleBook and wxCollapsiblePane XRC

### DIFF
--- a/wxcrafter/collapsible_pane_wrapper.cpp
+++ b/wxcrafter/collapsible_pane_wrapper.cpp
@@ -46,7 +46,7 @@ void CollapsiblePaneWrapper::ToXRC(wxString& text, XRC_TYPE type) const
         text << "<style>wxCP_NO_TLW_RESIZE</style>";
 
     } else {
-        text << "<collapsed>" << PropertyString(PROP_COLLAPSED) << "</collapsed>";
+        text << XRCStyle()  << "<collapsed>" << PropertyString(PROP_COLLAPSED) << "</collapsed>";
     }
 
     ChildrenXRC(text, type);

--- a/wxcrafter/simple_book_wrapper.cpp
+++ b/wxcrafter/simple_book_wrapper.cpp
@@ -6,6 +6,13 @@
 SimpleBookWrapper::SimpleBookWrapper()
     : NotebookBaseWrapper(ID_WXSIMPLEBOOK)
 {
+    // Remove styles added by NotebookBaseWrapper
+    REMOVE_STYLE(wxBK_DEFAULT);
+    REMOVE_STYLE(wxBK_LEFT);
+    REMOVE_STYLE(wxBK_RIGHT);
+    REMOVE_STYLE(wxBK_TOP);
+    REMOVE_STYLE(wxBK_BOTTOM);
+
     RegisterEvent(wxT("wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED"), wxT("wxNotebookEvent"),
                   _("The page selection was changed"));
     RegisterEvent(wxT("wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGING"), wxT("wxNotebookEvent"),


### PR DESCRIPTION
Great you made this open source. Now I can fix my reported issues myself. See #785 and #1585.

I had some issues getting the `wxCrafter` project to build, it seems to be missing the `wxcLib` project file. I build the stand-alone version, and the menu icons seem to be missing.