### PR TITLE
FixDependenciesGeneration

### DIFF
--- a/Plugin/builder_gnumake.cpp
+++ b/Plugin/builder_gnumake.cpp
@@ -789,9 +789,7 @@ void BuilderGnuMake::CreateFileTargets(ProjectPtr proj, const wxString& confToBu
                 }
 
                 // set the file rule
-                text << objectName << wxT(": ") << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << wxT(" ") << dependFile
-                     << wxT("\n");
-                text << wxT("\t") << compilationLine << wxT("\n");
+                text << objectName << wxT(": ") << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << wxT("\n");
 
                 wxString cmpOptions(wxT("$(CXXFLAGS) $(IncludePCH)"));
                 if(isCFile) { cmpOptions = wxT("$(CFLAGS)"); }
@@ -802,11 +800,11 @@ void BuilderGnuMake::CreateFileTargets(ProjectPtr proj, const wxString& confToBu
 
                 wxString compilerMacro = DoGetCompilerMacro(rel_paths.at(i).GetFullPath(wxPATH_UNIX));
                 if(generateDependenciesFiles) {
-                    text << dependFile << wxT(": ") << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << wxT("\n");
                     text << wxT("\t") << wxT("@") << compilerMacro << wxT(" ") << cmpOptions
                          << wxT(" $(IncludePath) -MG -MP -MT") << objectName << wxT(" -MF") << dependFile
-                         << wxT(" -MM ") << source_file_to_compile << wxT("\n\n");
+                         << wxT(" -MM ") << source_file_to_compile << wxT("\n");
                 }
+                text << wxT("\t") << compilationLine << wxT("\n");
 
                 if(supportPreprocessOnlyFiles) {
                     text << preprocessedFile << wxT(": ") << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << wxT("\n");


### PR DESCRIPTION
Mostly following http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/

Combining Compilation and Dependency Generation rule.

Currently dependencies are regenerated only when source is modified, but not when its dependencies are modified.

Steps to reproduce issue:
foo.c -> foo.h (-> means include)
compile foo.c
change foo.h to include bar.h
build: foo.c compiled (normal)
modify bar.h
build : foo.c should be compiled (and it is not)

Similar bug:
foo.c -> foo.h -> bar.h (-> means include)
compile foo.c
change foo.h to not include bar.h
build: foo.c compiled (normal)
modify bar.h
build : foo.c should not be compiled (and it is)