### PR TITLE
wxCrafter: Fix wxAuiManager right-click menu

### DIFF
--- a/wxcrafter/allocator_mgr.cpp
+++ b/wxcrafter/allocator_mgr.cpp
@@ -939,6 +939,12 @@ FLAGS_t Allocator::DoGetValidMenus(wxcWidget* item) const
             menuflags |= MT_INSERT_INTO_SIZER;
             break;
 
+        case ID_WXAUIMANAGER:
+            menuflags |= MT_EVENTS;
+            menuflags |= MT_COMMON_MENU;
+            menuflags |= MT_EDIT;
+            break;
+
         default:
             menuflags |= MT_EVENTS;
             menuflags |= MT_COMMON_MENU;


### PR DESCRIPTION
There is "Insert into new Sizer" menu when right-clicking the wxAuiManager, which crashes CodeLite and expected to be hidden.