### PR TITLE
Adding --no-factory flag to gnome-terminal in order to prevent it...

### DIFF
--- a/CodeLite/clConsoleGnomeTerminal.cpp
+++ b/CodeLite/clConsoleGnomeTerminal.cpp
@@ -53,7 +53,7 @@ static bool search_process_by_command(const wxString& name, wxString& tty, long&
 
 clConsoleGnomeTerminal::clConsoleGnomeTerminal()
 {
-    SetTerminalCommand("/usr/bin/gnome-terminal --working-directory=%WD% -e '%COMMAND%'");
+    SetTerminalCommand("/usr/bin/gnome-terminal --disable-factory --working-directory=%WD% -e '%COMMAND%'");
     SetEmptyTerminalCommand("/usr/bin/gnome-terminal --working-directory=%WD%");
 }
 


### PR DESCRIPTION
from attaching to the existing running gnome-terminal. This is needed in order for the terminal to appear when running Codelite via SSH -x. Tested and works fine locally as well.

https://github.com/eranif/codelite/issues/2248