### PR TITLE
vimode Visual selection changes and visual delete with x.

### DIFF
--- a/codelite_vim/vimCommands.h
+++ b/codelite_vim/vimCommands.h
@@ -283,6 +283,7 @@ private:
     COMMAND_PART m_currentCommandPart; /*!< current part of the command */
     VIM_MODI m_currentModus;           /*!< actual mode the editor is in */
     bool m_saveCommand;
+    long m_initialVisualPos;           /*!< initial position of cursor when changing to visual mode*/
     /*~~~~~~~~ COMMAND ~~~~~~~~~*/
     int m_repeat;           /*!< number of repetition for the command */
     wxChar m_baseCommand;   /*!< base command (first char of the cmd)*/


### PR DESCRIPTION
Modified visual mode selection to act like vim, previously when going backwards,
the selection did not extend to the very first character under the cursor. Yank
and delete where also changed to select the character under the cursor for a
forwards selection.

I also included a minor change where x can now be used to delete the selection
again in line with vim.