### PR TITLE
FIxing search prefix for the C++ docset  (cpp,not c++)

### DIFF
--- a/HelpPlugin/HelpPluginSettings.cpp
+++ b/HelpPlugin/HelpPluginSettings.cpp
@@ -2,7 +2,7 @@
 
 HelpPluginSettings::HelpPluginSettings()
     : clConfigItem("HelpPlugin")
-    , m_cxxDocset("c++,net,boost,qt 4,qt 5,cvcpp,cocos2dx,c,manpages")
+    , m_cxxDocset("cpp,net,boost,qt 4,qt 5,cvcpp,cocos2dx,c,manpages")
     , m_phpDocset("php,wordpress,drupal,zend,laravel,yii,joomla,ee,codeigniter,cakephp,phpunit,symfony,typo3,twig,"
                   "smarty,phpp,html,statamic,mysql,sqlite,mongodb,psql,redis,zend framework 1,zend framework 2")
     , m_htmlDocset(


### PR DESCRIPTION
Hello,
this enables help plugin to cooperate with Zeal browser out of the box again.
Thanks for merge
   zbyna