### PR TITLE
codelite_vim: Visual line mode

### DIFF
--- a/codelite_vim/vimCommands.cpp
+++ b/codelite_vim/vimCommands.cpp
@@ -794,15 +794,19 @@ bool VimCommand::Command_call()
         repeat_command = false;
     } break;
 
-    case COMMANDVI::x:
+    case COMMANDVI::x: {
         this->m_tmpbuf.Clear();
+        char currentChar = static_cast<char>(this->m_ctrl->GetCharAt(this->m_ctrl->GetCurrentPos()));
+        this->m_listCopiedStr.push_back(wxString(currentChar));
         m_ctrl->CharRight();
         m_ctrl->DeleteBackNotLine();
-        break;
-    case COMMANDVI::X:
+    }break;
+    case COMMANDVI::X: {
         this->m_tmpbuf.Clear();
+        char currentChar = static_cast<char>(this->m_ctrl->GetCharAt(this->m_ctrl->GetCurrentPos() - 1));
+        this->m_listCopiedStr.push_back(wxString(currentChar));
         m_ctrl->DeleteBackNotLine();
-        break;
+    }break;
 
     case COMMANDVI::dw: {
         int repeat_dw = std::max(1, m_actions);
@@ -2031,11 +2035,15 @@ bool VimCommand::is_cmd_complete()
         m_currentModus = VIM_MODI::INSERT_MODUS;
         break;
     case 'x':
+        this->m_newLineCopy = false;
+        this->m_listCopiedStr.clear();
         possible_command = true;
         command_complete = true;
         m_commandID = COMMANDVI::x;
         break;
     case 'X':
+        this->m_newLineCopy = false;
+        this->m_listCopiedStr.clear();
         possible_command = true;
         command_complete = true;
         m_commandID = COMMANDVI::X;

--- a/codelite_vim/vimCommands.h
+++ b/codelite_vim/vimCommands.h
@@ -21,6 +21,7 @@ enum class VIM_MODI {
     NORMAL_MODUS,
     INSERT_MODUS,
     VISUAL_MODUS,
+    VISUAL_LINE_MODUS,
     COMMAND_MODUS,
     SEARCH_MODUS,
     SEARCH_CURR_MODUS,
@@ -248,6 +249,7 @@ public:
     void RepeatIssueCommand(wxString buf);
     bool Command_call();
     bool Command_call_visual_mode();
+    bool command_call_visual_line_mode();
     bool is_cmd_complete();
     void set_current_word(wxString word);
     void set_current_modus(VIM_MODI modus);
@@ -257,7 +259,7 @@ public:
     void set_ctrl(wxStyledTextCtrl* ctrl);
 
 private:
-    /*~~~~~~~~ PRIVAT METHODS ~~~~~~~~~*/
+    /*~~~~~~~~ PRIVATE METHODS ~~~~~~~~~*/
     int getNumRepeat();
     int getNumActions();
     void evidentiate_word();
@@ -283,7 +285,8 @@ private:
     COMMAND_PART m_currentCommandPart; /*!< current part of the command */
     VIM_MODI m_currentModus;           /*!< actual mode the editor is in */
     bool m_saveCommand;
-    long m_initialVisualPos;           /*!< initial position of cursor when changing to visual mode*/
+    int m_initialVisualPos;  /*!< initial position of cursor when changing to visual mode*/
+    int m_initialVisualLine; /*!< initial line which cursor is on when changing to visual line mode*/
     /*~~~~~~~~ COMMAND ~~~~~~~~~*/
     int m_repeat;           /*!< number of repetition for the command */
     wxChar m_baseCommand;   /*!< base command (first char of the cmd)*/

--- a/codelite_vim/vim_manager.cpp
+++ b/codelite_vim/vim_manager.cpp
@@ -170,6 +170,10 @@ void VimManager::updateMessageModus()
         m_mgr->GetStatusBar()->SetMessage("VISUAL");
         if(status_vim->IsShown()) status_vim->Show(false);
         break;
+    case VIM_MODI::VISUAL_LINE_MODUS:
+        m_mgr->GetStatusBar()->SetMessage("VISUAL LINE");
+        if(status_vim->IsShown()) status_vim->Show(false);
+        break;
     case VIM_MODI::INSERT_MODUS:
         m_mgr->GetStatusBar()->SetMessage("INSERT");
         if(status_vim->IsShown()) status_vim->Show(false);


### PR DESCRIPTION
As well as a few bug fixes, added a working visual line mode. Allows user to visually select several full lines and paste as new line copy, like in vim.