### PR TITLE
Fix CodeFormatter regression

### DIFF
--- a/CodeFormatter/codeformatter.cpp
+++ b/CodeFormatter/codeformatter.cpp
@@ -121,7 +121,9 @@ CodeFormatter::CodeFormatter(IManager* manager)
     EventNotifier::Get()->Bind(wxEVT_CONTEXT_MENU_FOLDER, &CodeFormatter::OnContextMenu, this);
 
     m_optionsPhp.Load();
-    m_options.AutodetectSettings();
+    if(!m_mgr->GetConfigTool()->ReadObject("FormatterOptions", &m_options)) {
+        m_options.AutodetectSettings();
+    }
 }
 
 CodeFormatter::~CodeFormatter() {}


### PR DESCRIPTION
Fix CodeFormatter to not ignore user's previously configured settings.
(This is a regression introduced in b045366)