### PR TITLE
Improve PHPDoc generation

### DIFF
--- a/CodeLite/PHPDocComment.cpp
+++ b/CodeLite/PHPDocComment.cpp
@@ -37,9 +37,10 @@ PHPDocComment::PHPDocComment(PHPSourceFile& sourceFile, const wxString& comment)
         nativeTypes.insert("callback");
     }
 
-    static wxRegEx reReturnStatement(wxT("@(return)[ \t]+([\\a-zA-Z_]{1}[\\|\\a-zA-Z0-9_]*)"));
+    static wxRegEx reReturnStatement(wxT("@(return)[ \t]+(\??)([\\a-zA-Z_]{1}[\\|\\a-zA-Z0-9_]*)"));
     if(reReturnStatement.IsValid() && reReturnStatement.Matches(m_comment)) {
-        wxString returnValue = reReturnStatement.GetMatch(m_comment, 2);
+        wxString returnNullable = reReturnStatement.GetMatch(m_comment, 2);
+        wxString returnValue = reReturnStatement.GetMatch(m_comment, 3);
         wxArrayString types = ::wxStringTokenize(returnValue, "|", wxTOKEN_STRTOK);
         if(types.size() > 1) {
             // Multiple return types, guess the best match
@@ -57,6 +58,10 @@ PHPDocComment::PHPDocComment(PHPSourceFile& sourceFile, const wxString& comment)
             m_returnValue = sourceFile.MakeIdentifierAbsolute(bestMatch);
         } else if(types.size() == 1) {
             m_returnValue = sourceFile.MakeIdentifierAbsolute(types.Item(0));
+        }
+
+        if (!returnNullable.IsEmpty()) {
+            m_returnNullable = true;
         }
     }
 
@@ -105,6 +110,8 @@ const wxString& PHPDocComment::GetParam(size_t n) const
 }
 
 const wxString& PHPDocComment::GetReturn() const { return m_returnValue; }
+
+const bool PHPDocComment::IsReturnNullable() const { return m_returnNullable; }
 
 const wxString& PHPDocComment::GetVar() const { return m_varType; }
 

--- a/CodeLite/PHPDocComment.cpp
+++ b/CodeLite/PHPDocComment.cpp
@@ -126,7 +126,7 @@ const wxString& PHPDocComment::GetParam(const wxString& name) const
 
 void PHPDocComment::ProcessMethods()
 {
-    // The phpdoc for method does not confirm to the PHP syntax.
+    // The phpdoc for method does not conform to the PHP syntax.
     // We need to alter the signature so we can use our parse to parse
     // the signature
     // @method syntax is:

--- a/CodeLite/PHPDocComment.cpp
+++ b/CodeLite/PHPDocComment.cpp
@@ -13,19 +13,28 @@ PHPDocComment::PHPDocComment(PHPSourceFile& sourceFile, const wxString& comment)
 {
     static std::unordered_set<wxString> nativeTypes;
     if(nativeTypes.empty()) {
+        // List taken from https://www.php.net/manual/en/language.types.intro.php
+        // Native types
+        nativeTypes.insert("bool");
         nativeTypes.insert("int");
-        nativeTypes.insert("integer");
-        nativeTypes.insert("real");
-        nativeTypes.insert("double");
         nativeTypes.insert("float");
         nativeTypes.insert("string");
-        nativeTypes.insert("binary");
         nativeTypes.insert("array");
         nativeTypes.insert("object");
-        nativeTypes.insert("bool");
-        nativeTypes.insert("boolean");
-        nativeTypes.insert("mixed");
+        nativeTypes.insert("iterable");
+        nativeTypes.insert("callable");
         nativeTypes.insert("null");
+        nativeTypes.insert("mixed");
+        nativeTypes.insert("void");
+        // Types that are common in documentation
+        nativeTypes.insert("boolean");
+        nativeTypes.insert("integer");
+        nativeTypes.insert("double");
+        nativeTypes.insert("real");
+        nativeTypes.insert("binery");
+        nativeTypes.insert("resource");
+        nativeTypes.insert("number");
+        nativeTypes.insert("callback");
     }
 
     static wxRegEx reReturnStatement(wxT("@(return)[ \t]+([\\a-zA-Z_]{1}[\\|\\a-zA-Z0-9_]*)"));

--- a/CodeLite/PHPDocComment.h
+++ b/CodeLite/PHPDocComment.h
@@ -51,6 +51,7 @@ protected:
     std::unordered_map<wxString, wxString> m_params;
     wxArrayString m_paramsArr;
     wxString m_returnValue;
+    bool m_returnNullable;
     wxString m_varType;
     wxString m_varName;
     PHPDocComment::Property::Map_t m_properties; // @property, @property-read, @property-write
@@ -69,6 +70,7 @@ public:
 
     const wxString& GetVar() const;
     const wxString& GetReturn() const;
+    const bool IsReturnNullable() const;
     const wxString& GetParam(const wxString& name) const;
     const wxString& GetParam(size_t index) const;
     const PHPDocComment::Property::Map_t& GetProperties() const { return m_properties; }

--- a/CodeLite/PHPDocParam.cpp
+++ b/CodeLite/PHPDocParam.cpp
@@ -34,13 +34,20 @@ const PHPDocParam::Vec_t& PHPDocParam::Parse()
             sname = tokenizer.GetNextToken();
 
             // Handle common developer mistake
-            if (stype.StartsWith('$')) {
+            if (stype.StartsWith("$") || stype.StartsWith("&")) {
                 sname.swap(stype);
             }
 
             // TODO Support nullable parameters
             if (stype.StartsWith("?")) {
                 stype.Remove(0, 1);
+            }
+
+            // TODO Support by reference parameters
+            if (sname.StartsWith("&")) {
+                sname.Remove(0, 1);
+            } else if (stype.EndsWith("&")) {
+                stype.RemoveLast();
             }
 
             stype = m_sourceFile.MakeIdentifierAbsolute(stype);

--- a/CodeLite/PHPDocParam.cpp
+++ b/CodeLite/PHPDocParam.cpp
@@ -26,13 +26,20 @@ const PHPDocParam::Vec_t& PHPDocParam::Parse()
                 break;
             }
             stype = tokenizer.GetNextToken();
-            stype = m_sourceFile.MakeIdentifierAbsolute(stype);
 
             // Next comes the name
             if(!tokenizer.HasMoreTokens()) {
                 break;
             }
             sname = tokenizer.GetNextToken();
+
+            // Handle common developer mistake
+            if (stype.StartsWith('$')) {
+                sname.swap(stype);
+            }
+
+            stype = m_sourceFile.MakeIdentifierAbsolute(stype);
+
             m_params.push_back(std::make_pair(sname, stype));
         }
     }

--- a/CodeLite/PHPDocParam.cpp
+++ b/CodeLite/PHPDocParam.cpp
@@ -38,6 +38,11 @@ const PHPDocParam::Vec_t& PHPDocParam::Parse()
                 sname.swap(stype);
             }
 
+            // TODO Support nullable parameters
+            if (stype.StartsWith("?")) {
+                stype.Remove(0, 1);
+            }
+
             stype = m_sourceFile.MakeIdentifierAbsolute(stype);
 
             m_params.push_back(std::make_pair(sname, stype));

--- a/CodeLite/PHPDocVar.cpp
+++ b/CodeLite/PHPDocVar.cpp
@@ -23,43 +23,43 @@ void PHPDocVar::Parse(PHPSourceFile& sourceFile, const wxString& doc)
 {
     wxString sname;
     wxString stype;
-    wxString word;
     m_isOk = false;
     wxStringTokenizer tokenizer(doc, " \n\r", wxTOKEN_STRTOK);
-    while(tokenizer.HasMoreTokens()) {
-        wxString word = tokenizer.GetNextToken();
-        
-        // @var Type $name
-        // @var Type
-        // @var $Name Type
-        if(word == "@var") {
-            // Next word should be the type
-            if(!tokenizer.HasMoreTokens()) { break; }
-            word = tokenizer.GetNextToken();
-            if(word[0] == '$') {
-                // Found the name
-                m_name = word;
-                // Look for the type name
-                if(!tokenizer.HasMoreTokens()) {
-                    m_name.Clear();
-                    break;
-                }
-                 word = tokenizer.GetNextToken();
-                m_type = sourceFile.MakeIdentifierAbsolute(word);
-                m_isOk = true;
-            } else {
-                // Got the type
-                m_type = sourceFile.MakeIdentifierAbsolute(word);
-                m_isOk = true;
-                
-                // Get the name (optionally)
-                if(!tokenizer.HasMoreTokens()) {
-                    break;
-                }
-                m_name = tokenizer.GetNextToken();
-            }
-        }
+
+    // @var Type $name
+    // @var Type
+    // @var $Name Type
+    if(!tokenizer.HasMoreTokens() || tokenizer.GetNextToken() != "@var") {
+        return;
     }
+
+    // Next word should be the type
+    if(!tokenizer.HasMoreTokens()) {
+        return;
+    }
+    stype = tokenizer.GetNextToken();
+
+    // Next comes the name
+    if(tokenizer.HasMoreTokens()) {
+        sname = tokenizer.GetNextToken();
+    }
+
+    // Handle common developer mistake
+    if (stype.StartsWith("$")) {
+        sname.swap(stype);
+    }
+
+    // TODO Support nullable parameters
+    if (stype.StartsWith("?")) {
+        stype.Remove(0, 1);
+    }
+
+    // Got the type
+    m_type = sourceFile.MakeIdentifierAbsolute(stype);
+    m_isOk = true;
+
+    // Found the name
+    m_name = sname;
 }
 
 void PHPDocVar::Store(wxSQLite3Database& db, wxLongLong parentDdId)

--- a/CodeLite/PHPDocVisitor.cpp
+++ b/CodeLite/PHPDocVisitor.cpp
@@ -73,6 +73,9 @@ void PHPDocVisitor::OnEntity(PHPEntityBase::Ptr_t entity)
             PHPDocComment docComment(m_sourceFile, entity->GetDocComment());
             if(entity->Is(kEntityTypeFunction) && !docComment.GetReturn().IsEmpty()) {
                 entity->Cast<PHPEntityFunction>()->SetReturnValue(docComment.GetReturn());
+                if (docComment.IsReturnNullable()) {
+                    entity->Cast<PHPEntityFunction>()->SetFlag(kFunc_ReturnNullable);
+                }
             } else if(entity->Is(kEntityTypeVariable) && !entity->Cast<PHPEntityVariable>()->IsFunctionArg()) {
                 // A global variable, const or a member
                 entity->Cast<PHPEntityVariable>()->SetTypeHint(docComment.GetVar());

--- a/CodeLite/PHPEntityBase.h
+++ b/CodeLite/PHPEntityBase.h
@@ -63,6 +63,7 @@ enum {
     kVar_FunctionArg = (1 << 7),
     kVar_Static = (1 << 8),
     kVar_Define = (1 << 9),
+    kVar_Nullable = (1 << 10),
 };
 
 // Function flags
@@ -74,6 +75,7 @@ enum {
     kFunc_Static = (1 << 5),
     kFunc_Abstract = (1 << 6),
     kFunc_ReturnReference = (1 << 7),
+    kFunc_ReturnNullable = (1 << 8),
 };
 
 // Class flags

--- a/CodeLite/PHPEntityFunction.cpp
+++ b/CodeLite/PHPEntityFunction.cpp
@@ -41,6 +41,13 @@ wxString PHPEntityFunction::GetSignature() const
         }
         if(strSignature.EndsWith(", ")) { strSignature.RemoveLast(2); }
         strSignature << ")";
+        if (!GetReturnValue().IsEmpty()) {
+            strSignature << ": ";
+            if (HasFlag(kFunc_ReturnNullable)) {
+                strSignature << "?";
+            }
+            strSignature << GetReturnValue();
+        }
         return strSignature;
     }
 }

--- a/CodeLite/PHPEntityFunction.cpp
+++ b/CodeLite/PHPEntityFunction.cpp
@@ -110,7 +110,7 @@ wxString PHPEntityFunction::FormatPhpDoc(const CommentConfigData& data) const
         }
     }
     if(!GetShortName().Matches("__construct")) {
-        doc << " * @return " << GetReturnValue() << " \n";
+        doc << " * @return " << (GetReturnValue().IsEmpty() ? "mixed" : GetReturnValue()) << " \n";
     }
     doc << " */";
     return doc;

--- a/CodeLite/PHPEntityFunction.cpp
+++ b/CodeLite/PHPEntityFunction.cpp
@@ -98,6 +98,7 @@ bool PHPEntityFunction::Is(eEntityType type) const { return type == kEntityTypeF
 wxString PHPEntityFunction::GetDisplayName() const { return wxString() << GetShortName() << GetSignature(); }
 wxString PHPEntityFunction::FormatPhpDoc(const CommentConfigData& data) const
 {
+    bool hasParams = false;
     wxString doc;
     doc << data.GetCommentBlockPrefix() << "\n"
         << " * @brief \n";
@@ -105,11 +106,15 @@ wxString PHPEntityFunction::FormatPhpDoc(const CommentConfigData& data) const
     for(; iter != m_children.end(); ++iter) {
         const PHPEntityVariable* var = (*iter)->Cast<PHPEntityVariable>();
         if(var) {
+            hasParams = true;
             doc << " * @param " << (var->GetTypeHint().IsEmpty() ? "mixed" : var->GetTypeHint()) << " "
                 << var->GetFullName() << " \n";
         }
     }
     if(!GetShortName().Matches("__construct")) {
+        if(hasParams) {
+            doc << " *\n";
+        }
         doc << " * @return " << (GetReturnValue().IsEmpty() ? "mixed" : GetReturnValue()) << " \n";
     }
     doc << " */";

--- a/CodeLite/PHPEntityFunction.cpp
+++ b/CodeLite/PHPEntityFunction.cpp
@@ -109,7 +109,9 @@ wxString PHPEntityFunction::FormatPhpDoc(const CommentConfigData& data) const
                 << var->GetFullName() << " \n";
         }
     }
-    doc << " * @return " << GetReturnValue() << " \n";
+    if(!GetShortName().Matches("__construct")) {
+        doc << " * @return " << GetReturnValue() << " \n";
+    }
     doc << " */";
     return doc;
 }

--- a/CodeLite/PHPEntityFunction.cpp
+++ b/CodeLite/PHPEntityFunction.cpp
@@ -107,15 +107,26 @@ wxString PHPEntityFunction::FormatPhpDoc(const CommentConfigData& data) const
         const PHPEntityVariable* var = (*iter)->Cast<PHPEntityVariable>();
         if(var) {
             hasParams = true;
-            doc << " * @param " << (var->GetTypeHint().IsEmpty() ? "mixed" : var->GetTypeHint()) << " "
-                << var->GetFullName() << " \n";
+            doc << " * @param ";
+            if (var->IsNullable() || var->GetDefaultValue().Matches("null")) {
+                doc << "?";
+            }
+            doc << (var->GetTypeHint().IsEmpty() ? "mixed" : var->GetTypeHint()) << " " << var->GetFullName();
+            if (!var->GetDefaultValue().IsEmpty()) {
+                doc << " [" << var->GetDefaultValue() << "]";
+            }
+            doc << " \n";
         }
     }
     if(!GetShortName().Matches("__construct")) {
         if(hasParams) {
             doc << " *\n";
         }
-        doc << " * @return " << (GetReturnValue().IsEmpty() ? "mixed" : GetReturnValue()) << " \n";
+        doc << " * @return ";
+        if (HasFlag(kFunc_ReturnNullable)) {
+            doc << "?";
+        }
+        doc << (GetReturnValue().IsEmpty() ? "mixed" : GetReturnValue()) << " \n";
     }
     doc << " */";
     return doc;

--- a/CodeLite/PHPEntityVariable.cpp
+++ b/CodeLite/PHPEntityVariable.cpp
@@ -65,6 +65,9 @@ wxString PHPEntityVariable::ToFuncArgString() const
 
     wxString str;
     if(!GetTypeHint().IsEmpty()) {
+        if(IsNullable()) {
+            str << "?";
+        }
         str << GetTypeHint() << " ";
     }
 

--- a/CodeLite/PHPEntityVariable.h
+++ b/CodeLite/PHPEntityVariable.h
@@ -78,6 +78,7 @@ public:
     
     // Aliases
     void SetIsReference(bool isReference) { SetFlag(kVar_Reference, isReference); }
+    void SetIsNullable(bool isNullable) { SetFlag(kVar_Nullable, isNullable); }
     bool IsMember() const { return HasFlag(kVar_Member); }
     bool IsPublic() const { return HasFlag(kVar_Public); }
     bool IsPrivate() const { return HasFlag(kVar_Private); }
@@ -85,6 +86,7 @@ public:
     bool IsFunctionArg() const { return HasFlag(kVar_FunctionArg); }
     bool IsConst() const { return HasFlag(kVar_Const); }
     bool IsReference() const { return HasFlag(kVar_Reference); }
+    bool IsNullable() const { return HasFlag(kVar_Nullable); }
     bool IsStatic() const { return HasFlag(kVar_Static); }
     bool IsDefine() const { return HasFlag(kVar_Define); }
     bool IsBoolean() const { return GetTypeHint() == "boolean" || GetTypeHint() == "bool"; }

--- a/CodeLite/PHPSourceFile.cpp
+++ b/CodeLite/PHPSourceFile.cpp
@@ -359,6 +359,15 @@ void PHPSourceFile::OnFunction()
         if(token.type == ':') {
             // PHP 7 signature type
             // function foobar(...) : RETURN_TYPE
+
+            if(!NextToken(token)) return;
+            if(token.type == '?') {
+                // PHP 7.1 nullable return
+                funcPtr->SetFlag(kFunc_ReturnNullable);
+            } else {
+                UngetToken(token);
+            }
+
             wxString returnValuetype = ReadFunctionReturnValueFromSignature();
             if(returnValuetype.IsEmpty()) return; // parse error
             func->SetReturnValue(returnValuetype);
@@ -501,6 +510,12 @@ void PHPSourceFile::ParseFunctionSignature(int startingDepth)
             typeHint.Clear();
             defaultValue.Clear();
             collectingDefaultValue = false;
+            break;
+        case '?':
+            if(!var) {
+                var = new PHPEntityVariable();
+            }
+            var->SetIsNullable(true);
             break;
         case kPHP_T_NS_SEPARATOR:
         case kPHP_T_IDENTIFIER:

--- a/CodeLite/PHPSourceFile.cpp
+++ b/CodeLite/PHPSourceFile.cpp
@@ -457,6 +457,7 @@ void PHPSourceFile::ParseFunctionSignature(int startingDepth)
     int depth = 1;
     wxString typeHint;
     wxString defaultValue;
+    wxString name;
     PHPEntityVariable* var(NULL);
     bool collectingDefaultValue = false;
     while(NextToken(token)) {
@@ -468,15 +469,19 @@ void PHPSourceFile::ParseFunctionSignature(int startingDepth)
                 var = new PHPEntityVariable();
             }
 
-            var->SetFullName(token.Text());
+            name = token.Text();
             var->SetLine(token.lineNumber);
             var->SetFilename(m_filename);
             // Mark this variable as function argument
             var->SetFlag(kVar_FunctionArg);
-            if(typeHint.EndsWith("&")) {
+            if (name.StartsWith("&")) {
+                var->SetIsReference(true);
+                name.Remove(0, 1);
+            } else if(typeHint.EndsWith("&")) {
                 var->SetIsReference(true);
                 typeHint.RemoveLast();
             }
+            var->SetFullName(name);
             var->SetTypeHint(MakeIdentifierAbsolute(typeHint));
             break;
         case '(':

--- a/CodeLite/PHPSourceFile.cpp
+++ b/CodeLite/PHPSourceFile.cpp
@@ -1359,16 +1359,28 @@ wxString PHPSourceFile::DoMakeIdentifierAbsolute(const wxString& type, bool exac
 
     static std::unordered_set<std::string> phpKeywords;
     if(phpKeywords.empty()) {
+        // List taken from https://www.php.net/manual/en/language.types.intro.php
+        // Native types
+        phpKeywords.insert("bool");
+        phpKeywords.insert("int");
+        phpKeywords.insert("float");
         phpKeywords.insert("string");
         phpKeywords.insert("array");
+        phpKeywords.insert("object");
+        phpKeywords.insert("iterable");
+        phpKeywords.insert("callable");
+        phpKeywords.insert("null");
         phpKeywords.insert("mixed");
-        phpKeywords.insert("bool");
-        phpKeywords.insert("integer");
-        phpKeywords.insert("boolean");
-        phpKeywords.insert("double");
-        phpKeywords.insert("float");
-        phpKeywords.insert("float");
         phpKeywords.insert("void");
+        // Types that are common in documentation
+        phpKeywords.insert("boolean");
+        phpKeywords.insert("integer");
+        phpKeywords.insert("double");
+        phpKeywords.insert("real");
+        phpKeywords.insert("binery");
+        phpKeywords.insert("resource");
+        phpKeywords.insert("number");
+        phpKeywords.insert("callback");
     }
     wxString typeWithNS(type);
     typeWithNS.Trim().Trim(false);


### PR DESCRIPTION
This fixes case 1, 2, 4, 5 & 6 from https://github.com/eranif/codelite/issues/1828

More specifically:
- Fixes the list of native PHP types (case 1 was because `int` was missing from it).
- Adds support for PHP 7.1 nullable types.
- `@return` now defaults to `mixed`.
- `@return` is omitted for the `__construct` method.
- The parameter default is added to the PHPDoc.
- Add nullable to PHPDoc.
- `@param` and `@return` are separated by an empty line.
- Parse `@param` even when the type and name are swapped.
- Make parsing of PHP and PHPDoc block a bit more tolerant
- Add missing details (nullable parameters, return type) to the function signature

Before:
```PHP
<?php
use Service\FileHandler;
/**
 * 
 * @param \int $var 
 * @param \FileHandler $var2 
 * @return  
 */
function test(?int $var, FileHandler $var2 = null): ?int
{
}
```

After:
```PHP
<?php
use Service\FileHandler;
/**
 * 
 * @param ?int $var
 * @param ?\Service\FileHandler $var2 [null] 
 *
 * @return ?int 
 */
function test(?int $var, FileHandler $var2 = null): ?int
{
}
```

![image](https://user-images.githubusercontent.com/204594/86063715-ca81e980-ba6b-11ea-972d-6885a04da787.png)
