### PR TITLE
Fix for various warnings

### DIFF
--- a/CallGraph/dotwriter.cpp
+++ b/CallGraph/dotwriter.cpp
@@ -51,6 +51,7 @@ DotWriter::DotWriter()
     dwce = 0;
     dwtn = 0;
     dwte = 0;
+    m_writedotfileFlag = false;
     dwhideparams = false;
     dwhidenamespaces = false;
     dwstripparams = false;

--- a/CodeCompletionsTests/CCTest/tester.cpp
+++ b/CodeCompletionsTests/CCTest/tester.cpp
@@ -47,8 +47,8 @@ void Tester::RunTests()
 	if(success == totalTests) {
 		printf("    All tests passed successfully!!\n");
 	} else {
-		printf("    %u of %u tests passed\n", (int)success, (int)totalTests);
-		printf("    %u of %u tests failed\n", (int)errors,  (int)totalTests);
+		printf("    %u of %u tests passed\n", (unsigned int)success, (unsigned int)totalTests);
+		printf("    %u of %u tests failed\n", (unsigned int)errors,  (unsigned int)totalTests);
 	}
 }
 

--- a/CodeLite/CxxPreProcessor.cpp
+++ b/CodeLite/CxxPreProcessor.cpp
@@ -3,7 +3,8 @@
 #include "file_logger.h"
 
 CxxPreProcessor::CxxPreProcessor()
-    : m_maxDepth(-1)
+    : m_options(0)
+    , m_maxDepth(-1)
     , m_currentDepth(0)
 {
 }

--- a/CodeLite/CxxScannerBase.cpp
+++ b/CodeLite/CxxScannerBase.cpp
@@ -5,6 +5,7 @@
 CxxScannerBase::CxxScannerBase(CxxPreProcessor* preProcessor, const wxFileName& filename)
     : m_scanner(NULL)
     , m_filename(filename)
+    , m_options(0)
     , m_preProcessor(preProcessor)
 {
     wxString content;

--- a/CodeLite/CxxVariable.h
+++ b/CodeLite/CxxVariable.h
@@ -71,6 +71,7 @@ public:
     CxxVariable(eCxxStandard standard);
     CxxVariable()
         : m_standard(eCxxStandard::kCxx11)
+        , m_isAuto(false)
     {
     }
 

--- a/CodeLite/UnixProcess.cpp
+++ b/CodeLite/UnixProcess.cpp
@@ -96,7 +96,7 @@ bool UnixProcess::ReadAll(int fd, std::string& content, int timeoutMilliseconds)
 bool UnixProcess::Write(int fd, const std::string& message, std::atomic_bool& shutdown)
 {
     int bytes = 0;
-    std::string tmp = std::move(message);
+    std::string tmp = message;
     const int chunkSize = 4096;
     while(!tmp.empty() && !shutdown.load()) {
         errno = 0;

--- a/CodeLite/archive.cpp
+++ b/CodeLite/archive.cpp
@@ -105,7 +105,10 @@ static void SetCDATANodeContent(wxXmlNode* node, const wxString& text)
 }
 
 // class Tab info
-TabInfo::TabInfo() {}
+TabInfo::TabInfo()
+    : m_firstVisibleLine(0)
+    , m_currentLine(0)
+{}
 
 TabInfo::~TabInfo() {}
 

--- a/CodeLite/clGotoEntry.cpp
+++ b/CodeLite/clGotoEntry.cpp
@@ -10,5 +10,6 @@ clGotoEntry::clGotoEntry(const wxString& desc, const wxString& shortcut, int id)
 
 clGotoEntry::clGotoEntry()
     : m_resourceID(wxNOT_FOUND)
+    , m_flags(0)
 {
 }

--- a/CodeLite/cl_calltip.cpp
+++ b/CodeLite/cl_calltip.cpp
@@ -39,6 +39,11 @@ struct tagCallTipInfo {
     std::vector<std::pair<int, int> > paramLen;
 };
 
+clCallTip::clCallTip()
+    : m_curr(0)
+{
+}
+
 clCallTip::clCallTip(const std::vector<TagEntryPtr>& tips)
     : m_curr(0)
 {
@@ -51,6 +56,7 @@ clCallTip& clCallTip::operator=(const clCallTip& rhs)
 {
     if(this == &rhs) return *this;
     m_tips = rhs.m_tips;
+    m_curr = rhs.m_curr;
     return *this;
 }
 

--- a/CodeLite/cl_calltip.h
+++ b/CodeLite/cl_calltip.h
@@ -67,7 +67,7 @@ public:
     /**
      * default constructor
      */
-    clCallTip() {}
+    clCallTip();
 
     /**
      * Copy constructor

--- a/CodeLite/cl_command_event.cpp
+++ b/CodeLite/cl_command_event.cpp
@@ -29,6 +29,8 @@ clCommandEvent::clCommandEvent(wxEventType commandType, int winid)
     : wxCommandEvent(commandType, winid)
     , m_answer(false)
     , m_allowed(true)
+    , m_lineNumber(0)
+    , m_selected(false)
 {
 }
 

--- a/CodeLite/cl_ssh.cpp
+++ b/CodeLite/cl_ssh.cpp
@@ -97,6 +97,11 @@ clSSH::clSSH(const wxString& host, const wxString& user, const wxString& pass, i
 
 clSSH::clSSH()
     : m_port(22)
+    , m_connected(false)
+    , m_session(NULL)
+    , m_channel(NULL)
+    , m_timer(NULL)
+    , m_owner(NULL)
 {
 }
 

--- a/CodeLite/parsedtoken.h
+++ b/CodeLite/parsedtoken.h
@@ -171,6 +171,7 @@ public:
     TokenContainer()
         : head(NULL)
         , current(NULL)
+        , rew(false)
         , retries(0)
     {
     }

--- a/CommentParser/CommentParser/comment_parser.h
+++ b/CommentParser/CommentParser/comment_parser.h
@@ -41,7 +41,7 @@ public:
 	{
 		std::map<size_t, std::string>::const_iterator iter = m_comments.begin();
 		for(; iter != m_comments.end(); iter++) {
-			printf("Line   : %d\n", (unsigned int)iter->first);
+			printf("Line   : %u\n", (unsigned int)iter->first);
 			printf("Comment:\n%s\n", iter->second.c_str());
 		}
 	}

--- a/DatabaseExplorer/IDbAdapter.h
+++ b/DatabaseExplorer/IDbAdapter.h
@@ -54,7 +54,11 @@ public:
         atPOSTGRES
     };
     
-    IDbAdapter() {}
+    IDbAdapter()
+        : m_adapterType(atUNKNOWN)
+    {
+    }
+
     virtual ~IDbAdapter() {}
     
     /*! \brief Return opened DatabaseLayer for selected database. If dbName is empty, DatabaseLayer will be opend without defalut database. */

--- a/DatabaseExplorer/MySqlDbAdapter.cpp
+++ b/DatabaseExplorer/MySqlDbAdapter.cpp
@@ -448,10 +448,10 @@ IDbType* MySqlDbAdapter::ConvertType(IDbType* pType)
 	if (!newType) {
 		newType = GetDbTypeByUniversalName(pType->GetUniversalType());
 		delete pType;
-		pType = NULL;
 	}
 	return newType;
 }
+
 IDbType* MySqlDbAdapter::GetDbTypeByUniversalName(IDbType::UNIVERSAL_TYPE type)
 {
 	IDbType* newType = NULL;

--- a/DatabaseExplorer/PostgreSqlDbAdapter.cpp
+++ b/DatabaseExplorer/PostgreSqlDbAdapter.cpp
@@ -539,10 +539,10 @@ IDbType* PostgreSqlDbAdapter::ConvertType(IDbType* pType) {
 	if (!newType) {
 		newType = GetDbTypeByUniversalName(pType->GetUniversalType());
 		delete pType;
-		pType = NULL;
 	}
 	return newType;
 }
+
 IDbType* PostgreSqlDbAdapter::GetDbTypeByUniversalName(IDbType::UNIVERSAL_TYPE type) {
 	IDbType* newType = NULL;
 	switch (type) {

--- a/DatabaseExplorer/SqlCommandPanel.h
+++ b/DatabaseExplorer/SqlCommandPanel.h
@@ -52,7 +52,10 @@ public:
     typedef std::vector<ColumnInfo> Vector_t;
 
 public:
-    ColumnInfo() {}
+    ColumnInfo()
+        : m_type(0)
+    {
+    }
 
     ColumnInfo(int type, const wxString& name)
         : m_type(type)

--- a/DatabaseExplorer/SqliteDbAdapter.cpp
+++ b/DatabaseExplorer/SqliteDbAdapter.cpp
@@ -321,10 +321,10 @@ IDbType* SQLiteDbAdapter::ConvertType(IDbType* pType) {
 	if (!newType ) {
 		newType = (SqliteType*) GetDbTypeByUniversalName(pType->GetUniversalType());
 		delete pType;
-		pType = NULL;
 	}
 	return newType;
 }
+
 IDbType* SQLiteDbAdapter::GetDbTypeByUniversalName(IDbType::UNIVERSAL_TYPE type) {
 	IDbType* newType = NULL;
 	switch (type) {

--- a/ExternalTools/externaltoolsdata.cpp
+++ b/ExternalTools/externaltoolsdata.cpp
@@ -26,7 +26,9 @@
 #include "externaltoolsdata.h"
 
 ToolInfo::ToolInfo()
-    : m_flags(0)
+    : m_captureOutput(false)
+    , m_saveAllFiles(false)
+    , m_flags(0)
 {
 }
 

--- a/Interfaces/debugger.h
+++ b/Interfaces/debugger.h
@@ -625,8 +625,10 @@ protected:
 
 public:
     IDebugger()
-        : m_env(NULL)
-        , m_isRemoteDebugging(false){};
+        : m_observer(NULL)
+        , m_env(NULL)
+        , m_isRemoteDebugging(false)
+        , m_isRemoteExtended(false){};
     virtual ~IDebugger(){};
     void SetProjectName(const wxString& project) { m_debuggeeProjectName = project; }
     void SetName(const wxString& name) { m_name = name; }

--- a/LLDBDebugger/LLDBProtocol/LLDBCommand.h
+++ b/LLDBDebugger/LLDBProtocol/LLDBCommand.h
@@ -63,6 +63,7 @@ public:
         : m_commandType(kCommandInvalid)
         , m_interruptReason(kInterruptReasonNone)
         , m_lldbId(0)
+        , m_frameId(0)
         , m_processID(wxNOT_FOUND)
         , m_displayFormat((int)eLLDBFormat::kFormatDefault)
     {

--- a/LLDBDebugger/LLDBProtocol/LLDBThread.cpp
+++ b/LLDBDebugger/LLDBProtocol/LLDBThread.cpp
@@ -30,6 +30,7 @@ LLDBThread::LLDBThread()
     : m_id(wxNOT_FOUND)
     , m_line(wxNOT_FOUND)
     , m_active(false)
+    , m_suspended(false)
     , m_stopReason( kStopReasonInvalid )
 {
 }

--- a/LLDBDebugger/LLDBProtocol/LLDBVariable.h
+++ b/LLDBDebugger/LLDBProtocol/LLDBVariable.h
@@ -68,6 +68,7 @@ public:
         : m_valueChanged(false)
         , m_lldbId(wxNOT_FOUND)
         , m_hasChildren(false)
+        , m_isWatch(false)
     {
     }
     virtual ~LLDBVariable();

--- a/codelite-stdio/UnixProcess.cpp
+++ b/codelite-stdio/UnixProcess.cpp
@@ -89,7 +89,7 @@ bool UnixProcess::ReadAll(int fd, std::string& content, int timeoutMilliseconds)
 bool UnixProcess::Write(int fd, const std::string& message, std::atomic_bool& shutdown)
 {
     int bytes = 0;
-    std::string tmp = std::move(message);
+    std::string tmp = message;
     const int chunkSize = 4096;
     while(!tmp.empty() && !shutdown.load()) {
         errno = 0;

--- a/codelitegcc/main.cpp
+++ b/codelitegcc/main.cpp
@@ -40,11 +40,12 @@ void WriteContent( const std::string& logfile, const std::string& filename, cons
     int fd = ::open(logfile.c_str(), O_CREAT|O_APPEND, 0660);
     ::chmod(logfile.c_str(), 0660);
 
-    // Lock it
     if ( fd < 0 )
         return;
 
+    // Lock it
     if(::flock(fd, LOCK_EX) < 0) {
+        ::close(fd);
         return;
     }
 
@@ -84,7 +85,7 @@ int main(int argc, char **argv)
     if ( argc < 2 ) {
         return -1;
     }
-    
+
     StringVec_t file_names;
     const char *pdb = getenv("CL_COMPILATION_DB");
     std::string commandline;
@@ -96,7 +97,7 @@ int main(int argc, char **argv)
         if ( is_source_file( arg, file_name ) ) {
             file_names.push_back( file_name );
         }
-        
+
         // re-escape double quotes if needed
         size_t pos = arg.find('"');
         while ( pos != std::string::npos ) {
@@ -146,7 +147,7 @@ bool is_source_file(const std::string& filename, std::string &fixed_file_name)
     extensions.push_back(".cxx");
     extensions.push_back(".cc");
     extensions.push_back(".c");
-    
+
     for(size_t n=0; n<extensions.size(); ++n) {
         if ( ends_with(filename, extensions.at(n)) ) {
             fixed_file_name = filename;


### PR DESCRIPTION
This patch should reduce warnings(~ not initialized in ctor, dead assigment) from compilers and static analyzers;

I don't know why a diff for codelitegcc/main.cpp is so funny. I barely changed it.

P.S. I could try to fix other similar warnings and/or make code more c++11 and/or try to configure travis-ci for a project if you don't mind.