### PR TITLE
Fix CMakeGenerator generates unnecessary quotes

### DIFF
--- a/CMakePlugin/CMakeGenerator.cpp
+++ b/CMakePlugin/CMakeGenerator.cpp
@@ -452,7 +452,7 @@ wxString CMakeGenerator::GenerateProject(ProjectPtr project, bool topProject, co
         }
 
         content << "# Library path\n";
-        content << "link_directories(\n" << lib_paths << "\")\n\n";
+        content << "link_directories(\n" << lib_paths << ")\n\n";
     }
 
     // Write sources


### PR DESCRIPTION
On the commit https://github.com/eranif/codelite/commit/e6b449f6b67ae30a5c81d7b013d9f9571a59c97c  
The quotes at the beginning of a single line in LIB_PATH have been deleted.The content will output one more quote when the final output.
Finally it will become like this
```cpp
link_directories(
    .
    D:/project/codelite/mylib/output/
")
```
This will cause CMake to generate an error, So i removed the last quote to fix it.
```cpp
//old
//content << "link_directories(\n" << lib_paths << "\")\n\n";
//new
//content << "link_directories(\n" << lib_paths << ")\n\n";
```