### PR TITLE
Add CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  linux:
+    docker:
+      - image: debian:buster
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run: apt-get update -y
+      - run: apt-get install -y libgtk2.0-dev pkg-config build-essential git cmake libssh-dev libwxbase3.0-dev libsqlite3-dev libwxsqlite3-3.0-dev
+      - run: mkdir build-release
+      - run: cd build-release && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+      - run: cd build-release && make -j$(nproc)
+
+workflows:
+  version: 2
+  testflow:
+    jobs:
+      - linux

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/build-release/


### PR DESCRIPTION
This way we can see if a PR breaks the Linux (Debian 10) builds

Also, ignore the build-release folder since it is the suggested folder by the readme.