### PR TITLE
fix add libraries paths not working

### DIFF
--- a/CMakePlugin/CMakeGenerator.cpp
+++ b/CMakePlugin/CMakeGenerator.cpp
@@ -335,6 +335,7 @@ wxString CMakeGenerator::GenerateProject(ProjectPtr project, bool topProject, co
             includePath.Trim(false).Trim();
             // Replace standard macros with CMake variables
             includePath.Replace("$(WorkspacePath)", "${WORKSPACE_PATH}");
+            includePath.Replace("$(WorkspaceConfiguration)", "${CONFIGURATION_NAME}");
             includePath.Replace("$(ProjectPath)", projectPathVariableValue);
             if(includePath.IsEmpty()) { continue; }
             content << "    " << includes.Item(i) << "\n";
@@ -448,6 +449,7 @@ wxString CMakeGenerator::GenerateProject(ProjectPtr project, bool topProject, co
             wxString libPath = lib_paths_list.Item(i);
             // Replace standard macros with CMake variables
             libPath.Replace("$(WorkspacePath)", "${WORKSPACE_PATH}");
+            libPath.Replace("$(WorkspaceConfiguration)", "${CONFIGURATION_NAME}");
             libPath.Replace("$(ProjectPath)", projectPathVariableValue);
             ::WrapWithQuotes(libPath);
             lib_paths << "    \"" << libPath << "\"\n";

--- a/CMakePlugin/CMakeGenerator.cpp
+++ b/CMakePlugin/CMakeGenerator.cpp
@@ -424,7 +424,7 @@ wxString CMakeGenerator::GenerateProject(ProjectPtr project, bool topProject, co
     // Add libraries paths
     {
         wxString lib_paths = buildConf->GetLibPath();
-        wxString lib_switch = "-L";
+        //wxString lib_switch = "-L";
 
         // Get switch from compiler
         if(compiler) {
@@ -450,11 +450,11 @@ wxString CMakeGenerator::GenerateProject(ProjectPtr project, bool topProject, co
             libPath.Replace("$(WorkspacePath)", "${WORKSPACE_PATH}");
             libPath.Replace("$(ProjectPath)", projectPathVariableValue);
             ::WrapWithQuotes(libPath);
-            lib_paths << lib_switch << libPath << " ";
+            lib_paths << "    \"" << libPath << "\"\n";
         }
 
         content << "# Library path\n";
-        content << "set(CMAKE_LDFLAGS \"${CMAKE_LDFLAGS} " << lib_paths << "\")\n\n";
+        content << "link_directories(\n" << lib_paths << "\")\n\n";
     }
 
     // Write sources


### PR DESCRIPTION
fix Issue #2243. 
Change from modifying CMAKE_LDFLAGS to using link_directories().