### PR TITLE
Define wxCONTROL_NONE when wx version is before 3.1.0

### DIFF
--- a/Plugin/clRowEntry.cpp
+++ b/Plugin/clRowEntry.cpp
@@ -12,6 +12,10 @@
 #include <wx/window.h>
 #include <drawingutils.h>
 
+#if !wxCHECK_VERSION(3, 1, 0)
+#define wxCONTROL_NONE 0
+#endif
+
 #ifdef __WXMSW__
 #define PEN_STYLE wxPENSTYLE_SHORT_DASH
 #else


### PR DESCRIPTION
I am working on getting the MSys2 MinGW package to build and this patch looked like one to push upstream. Tim S.