### PR TITLE
Fix phpstan intergration

### DIFF
--- a/PHPLint/phplint.cpp
+++ b/PHPLint/phplint.cpp
@@ -197,7 +197,8 @@ void PHPLint::QueuePhpstanCommand(const wxString& phpPath, const wxString& file)
     wxString phpstanPath = phpstan.GetFullPath();
     ::WrapWithQuotes(phpstanPath);
 
-    m_queue.push_back(phpPath + " " + phpstanPath + " analyze --errorFormat=checkstyle --no-progress " + file);
+    m_queue.push_back(phpPath + " " + phpstanPath + " analyze -c " + wxGetCwd() +
+                      "/phpstan.neon --error-format=checkstyle --no-progress " + file);
 }
 
 void PHPLint::DoProcessQueue()
@@ -279,6 +280,11 @@ void PHPLint::ProcessXML(const wxString& lintOutput)
 
     // Find the editor
     wxString filename = file->GetAttribute("name");
+    if(!filename.StartsWith("/")) {
+        // relative path
+        filename.Prepend(wxGetCwd() + "/");
+    }
+
     clDEBUG() << "PHPLint: searching editor for file:" << filename << clEndl;
     IEditor* editor = m_mgr->FindEditor(filename);
     CHECK_PTR_RET(editor);

--- a/PHPLint/phplint.cpp
+++ b/PHPLint/phplint.cpp
@@ -280,7 +280,7 @@ void PHPLint::ProcessXML(const wxString& lintOutput)
 
     // Find the editor
     wxString filename = file->GetAttribute("name");
-    if(!filename.StartsWith("/")) {
+    if(!wxFileName(filename).IsAbsolute()) {
         // relative path
         filename.Prepend(wxGetCwd() + "/");
     }

--- a/PHPLint/phplintdlg.wxcp
+++ b/PHPLint/phplintdlg.wxcp
@@ -1677,10 +1677,6 @@
                  "m_label": "Style:",
                  "m_value": ""
                 }, {
-                 "type": "multi-string",
-                 "m_label": "Label:",
-                 "m_value": "Phpstan-config:"
-                }, {
                  "type": "string",
                  "m_label": "Wrap:",
                  "m_value": "-1"
@@ -1707,10 +1703,6 @@
                  "type": "string",
                  "m_label": "Minimum Size:",
                  "m_value": "-1,-1"
-                }, {
-                 "type": "string",
-                 "m_label": "Name:",
-                 "m_value": "m_filePickerPhpstanConfig"
                 }, {
                  "type": "multi-string",
                  "m_label": "Tooltip:",

--- a/PHPLint/phplintdlgbase.cpp
+++ b/PHPLint/phplintdlgbase.cpp
@@ -131,15 +131,6 @@ PHPLintBaseDlg::PHPLintBaseDlg(wxWindow* parent, wxWindowID id, const wxString& 
     
     flexGridSizer3->Add(m_filePickerPhpstanPhar, 0, wxALL|wxEXPAND, WXC_FROM_DIP(5));
     
-    m_staticText4 = new wxStaticText(m_panelPhpstan, wxID_ANY, _("Phpstan-config:"), wxDefaultPosition, wxDLG_UNIT(m_panelPhpstan, wxSize(-1,-1)), 0);
-    
-    flexGridSizer3->Add(m_staticText4, 0, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, WXC_FROM_DIP(5));
-    
-    m_filePickerPhpstanConfig = new wxFilePickerCtrl(m_panelPhpstan, wxID_ANY, wxEmptyString, _("Select a file"), wxT("*.neon"), wxDefaultPosition, wxDLG_UNIT(m_panelPhpstan, wxSize(-1,-1)), wxFLP_USE_TEXTCTRL|wxFLP_SMALL);
-    m_filePickerPhpstanConfig->SetToolTip(_("Select the neon rules file to use with Phpstan"));
-    
-    flexGridSizer3->Add(m_filePickerPhpstanConfig, 0, wxALL|wxEXPAND, WXC_FROM_DIP(5));
-    
     wxBoxSizer* bSizerButtons = new wxBoxSizer(wxHORIZONTAL);
     
     bSizerMain->Add(bSizerButtons, 0, wxALL|wxALIGN_CENTER_HORIZONTAL, WXC_FROM_DIP(5));

--- a/PHPLint/phplintdlgbase.h
+++ b/PHPLint/phplintdlgbase.h
@@ -56,8 +56,6 @@ protected:
     wxPanel* m_panelPhpstan;
     wxStaticText* m_staticText3;
     wxFilePickerCtrl* m_filePickerPhpstanPhar;
-    wxStaticText* m_staticText4;
-    wxFilePickerCtrl* m_filePickerPhpstanConfig;
     wxStdDialogButtonSizer* m_stdBtnSizer;
     wxButton* m_buttonOK;
     wxButton* m_buttonCancel;
@@ -78,8 +76,6 @@ public:
     wxPanel* GetPanelPhpmd() { return m_panelPhpmd; }
     wxStaticText* GetStaticText3() { return m_staticText3; }
     wxFilePickerCtrl* GetFilePickerPhpstanPhar() { return m_filePickerPhpstanPhar; }
-    wxStaticText* GetStaticText4() { return m_staticText4; }
-    wxFilePickerCtrl* GetFilePickerPhpstanConfig() { return m_filePickerPhpstanConfig; }
     wxPanel* GetPanelPhpstan() { return m_panelPhpstan; }
     wxNotebook* GetNotebook() { return m_notebook; }
     PHPLintBaseDlg(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("PHP Linter Options"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(-1,-1), long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);


### PR DESCRIPTION
The the `errorFormat` parameter name appears to have been changed.

Path are relative to CWD in phpstan https://github.com/phpstan/phpstan/issues/2019

Drop input for phpstan config as this wasn't fully implemented.

Assume that phpstan.neon exists for the current project root. This is
required because else the output will contain a notice that breaks the
XML. (note it's on stderr but we still include it in the output buffer for some reason)