### PR TITLE
Fix build with libssh v7

### DIFF
--- a/CodeLite/cl_ssh.cpp
+++ b/CodeLite/cl_ssh.cpp
@@ -115,7 +115,11 @@ bool clSSH::AuthenticateServer(wxString& message)
 #else
     size_t hlen = 0;
     ssh_key key = NULL;
+#if LIBSSH_VERSION_INT >= SSH_VERSION_INT(0, 8, 0)
     ssh_get_server_publickey(m_session, &key);
+#else
+    ssh_get_publickey(m_session, &key);
+#endif
     ssh_get_publickey_hash(key, SSH_PUBLICKEY_HASH_SHA1, &hash, &hlen);
     if(hlen == 0) {
         throw clException("Unable to obtain server public key!");


### PR DESCRIPTION
ssh_get_server_publickey exists since 0.8.0