### PR TITLE
Remove --use-temp-file from wx-config's rcflags

### DIFF
--- a/sdk/wxconfig/wx-config-win.cpp
+++ b/sdk/wxconfig/wx-config-win.cpp
@@ -1048,7 +1048,7 @@ public:
         + addLib("version") + addLib("shlwapi") + addLib("ole32") + addLib("oleaut32"); po["libs"] += addLib("uuid") +
         addLib("rpcrt4") + addLib("advapi32") + addLib("wsock32") + addLib("odbc32");
         */
-        po["rcflags"] = addFlag("--use-temp-file") + addResDefine("__WXMSW__") + po["__WXUNIV_DEFINE_p_1"];
+        po["rcflags"] = addResDefine("__WXMSW__") + po["__WXUNIV_DEFINE_p_1"];
         po["rcflags"] += po["__DEBUG_DEFINE_p_1"] + po["__EXCEPTIONS_DEFINE_p_1"];
         po["rcflags"] += po["__RTTI_DEFINE_p_1"] + po["__THREAD_DEFINE_p_1"] + po["__UNICODE_DEFINE_p_1"];
         po["rcflags"] += po["__MSLU_DEFINE_p_1"] + po["__GFXCTX_DEFINE_p_1"] + addResIncludeDir(po["SETUPHDIR"]);


### PR DESCRIPTION
TBH, I do not really use CodeLite but when I did to try something (based on a post on wxForum), I noticed that I was unable to compile the windows resource file in a wxWidgets project using GCC 10. The error message was about a missing resource file but I encountered this before so I knew that it is actually a bug in windres shipped with GCC 10, triggered by using `--use-temp-file` parameter.

The bug can be worked around by appending `--no-use-temp-file` to the Resource Compiler Options in the Project Settings but I  believe that removing `--use-temp-file` parameter from wx-config rcflags altogether is the better solution. `--use-temp-file` was needed only for MS Windows 9x and is known to break compilation in newer GCC versions. wxWidgets removed it as well, see https://github.com/wxWidgets/wxWidgets/commit/093c3067e8ee9f1ff203bca4b7491ae22cf6853c