### PR TITLE
Fix some problems with c++ code completion and vim plugin

### DIFF
--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -2983,7 +2983,7 @@ void clEditor::DoUpdateRelativeLineNumbers()
     m_lastBeginLine = beginLine;
     m_lastLineCount = lineCount;
     m_lastEndLine = endLine;
-    MarginSetText(curLine, (wxString() << " " << (curLine)));
+    MarginSetText(curLine, (wxString() << " " << (curLine + 1)));
 
     // Use a distinct style to highlight the current line number
     StyleSetBackground(CUR_LINE_NUMBER_STYLE, m_selTextBgColour);

--- a/Plugin/wxCodeCompletionBoxManager.cpp
+++ b/Plugin/wxCodeCompletionBoxManager.cpp
@@ -128,6 +128,7 @@ int GetWordStartPos(wxStyledTextCtrl* ctrl, int from, bool includeNekudotaiim)
         if((ch >= 97 && ch <= 122)       // a-z
            || (ch >= 65 && ch <= 90)     // A-Z
            || (ch == '_') || (ch == '$') // _ or $ (for PHP)
+           || (ch >= '0' && ch <= '9')
            || (includeNekudotaiim && (ch == ':'))) {
             continue;
         }


### PR DESCRIPTION
VIM: Support np command
VIM: The current line of the relative line number starts from 1.
Fix code completion errors when keywords contain numbers