### PR TITLE
Fix for compatibility with wxWidgets 3.1.3

### DIFF
--- a/CodeLite/JSON.cpp
+++ b/CodeLite/JSON.cpp
@@ -549,6 +549,6 @@ bool JSONItem::isNumber() const
 JSONItem JSONItem::detachProperty(const wxString& name)
 {
     if(!_json) { return JSONItem(NULL); }
-    cJSON* j = cJSON_DetachItemFromObject(_json, name);
+    cJSON* j = cJSON_DetachItemFromObject(_json, name.c_str());
     return JSONItem(j);
 }

--- a/CodeLite/LSP/ResponseMessage.cpp
+++ b/CodeLite/LSP/ResponseMessage.cpp
@@ -60,7 +60,7 @@ JSONItem LSP::ResponseMessage::Get(const wxString& property) const
 
 int LSP::ResponseMessage::ReadHeaders(const wxString& message, wxStringMap_t& headers)
 {
-    int where = message.Index(wxString("\r\n\r\n"));
+    int where = message.Find("\r\n\r\n");
     if(where == wxNOT_FOUND) { return wxNOT_FOUND; }
     wxString headerSection = message.Mid(0, where); // excluding the "\r\n\r\n"
     wxArrayString lines = ::wxStringTokenize(headerSection, "\n", wxTOKEN_STRTOK);

--- a/codelite_terminal/wxTerminalOptions.cpp
+++ b/codelite_terminal/wxTerminalOptions.cpp
@@ -65,8 +65,13 @@ wxTerminalOptions& wxTerminalOptions::Save()
 
 void wxTerminalOptions::SetHistory(const wxArrayString& history)
 {
-    if(history.size() > 501) {
-        m_history = wxArrayString(history.begin(), history.begin() + 500);
+    const std::size_t threshold = 500;
+    if(history.size() > threshold + 1) {
+        m_history = wxArrayString();
+        m_history.Alloc(threshold);
+        for(std::size_t i = 0; i < threshold; ++i) {
+            m_history.Add(history[i]);
+        }
     } else {
         m_history = history;
     }


### PR DESCRIPTION
Hello

I tried to build current version of the CodeLite on opensuse-tumbleweed with 'wxWidgets 3.1.3'(as written in wx-3.1/wx/version.h) and faced with some issues. In the documentation those methods/ctors are not present, so I replaced it with methods/ctors from docs.