### PR TITLE
Initial musl C library support.

### DIFF
--- a/codelitegcc/main.cpp
+++ b/codelitegcc/main.cpp
@@ -32,7 +32,7 @@ extern int ExecuteProcessWIN(const std::string& commandline);
 #include <sys/wait.h>
 #include <sys/file.h>
 #include <sys/stat.h>
-#include <sys/stat.h>
+#include <fcntl.h>
 
 void WriteContent( const std::string& logfile, const std::string& filename, const std::string& flags )
 {

--- a/sdk/codelite_indexer/libctags/read.c
+++ b/sdk/codelite_indexer/libctags/read.c
@@ -605,6 +605,9 @@ extern int readChars (char *buffer, size_t bufferSize, fpos_t location, fpos_t e
 #if defined(__WXMSW__) || defined(__APPLE__) || defined(__FreeBSD__)
 	if(location < 0)
 		return 0;
+#elif defined(__linux__) && !defined(__GLIBC__) /* musl */
+	if(location.__lldata < 0)
+		return 0;
 #else
 	if(location.__pos < 0)
 		return 0;
@@ -619,6 +622,8 @@ extern int readChars (char *buffer, size_t bufferSize, fpos_t location, fpos_t e
 
 #if defined(__WXMSW__) || defined(__APPLE__) || defined(__FreeBSD__)
 	sizeToRead = endPos - location;
+#elif defined(__linux__) && !defined(__GLIBC__) /* musl */
+	sizeToRead = endPos.__lldata - location.__lldata;
 #else
 	sizeToRead = endPos.__pos - location.__pos;
 #endif

--- a/sdk/codelite_indexer/network/named_pipe.cpp
+++ b/sdk/codelite_indexer/network/named_pipe.cpp
@@ -27,9 +27,9 @@
 
 #ifndef __WXMSW__
 #  include <sys/types.h>
-#  include <sys/unistd.h>
 #  include <sys/socket.h>
 #  include <sys/time.h>
+#  include <unistd.h>
 #endif
 
 #ifdef __WXMSW__

--- a/sdk/codelite_indexer/network/named_pipe_server.cpp
+++ b/sdk/codelite_indexer/network/named_pipe_server.cpp
@@ -26,8 +26,8 @@
 #include "named_pipe_server.h"
 #ifndef __WXMSW__
 # include <sys/types.h>
-# include <sys/unistd.h>
 # include <sys/socket.h>
+# include <unistd.h>
 #endif
 clNamedPipeServer::clNamedPipeServer(const char* pipePath)
 		: clNamedPipe(pipePath)


### PR DESCRIPTION
- fcntl.h was needed for O_APPEND
- Remove dup headers
- use correct fpos_t member
- <sys/unistd.h> -> <unistd.h>

Tested on voidlinux/x86_64-musl.