### PR TITLE
Use CMake to run the build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,10 @@ jobs:
       - run: apt-get update -y
       - run: apt-get install -y libgtk2.0-dev pkg-config build-essential git cmake libssh-dev libwxbase3.0-dev libsqlite3-dev libwxsqlite3-3.0-dev
       - run: mkdir build-release
-      - run: cd build-release && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release .. -DMAKE_DEB=1
-      - run: cd build-release && make -j4
+      - run: cd build-release && cmake .. -DCMAKE_BUILD_TYPE=Release -DMAKE_DEB=1
+      - run: cd build-release && cmake --build . --target package -j 4
+      - run: mkdir deb && mv build-release/*.deb deb
+      - store_artifacts: {path: ./deb}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run: apt-get install -y libgtk2.0-dev pkg-config build-essential git cmake libssh-dev libwxbase3.0-dev libsqlite3-dev libwxsqlite3-3.0-dev
       - run: mkdir build-release
       - run: cd build-release && cmake .. -DCMAKE_BUILD_TYPE=Release -DMAKE_DEB=1
-      - run: cd build-release && cmake --build . --target package -j 4
+      - run: cd build-release && cmake --build . --target package -j $(getconf _NPROCESSORS_ONLN)
       - run: mkdir deb && mv build-release/*.deb deb
       - store_artifacts: {path: ./deb}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,10 +232,10 @@ if ( WITH_SFTP )
             if (UNIX AND NOT APPLE )
                 ## Linux / FreeBSD
                 message("**** NOTICE: Install libssh-dev and try again")
-            else (UNIX AND NOT APPLE )
+            elseif (NOT MINGW )
                 ## OSX
                 message("**** NOTICE: Install libssh and try again (brew install libssh)")
-            endif (UNIX AND NOT APPLE )
+            endif ()
             message(FATAL_ERROR "-- Could not find libssh")
         endif( LIBSSH_NOT_FOUND_POS GREATER -1 )
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ More information can be found here:
  - [Official Website][3]
  - [Download Page][4]
  - [Wiki][5]
- 
+
 ----------
 
 Building CodeLite on Linux
@@ -42,12 +42,14 @@ Git clone the sources:
 
 Run CMake and build CodeLite:
 
-    cd codelite
-    mkdir build-release
-    cd build-release
-    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
-    make -j
-    sudo make install
+  ```bash
+  cd codelite
+  mkdir build-release
+  cd build-release
+  cmake .. -DCMAKE_BUILD_TYPE=Release
+  cmake --build . -j $(nproc)
+  sudo cmake --build . --target install
+  ```
 
 ----------
 
@@ -62,7 +64,7 @@ Prerequisites:
  - Xcode
  - Xcode command-line tools
  - Homebrew.
- 
+
 Preparation:
  - (Optional) Make a separate folder for building if you want to get rid of all except the .app file after building
  - Install Xcode from Mac App Store
@@ -76,7 +78,7 @@ Preparation:
  - Install Git: `brew install git`
  - Install CMake: `brew install cmake`
  - Install wxWidgets: `brew install wxmac --dev --use-llvm`
- 
+
 
 Clone the repo (lets assume that you have a folder `/Users/YOU/src`)
 
@@ -85,20 +87,20 @@ Clone the repo (lets assume that you have a folder `/Users/YOU/src`)
   git clone https://github.com/eranif/codelite.git
   ```
  the above will create the folder `/Users/YOU/codelite`
- 
+
  To build CodeLite:
- 
+
   ```bash
   cd /Users/YOU/codelite
   mkdir build-release
   cd build-release
   cmake .. -DCMAKE_BUILD_TYPE=Release
-  make -j4
-  make install
+  cmake --build . -j $(sysctl -n hw.physicalcpu)
+  cmake --build . --target install
   ```
- 
+
 You should now have an app bundle `/Users/YOU/codelite/build-release/codelite.app`
- 
+
 To launch CodeLite:
 
 `open /Users/YOU/codelite/build-release/codelite.app`

--- a/make-weekly
+++ b/make-weekly
@@ -13,9 +13,9 @@ os_name=`uname -s`
 if [ ${os_name} == "Darwin" ]; then
     echo rm -f $curdir/build-release/codelite.app.tar.gz
     rm -f $curdir/build-release/codelite.app.tar.gz
-    cpu_count=4
+    cpu_count=`sysctl -n hw.physicalcpu`
 else
-    cpu_count=`grep -c ^processor /proc/cpuinfo`
+    cpu_count=`nproc`
 fi
 
 ## parse the command line arguments and over defaults


### PR DESCRIPTION
Using CMake to run the build should allow some more flexibility in what build tools are used.

Also store the resulting .deb file on the build server so that it can be downloaded and tested (nightly builds).
https://51-16066615-gh.circle-artifacts.com/0/root/repo/deb/CodeLite-13.0.5-gtk2---x86_64.deb

Note that `make -j` turned out to bleed RAM, using 32GB for about every ~25% of the process. Using nproc and physicalcpu lets the process use all cores but keep memory usage stable under 8GB (tested on 16 thread Linux system) for the whole process.