### PR TITLE
Fix typos and translations

### DIFF
--- a/AutoSave/autosave.cpp
+++ b/AutoSave/autosave.cpp
@@ -46,7 +46,7 @@ void AutoSave::CreatePluginMenu(wxMenu* pluginsMenu)
 {
     wxMenu* menu = new wxMenu();
     menu->Append(new wxMenuItem(menu, XRCID("auto_save_settings"), _("Settings...")));
-    pluginsMenu->Append(wxID_ANY, "Auto Save", menu);
+    pluginsMenu->Append(wxID_ANY, _("Auto Save"), menu);
 }
 
 void AutoSave::UnPlug()

--- a/CallGraph/callgraph.cpp
+++ b/CallGraph/callgraph.cpp
@@ -158,7 +158,7 @@ void CallGraph::CreatePluginMenu(wxMenu* pluginsMenu)
     item = new wxMenuItem(menu, XRCID("cg_about"), _("About..."), wxEmptyString, wxITEM_NORMAL);
     menu->Append(item);
     //
-    pluginsMenu->Append(wxID_ANY, wxT("Call Graph"), menu);
+    pluginsMenu->Append(wxID_ANY, _("Call Graph"), menu);
 }
 
 //-----------------------------------------------------------------------------
@@ -377,12 +377,12 @@ void CallGraph::OnShowCallGraph(wxCommandEvent& event)
     // check source binary exists
     wxString bin_fpath = cfn.GetFullPath();
     if(!cfn.Exists()) {
-        bin_fpath = wxFileSelector("Please select the binary to analyze", base_path, "", "");
-        if(bin_fpath.IsEmpty()) return MessageBox("selected binary was canceled", wxICON_ERROR);
+        bin_fpath = wxFileSelector(_("Please select the binary to analyze"), base_path, "", "");
+        if(bin_fpath.IsEmpty()) return MessageBox(_("selected binary was canceled"), wxICON_ERROR);
 
         cfn.Assign(bin_fpath, wxPATH_NATIVE);
     }
-    if(!cfn.IsFileExecutable()) return MessageBox("bin/exe isn't executable", wxICON_ERROR);
+    if(!cfn.IsFileExecutable()) return MessageBox(_("bin/exe isn't executable"), wxICON_ERROR);
 
     // check 'gmon.out' file exists
     wxFileName gmon_cfn(cfn.GetPath() + wxFileName::GetPathSeparator() + GMON_FILENAME_OUT);
@@ -390,8 +390,8 @@ void CallGraph::OnShowCallGraph(wxCommandEvent& event)
 
     wxString gmonfn = gmon_cfn.GetFullPath();
     if(!gmon_cfn.Exists()) {
-        gmonfn = wxFileSelector("Please select the gprof file", gmon_cfn.GetPath(), "gmon", "out");
-        if(gmonfn.IsEmpty()) return MessageBox("selected gprof was canceled", wxICON_ERROR);
+        gmonfn = wxFileSelector(_("Please select the gprof file"), gmon_cfn.GetPath(), "gmon", "out");
+        if(gmonfn.IsEmpty()) return MessageBox(_("selected gprof was canceled"), wxICON_ERROR);
 
         gmon_cfn.Assign(gmonfn, wxPATH_NATIVE);
     }

--- a/CallGraph/dotwriter.cpp
+++ b/CallGraph/dotwriter.cpp
@@ -194,7 +194,7 @@ void DotWriter::WriteToDotLanguage()
     if(!is_node) { // if the call graph is empty create new graph with label node
         m_OutputString = wxT("digraph e {0 [label=");
         m_OutputString +=
-            _(wxString::Format("\"The call-graph is empty; the node threshold ceiling is %d !\"", wxRound(max_time)));
+            wxString::Format(_("\"The call-graph is empty; the node threshold ceiling is %d !\""), wxRound(max_time));
         m_OutputString += wxT(", shape=none, height=2, width=2, fontname=Arial, fontsize=14.00];}");
     }
 }

--- a/CodeFormatter/codeformatterdlg.wxcp
+++ b/CodeFormatter/codeformatterdlg.wxcp
@@ -1768,7 +1768,7 @@
 																														}, {
 																															"type":	"multi-string",
 																															"m_label":	"Choices:",
-																															"m_value":	"Align Escaped Newlines Left;Align Trailing Comments;Allow All Parameters Of Declaration On Next Line;Allow Short Functions On A Single Line;Allow Short Blocks On A Single Line;Allow Short Loops On A Single Line;Allow Short If Statements On A SingleLine;Always Break Before Multiline Strings;Always Break Template Declarations;Bin Pack Parameters;Break Before Binary Operators;Break Before Ternary Operators;Break Constructor Initializers Before Comma;Indent Case Labels;Indent Function DeclarationAfterType;Space Before Assignment Operators;Space Before Parentheses;Spaces In Parentheses;Pointer And Reference Aligned to the Right"
+																															"m_value":	"Align Escaped Newlines Left;Align Trailing Comments;Allow All Parameters Of Declaration On Next Line;Allow Short Functions On A Single Line;Allow Short Blocks On A Single Line;Allow Short Loops On A Single Line;Allow Short If Statements On A SingleLine;Always Break Before Multiline Strings;Always Break Template Declarations;Bin Pack Parameters;Break Before Binary Operators;Break Before Ternary Operators;Break Constructor Initializers Before Comma;Indent Case Labels;Indent Function Declaration After Type;Space Before Assignment Operators;Space Before Parentheses;Spaces In Parentheses;Pointer And Reference Aligned to the Right"
 																														}, {
 																															"type":	"multi-string",
 																															"m_label":	"Array Integer Values",
@@ -2614,7 +2614,7 @@
 																														}, {
 																															"type":	"multi-string",
 																															"m_label":	"Choices:",
-																															"m_value":	"Class;Brackets;Switches;Namespaces;Case;Labels;Blocks;Preprocessors;Max Instatement Indent;Min Instatement Indent"
+																															"m_value":	"Class;Brackets;Switches;Namespaces;Case;Labels;Blocks;Preprocessors;Max Instatement Indent;Min Conditional Indent"
 																														}, {
 																															"type":	"multi-string",
 																															"m_label":	"Array Integer Values",
@@ -4563,7 +4563,7 @@
 																														}, {
 																															"type":	"string",
 																															"m_label":	"Label:",
-																															"m_value":	"PHP-CS-Fixer parh path"
+																															"m_value":	"PHP-CS-Fixer phar path"
 																														}, {
 																															"type":	"multi-string",
 																															"m_label":	"Tooltip:",

--- a/CodeFormatter/codeformatterdlgbase.cpp
+++ b/CodeFormatter/codeformatterdlgbase.cpp
@@ -202,7 +202,7 @@ CodeFormatterBaseDlg::CodeFormatterBaseDlg(wxWindow* parent,
     m_pgMgrClangArr.Add(_("Break Before Ternary Operators"));
     m_pgMgrClangArr.Add(_("Break Constructor Initializers Before Comma"));
     m_pgMgrClangArr.Add(_("Indent Case Labels"));
-    m_pgMgrClangArr.Add(_("Indent Function DeclarationAfterType"));
+    m_pgMgrClangArr.Add(_("Indent Function Declaration After Type"));
     m_pgMgrClangArr.Add(_("Space Before Assignment Operators"));
     m_pgMgrClangArr.Add(_("Space Before Parentheses"));
     m_pgMgrClangArr.Add(_("Spaces In Parentheses"));
@@ -342,7 +342,7 @@ CodeFormatterBaseDlg::CodeFormatterBaseDlg(wxWindow* parent,
     m_pgMgrAstyleArr.Add(_("Blocks"));
     m_pgMgrAstyleArr.Add(_("Preprocessors"));
     m_pgMgrAstyleArr.Add(_("Max Instatement Indent"));
-    m_pgMgrAstyleArr.Add(_("Min Instatement Indent"));
+    m_pgMgrAstyleArr.Add(_("Min Conditional Indent"));
     m_pgMgrAstyleIntArr.Add(AS_INDENT_CLASS);
     m_pgMgrAstyleIntArr.Add(AS_INDENT_BRACKETS);
     m_pgMgrAstyleIntArr.Add(AS_INDENT_SWITCHES);
@@ -608,7 +608,7 @@ CodeFormatterBaseDlg::CodeFormatterBaseDlg(wxWindow* parent,
     m_pgPropPhpCSFixer->SetHelpString(wxT(""));
 
     m_filePickerPHPCsFixerPhar = m_pgMgrPHPCsFixer->AppendIn(
-        m_pgPropPhpCSFixer, new wxFileProperty(_("PHP-CS-Fixer parh path"), wxPG_LABEL, wxT("")));
+        m_pgPropPhpCSFixer, new wxFileProperty(_("PHP-CS-Fixer phar path"), wxPG_LABEL, wxT("")));
 #if !defined(__WXOSX__) && !defined(_WIN64)
     m_filePickerPHPCsFixerPhar->SetAttribute(wxPG_FILE_WILDCARD, wxT(""));
 #endif // !defined(__WXOSX__) && !defined(_WIN64)

--- a/CodeLite/cl_ssh.cpp
+++ b/CodeLite/cl_ssh.cpp
@@ -201,7 +201,7 @@ bool clSSH::LoginPassword(bool throwExc)
         return true;
 
     } else if(rc == SSH_AUTH_DENIED) {
-        THROW_OR_FALSE("Login failed: invalid username/password");
+        THROW_OR_FALSE(_("Login failed: invalid username/password"));
 
     } else {
         THROW_OR_FALSE(wxString() << _("Authentication error: ") << ssh_get_error(m_session));
@@ -248,7 +248,7 @@ bool clSSH::LoginInteractiveKBD(bool throwExc)
         }
         return true; // success
     }
-    THROW_OR_FALSE("Interactive Keyboard is not enabled for this server");
+    THROW_OR_FALSE(_("Interactive Keyboard is not enabled for this server"));
     return false;
 }
 

--- a/CodeLite/macros.h
+++ b/CodeLite/macros.h
@@ -87,24 +87,24 @@
 // Constants
 //-----------------------------------------------------
 
-#define clCMD_NEW  "<New...>"
-#define clCMD_EDIT "<Edit...>"
+#define clCMD_NEW  _("<New...>")
+#define clCMD_EDIT _("<Edit...>")
 
 // constant message
-#define BUILD_START_MSG "----------Build Started--------\n"
-#define BUILD_END_MSG "----------Build Ended----------\n"
-#define BUILD_PROJECT_PREFIX "----------Building project:[ "
-#define CLEAN_PROJECT_PREFIX "----------Cleaning project:[ "
+#define BUILD_START_MSG _("----------Build Started--------\n")
+#define BUILD_END_MSG _("----------Build Ended----------\n")
+#define BUILD_PROJECT_PREFIX _("----------Building project:[ ")
+#define CLEAN_PROJECT_PREFIX _("----------Cleaning project:[ ")
 
 // Find in files options
-#define SEARCH_IN_WORKSPACE "<Entire Workspace>"
-#define SEARCH_IN_PROJECT "<Active Project>"
-#define SEARCH_IN_CURR_FILE_PROJECT "<Current File's Project>"
-#define SEARCH_IN_CURRENT_FILE "<Current File>"
-#define SEARCH_IN_OPEN_FILES "<Open Files>"
-#define SEARCH_IN_WORKSPACE_FOLDER "<Workspace Folder>"
-#define USE_WORKSPACE_ENV_VAR_SET _("<Use Defaults>")
-#define USE_GLOBAL_SETTINGS _("<Use Defaults>")
+#define SEARCH_IN_WORKSPACE wxTRANSLATE("<Entire Workspace>")
+#define SEARCH_IN_PROJECT wxTRANSLATE("<Active Project>")
+#define SEARCH_IN_CURR_FILE_PROJECT wxTRANSLATE("<Current File's Project>")
+#define SEARCH_IN_CURRENT_FILE wxTRANSLATE("<Current File>")
+#define SEARCH_IN_OPEN_FILES wxTRANSLATE("<Open Files>")
+#define SEARCH_IN_WORKSPACE_FOLDER wxTRANSLATE("<Workspace Folder>")
+#define USE_WORKSPACE_ENV_VAR_SET wxTRANSLATE("<Use Defaults>")
+#define USE_GLOBAL_SETTINGS wxTRANSLATE("<Use Defaults>")
 
 // terminal macro
 #ifdef __WXGTK__

--- a/DatabaseExplorer/DbViewerPanel.cpp
+++ b/DatabaseExplorer/DbViewerPanel.cpp
@@ -178,7 +178,7 @@ void DbViewerPanel::RefreshDbView()
     int img_find = loader->GetImageIndex(BitmapLoader::kFind);
     int img_database = loader->GetImageIndex(BitmapLoader::kDatabase);
     int img_column = loader->GetImageIndex(BitmapLoader::kColumn);
-    wxTreeItemId totalRootID = m_treeDatabases->AddRoot(wxString::Format(wxT("Databases")), wxNOT_FOUND);
+    wxTreeItemId totalRootID = m_treeDatabases->AddRoot(wxString::Format(_("Databases")), wxNOT_FOUND);
 
     // ---------------- load connections ----------------------------
     SerializableList::compatibility_iterator connectionNode = m_pConnections->GetFirstChildNode();
@@ -186,7 +186,7 @@ void DbViewerPanel::RefreshDbView()
         DbConnection* pDbCon = (DbConnection*)wxDynamicCast(connectionNode->GetData(), DbConnection);
         if(pDbCon) {
             wxTreeItemId rootID = m_treeDatabases->AppendItem(
-                totalRootID, wxString::Format(wxT("Databases (%s)"), pDbCon->GetServerName().c_str()), img_database,
+                totalRootID, wxString::Format(_("Databases (%s)"), pDbCon->GetServerName().c_str()), img_database,
                 img_database, new DbItem(pDbCon));
 
             // ----------------------- load databases -------------------------------
@@ -198,7 +198,7 @@ void DbViewerPanel::RefreshDbView()
                                                                     img_database, new DbItem(pDatabase));
                     m_treeDatabases->Expand(rootID);
                     wxTreeItemId idFolder =
-                        m_treeDatabases->AppendItem(dbID, wxT("Tables"), img_folder, img_folder, NULL);
+                        m_treeDatabases->AppendItem(dbID, _("Tables"), img_folder, img_folder, NULL);
 
                     // ----------------------------- load tables ----------------------------------
                     SerializableList::compatibility_iterator tabNode = pDatabase->GetFirstChildNode();
@@ -226,7 +226,7 @@ void DbViewerPanel::RefreshDbView()
                     }
                     // ----------------------------------------------------------------------------
 
-                    idFolder = m_treeDatabases->AppendItem(dbID, wxT("Views"), img_folder, img_folder, NULL);
+                    idFolder = m_treeDatabases->AppendItem(dbID, _("Views"), img_folder, img_folder, NULL);
 
                     // ----------------------------- load views ----------------------------------
                     tabNode = pDatabase->GetFirstChildNode();

--- a/DatabaseExplorer/ErdCommitWizard.cpp
+++ b/DatabaseExplorer/ErdCommitWizard.cpp
@@ -120,14 +120,14 @@ void DatabasePage::LoadDatabases() {
 	pImageList->Add(wxIcon(form_yellow_xpm));						// view icon
 	m_treeDatabases->SetImageList(pImageList);
 
-	wxTreeItemId totalRootID = m_treeDatabases->AddRoot(wxString::Format(wxT("Databases")),-1);
+	wxTreeItemId totalRootID = m_treeDatabases->AddRoot(wxString::Format(_("Databases")),-1);
 
 	// ---------------- load connections ----------------------------
 	SerializableList::compatibility_iterator connectionNode = m_pConnections->GetFirstChildNode();
 	while(connectionNode) {
 		DbConnection* pDbCon = (DbConnection*) wxDynamicCast(connectionNode->GetData(),DbConnection);
 		if (pDbCon) {
-			wxTreeItemId rootID = m_treeDatabases->AppendItem(totalRootID,wxString::Format(wxT("Databases (%s)"),pDbCon->GetServerName().c_str()),-1,-1, new DbItem(pDbCon));
+			wxTreeItemId rootID = m_treeDatabases->AppendItem(totalRootID,wxString::Format(_("Databases (%s)"),pDbCon->GetServerName().c_str()),-1,-1, new DbItem(pDbCon));
 			m_treeDatabases->Expand(rootID);
 			// ----------------------- load databases -------------------------------
 			SerializableList::compatibility_iterator dbNode = pDbCon->GetFirstChildNode();

--- a/DatabaseExplorer/SqlCommandPanel.cpp
+++ b/DatabaseExplorer/SqlCommandPanel.cpp
@@ -88,7 +88,7 @@ SQLCommandPanel::SQLCommandPanel(wxWindow* parent, IDbAdapter* dbAdapter, const 
     m_dbTable = dbTable;
 
     m_editHelper.Reset(new clEditEventsHandler(m_scintillaSQL));
-    m_scintillaSQL->AddText(wxString::Format(wxT(" -- selected database %s\n"), m_dbName.c_str()));
+    m_scintillaSQL->AddText(wxString::Format(_(" -- selected database %s\n"), m_dbName.c_str()));
     if(!dbTable.IsEmpty()) {
         m_scintillaSQL->AddText(m_pDbAdapter->GetDefaultSelect(m_dbName, m_dbTable));
         wxCommandEvent event(wxEVT_EXECUTE_SQL);
@@ -379,7 +379,7 @@ bool SQLCommandPanel::IsBlobColumn(const wxString& str)
 void SQLCommandPanel::SetDefaultSelect()
 {
     m_scintillaSQL->ClearAll();
-    m_scintillaSQL->AddText(wxString::Format(wxT(" -- selected database %s\n"), m_dbName.c_str()));
+    m_scintillaSQL->AddText(wxString::Format(_(" -- selected database %s\n"), m_dbName.c_str()));
     if(!m_dbTable.IsEmpty()) {
         m_scintillaSQL->AddText(m_pDbAdapter->GetDefaultSelect(m_dbName, m_dbTable));
         CallAfter(&SQLCommandPanel::ExecuteSql);

--- a/Debugger/debuggergdb.cpp
+++ b/Debugger/debuggergdb.cpp
@@ -1135,7 +1135,7 @@ bool DbgGdb::DoLocateGdbExecutable(const wxString& debuggerPath, wxString& dbgEx
 
     wxString actualPath;
     if(ExeLocator::Locate(dbgExeName, actualPath) == false) {
-        wxMessageBox(wxString::Format(wxT("Failed to locate gdb! at '%s'"), dbgExeName.c_str()), wxT("CodeLite"));
+        wxMessageBox(wxString::Format(_("Failed to locate gdb! at '%s'"), dbgExeName.c_str()), wxT("CodeLite"));
         return false;
     }
 

--- a/EOSWiki/eoswiki.cpp
+++ b/EOSWiki/eoswiki.cpp
@@ -58,7 +58,7 @@ void EOSWiki::CreatePluginMenu(wxMenu* pluginsMenu)
 {
     wxMenu* menu = new wxMenu();
     menu->Append(new wxMenuItem(menu, XRCID("eosio_new_project"), _("New Project...")));
-    pluginsMenu->Append(wxID_ANY, "EOS Wiki", menu);
+    pluginsMenu->Append(wxID_ANY, _("EOS Wiki"), menu);
 }
 
 void EOSWiki::UnPlug() { wxTheApp->Unbind(wxEVT_MENU, &EOSWiki::OnNewProject, this, XRCID("eosio_new_project")); }

--- a/EditorConfigPlugin/editorconfigplugin.cpp
+++ b/EditorConfigPlugin/editorconfigplugin.cpp
@@ -52,7 +52,7 @@ void EditorConfigPlugin::CreatePluginMenu(wxMenu* pluginsMenu)
 {
     wxMenu* menu = new wxMenu();
     menu->Append(new wxMenuItem(menu, XRCID("editor_config_settings"), _("Settings...")));
-    pluginsMenu->Append(wxID_ANY, "EditorConfig", menu);
+    pluginsMenu->Append(wxID_ANY, _("EditorConfig"), menu);
     menu->Bind(wxEVT_MENU, &EditorConfigPlugin::OnSettings, this, XRCID("editor_config_settings"));
 }
 

--- a/Gizmos/gizmos.cpp
+++ b/Gizmos/gizmos.cpp
@@ -203,7 +203,7 @@ void WizardsPlugin::CreatePluginMenu(wxMenu* pluginsMenu)
     item =
         new wxMenuItem(menu, ID_MI_NEW_WX_PROJECT, _("New wxWidgets Project Wizard..."), wxEmptyString, wxITEM_NORMAL);
     menu->Append(item);
-    pluginsMenu->Append(wxID_ANY, wxT("Wizards"), menu);
+    pluginsMenu->Append(wxID_ANY, _("Wizards"), menu);
 }
 
 void WizardsPlugin::HookPopupMenu(wxMenu* menu, MenuType type)

--- a/LLDBDebugger/LLDBLocalsView.cpp
+++ b/LLDBDebugger/LLDBLocalsView.cpp
@@ -303,18 +303,18 @@ void LLDBLocalsView::OnLocalsContextMenu(wxTreeEvent& event)
     }
 
     wxMenu menu;
-    menu.Append(wxID_COPY, wxString::Format("Copy value%s to clipboard", ((1 == selections.GetCount()) ? "" : "s")));
+    menu.Append(wxID_COPY, wxPLURAL("Copy value to clipboard", "Copy values to clipboard", selections.GetCount()));
     if(1 == selections.GetCount()) {
         menu.Append(lldbLocalsViewEditValueMenuId, _("Edit value"));
     }
     menu.Append(lldbLocalsViewAddWatchContextMenuId,
-                wxString::Format("Add watch%s", ((1 == selections.GetCount()) ? "" : "es")));
+                wxPLURAL("Add watch", "Add watches", selections.GetCount()));
 
     wxArrayTreeItemIds watches;
     GetWatchesFromSelections(watches);
     if(watches.GetCount()) {
         menu.Append(lldbLocalsViewRemoveWatchContextMenuId,
-                    wxString::Format("Remove watch%s", ((1 == watches.GetCount()) ? "" : "es")));
+                    wxPLURAL("Remove watch", "Remove watches", watches.GetCount()));
     }
 
     wxMenu* pSubMenu = LLDBFormat::CreateMenu();

--- a/LLDBDebugger/LLDBPlugin.cpp
+++ b/LLDBDebugger/LLDBPlugin.cpp
@@ -299,10 +299,10 @@ void LLDBPlugin::HookPopupMenu(wxMenu* menu, MenuType type)
     size_t numberOfMenuItems = 0;
 
     if(m_connector.IsCanInteract()) {
-        menu->Prepend(lldbJumpToCursorContextMenuId, wxT("Jump to Caret Line"));
+        menu->Prepend(lldbJumpToCursorContextMenuId, _("Jump to Caret Line"));
         ++numberOfMenuItems;
 
-        menu->Prepend(lldbRunToCursorContextMenuId, wxT("Run to Caret Line"));
+        menu->Prepend(lldbRunToCursorContextMenuId, _("Run to Caret Line"));
         ++numberOfMenuItems;
     }
 
@@ -319,7 +319,7 @@ void LLDBPlugin::HookPopupMenu(wxMenu* menu, MenuType type)
     }
 
     if(!word.IsEmpty()) {
-        const auto menuItemText = wxString(wxT("Add Watch")) << wxT(" '") << word << wxT("'");
+        const auto menuItemText = wxString(_("Add Watch")) << wxT(" '") << word << wxT("'");
         menu->Prepend(lldbAddWatchContextMenuId, menuItemText);
         ++numberOfMenuItems;
     }

--- a/LLDBDebugger/LLDBThreadsView.cpp
+++ b/LLDBDebugger/LLDBThreadsView.cpp
@@ -140,15 +140,14 @@ void LLDBThreadsView::OnContextMenu(wxDataViewEvent& event)
 
     wxMenu menu;
     if(!threadIds.empty()) {
-        const auto suffix = (threadIds.size() > 1) ? wxT("s") : wxT("");
-        menu.Append(lldbSuspendThreadIds, wxString("Suspend thread") << suffix);
-        menu.Append(lldbSuspendOtherThreadIds, wxString("Suspend other threads"));
+        menu.Append(lldbSuspendThreadIds, wxPLURAL("Suspend thread", "Suspend threads", threadIds.size()));
+        menu.Append(lldbSuspendOtherThreadIds, _("Suspend other threads"));
         menu.AppendSeparator();
-        menu.Append(lldbResumeThreadIds, wxString("Resume thread") << suffix);
-        menu.Append(lldbResumeOtherThreadIds, wxString("Resume other threads"));
+        menu.Append(lldbResumeThreadIds, wxPLURAL("Resume thread", "Resume threads", threadIds.size()));
+        menu.Append(lldbResumeOtherThreadIds, _("Resume other threads"));
     }
 
-    menu.Append(lldbResumeAllThreadsId, wxString("Resume all threads"));
+    menu.Append(lldbResumeAllThreadsId, _("Resume all threads"));
 
     const auto sel = GetPopupMenuSelectionFromUser(menu);
 

--- a/LiteEditor/CompilersModifiedDlg.cpp
+++ b/LiteEditor/CompilersModifiedDlg.cpp
@@ -27,7 +27,7 @@
 #include <build_settings_config.h>
 #include <windowattrmanager.h>
 
-#define SELECT_COMPILER "<Click to select a compiler...>"
+#define SELECT_COMPILER _("<Click to select a compiler...>")
 
 CompilersModifiedDlg::CompilersModifiedDlg(wxWindow* parent, const wxStringSet_t& deletedCompilers)
     : CompilersModifiedDlgBase(parent)
@@ -44,7 +44,7 @@ CompilersModifiedDlg::CompilersModifiedDlg(wxWindow* parent, const wxStringSet_t
         m_props.push_back( prop );
         
         wxString message;
-        message << _("Create a new compiler named '") << *iter << "' by cloning an existing compiler";
+        message << _("Create a new compiler named '") << *iter << _("' by cloning an existing compiler");
         prop->SetHelpString( message );
     }
     SetName("CompilersModifiedDlg");

--- a/LiteEditor/DebuggerDisassemblyTab.cpp
+++ b/LiteEditor/DebuggerDisassemblyTab.cpp
@@ -247,7 +247,7 @@ void DebuggerDisassemblyTab::OnRefreshView(clCommandEvent& e)
     IDebugger* debugger = DebuggerMgr::Get().GetActiveDebugger();
     if(debugger && debugger->IsRunning() && ManagerST::Get()->DbgCanInteract()) {
         // Only update disass view if the view is visible
-        if(ManagerST::Get()->IsDebuggerViewVisible(DebuggerPane::DISASSEMBLY)) {
+        if(ManagerST::Get()->IsDebuggerViewVisible(wxGetTranslation(DebuggerPane::DISASSEMBLY))) {
             debugger->ListRegisters();
             debugger->Disassemble("", -1);
         }

--- a/LiteEditor/breakpointdlg.wxcp
+++ b/LiteEditor/breakpointdlg.wxcp
@@ -2719,7 +2719,7 @@
 										}, {
 											"type":	"multi-string",
 											"m_label":	"Tooltip:",
-											"m_value":	"You can add a condition to any breakpoint or watchpoint. The debugger will then stop only if the condition is met.\\nThe condition can be any simple or complex expression in your programming language,providing it returns a bool. However any variables that you use must be in scope.\\nIf you've previously set a condition and no longer want it, just clear this textctrl."
+											"m_value":	"You can add a condition to any breakpoint or watchpoint. The debugger will then stop only if the condition is met.\\nThe condition can be any simple or complex expression in your programming language, providing it returns a bool. However any variables that you use must be in scope.\\nIf you've previously set a condition and no longer want it, just clear this textctrl."
 										}, {
 											"type":	"colour",
 											"m_label":	"Bg Colour:",

--- a/LiteEditor/breakpointpropertiesdlg.cpp
+++ b/LiteEditor/breakpointpropertiesdlg.cpp
@@ -245,7 +245,7 @@ void BreakptPropertiesDlg::OnPageChanged(wxChoicebookEvent& event)
     if (!GetTitle().StartsWith("Properties")) {
         wxString tip =  (its_a_breakpt ?
                             "You can add a condition to any breakpoint. The debugger will then stop only if the condition is met.\n \
-The condition can be any simple or complex expression in your programming language,providing it returns a bool. However any variables that you use must be in scope.\n \
+The condition can be any simple or complex expression in your programming language, providing it returns a bool. However any variables that you use must be in scope.\n \
 If you've previously set a condition and no longer want it, just clear this textctrl." :
                         "It is not possible to Add a conditional watchpoint. Create a normal watchpoint first, then Edit it to add the conditon"
                         );

--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -4000,7 +4000,7 @@ void clEditor::OnDbgAddWatch(wxCommandEvent& event)
         }
     }
     clMainFrame::Get()->GetDebuggerPane()->GetWatchesTable()->AddExpression(word);
-    clMainFrame::Get()->GetDebuggerPane()->SelectTab(DebuggerPane::WATCHES);
+    clMainFrame::Get()->GetDebuggerPane()->SelectTab(wxGetTranslation(DebuggerPane::WATCHES));
     clMainFrame::Get()->GetDebuggerPane()->GetWatchesTable()->RefreshValues();
 }
 
@@ -4024,7 +4024,7 @@ void clEditor::OnDbgCustomWatch(wxCommandEvent& event)
         command = MacroManager::Instance()->Replace(command, wxT("variable"), word, true);
 
         clMainFrame::Get()->GetDebuggerPane()->GetWatchesTable()->AddExpression(command);
-        clMainFrame::Get()->GetDebuggerPane()->SelectTab(DebuggerPane::WATCHES);
+        clMainFrame::Get()->GetDebuggerPane()->SelectTab(wxGetTranslation(DebuggerPane::WATCHES));
         clMainFrame::Get()->GetDebuggerPane()->GetWatchesTable()->RefreshValues();
     }
 }

--- a/LiteEditor/compiler_page.wxcp
+++ b/LiteEditor/compiler_page.wxcp
@@ -3123,7 +3123,7 @@
 																				}, {
 																					"type":	"multi-string",
 																					"m_label":	"Tooltip:",
-																					"m_value":	"The C++ compiler path (plus optional flags). This tool is represented in the Makefile as $(CC)"
+																					"m_value":	"The C compiler path (plus optional flags). This tool is represented in the Makefile as $(CC)"
 																				}, {
 																					"type":	"colour",
 																					"m_label":	"Bg Colour:",
@@ -3643,7 +3643,7 @@
 																				}, {
 																					"type":	"multi-string",
 																					"m_label":	"Tooltip:",
-																					"m_value":	"On various platform (e.g. Cygwin) it is recommended to use their own sepcial gdb executable rather than the global one\\nYou can specify one here, or leave this empty to use the default"
+																					"m_value":	"On various platform (e.g. Cygwin) it is recommended to use their own special gdb executable rather than the global one\\nYou can specify one here, or leave this empty to use the default"
 																				}, {
 																					"type":	"colour",
 																					"m_label":	"Bg Colour:",

--- a/LiteEditor/compiler_pages.cpp
+++ b/LiteEditor/compiler_pages.cpp
@@ -355,7 +355,7 @@ CompilerMainPageBase::CompilerMainPageBase(wxWindow* parent, wxWindowID id, cons
 
     m_pgPropCC = m_pgMgrTools->AppendIn(m_pgProp94, new wxStringProperty(_("C Compiler"), wxPG_LABEL, wxT("")));
     m_pgPropCC->SetHelpString(
-        _("The C++ compiler path (plus optional flags). This tool is represented in the Makefile as $(CC)"));
+        _("The C compiler path (plus optional flags). This tool is represented in the Makefile as $(CC)"));
     m_pgPropCC->SetEditor(wxT("TextCtrlAndButton"));
 
     m_pgPropAS = m_pgMgrTools->AppendIn(m_pgProp94, new wxStringProperty(_("Assembler Name"), wxPG_LABEL, wxT("")));
@@ -391,7 +391,7 @@ CompilerMainPageBase::CompilerMainPageBase(wxWindow* parent, wxWindowID id, cons
 
     m_pgPropDebugger = m_pgMgrTools->AppendIn(m_pgProp94, new wxStringProperty(_("Gdb"), wxPG_LABEL, wxT("")));
     m_pgPropDebugger->SetHelpString(
-        _("On various platform (e.g. Cygwin) it is recommended to use their own sepcial gdb executable rather than the "
+        _("On various platform (e.g. Cygwin) it is recommended to use their own special gdb executable rather than the "
           "global one\nYou can specify one here, or leave this empty to use the default"));
     m_pgPropDebugger->SetEditor(wxT("TextCtrlAndButton"));
 

--- a/LiteEditor/configuration_manager_dlg.cpp
+++ b/LiteEditor/configuration_manager_dlg.cpp
@@ -82,8 +82,8 @@ wxArrayString ConfigurationManagerDlg::GetChoicesForProject(const wxString& proj
         }
     }
 
-    choices.Add(wxGetTranslation(clCMD_NEW));
-    choices.Add(wxGetTranslation(clCMD_EDIT));
+    choices.Add(clCMD_NEW);
+    choices.Add(clCMD_EDIT);
     return choices;
 }
 
@@ -108,8 +108,8 @@ void ConfigurationManagerDlg::PopulateConfigurations()
     }
 
     // append the 'New' & 'Delete' commands
-    m_choiceConfigurations->Append(wxGetTranslation(clCMD_NEW));
-    m_choiceConfigurations->Append(wxGetTranslation(clCMD_EDIT));
+    m_choiceConfigurations->Append(clCMD_NEW);
+    m_choiceConfigurations->Append(clCMD_EDIT);
 
     int sel = m_choiceConfigurations->FindString(m_currentWorkspaceConfiguration.IsEmpty()
                                                      ? matrix->GetSelectedConfigurationName()
@@ -150,9 +150,9 @@ void ConfigurationManagerDlg::LoadWorkspaceConfiguration(const wxString& confNam
 
 void ConfigurationManagerDlg::OnWorkspaceConfigSelected(wxCommandEvent& event)
 {
-    if(event.GetString() == wxGetTranslation(clCMD_NEW)) {
+    if(event.GetString() == clCMD_NEW) {
         OnButtonNew(event);
-    } else if(event.GetString() == wxGetTranslation(clCMD_EDIT)) {
+    } else if(event.GetString() == clCMD_EDIT) {
         // popup the delete dialog for configurations
         EditWorkspaceConfDlg dlg(this);
         dlg.ShowModal();
@@ -217,7 +217,7 @@ WorkspaceConfiguration::ConfigMappingList ConfigurationManagerDlg::GetCurrentSet
         wxDataViewItem item = m_dvListCtrl->RowToItem(i);
         wxString projectName = m_dvListCtrl->GetItemText(item, 0);
         wxString configName = m_dvListCtrl->GetItemText(item, 1);
-        if((configName != wxGetTranslation(clCMD_NEW)) && (configName != wxGetTranslation(clCMD_EDIT))) {
+        if((configName != clCMD_NEW) && (configName != clCMD_EDIT)) {
             ConfigMappingEntry entry(projectName, configName);
             list.push_back(entry);
         }
@@ -272,7 +272,7 @@ void ConfigurationManagerDlg::OnValueChanged(wxDataViewEvent& event)
     wxString projectName = m_dvListCtrl->GetItemText(event.GetItem(), 0);
     wxString selection = event.GetString(); // the new selection
 
-    if(selection == wxGetTranslation(clCMD_NEW)) {
+    if(selection == clCMD_NEW) {
         // popup the 'New Configuration' dialog
         NewConfigurationDlg dlg(this, projectName);
         if(dlg.ShowModal() == wxID_OK) {
@@ -281,7 +281,7 @@ void ConfigurationManagerDlg::OnValueChanged(wxDataViewEvent& event)
             PopulateConfigurations();
         }
         event.Veto(); // prevent the change from taking place
-    } else if(selection == wxGetTranslation(clCMD_EDIT)) {
+    } else if(selection == clCMD_EDIT) {
         EditConfigurationDialog dlg(this, projectName);
         if(dlg.ShowModal() == wxID_OK) {
             m_dirty = true;

--- a/LiteEditor/debuggerpane.cpp
+++ b/LiteEditor/debuggerpane.cpp
@@ -45,15 +45,15 @@
 #include "wx/xrc/xmlres.h"
 #include <wx/aui/framemanager.h>
 
-const wxString DebuggerPane::LOCALS = _("Locals");
-const wxString DebuggerPane::WATCHES = _("Watches");
-const wxString DebuggerPane::FRAMES = _("Call Stack");
-const wxString DebuggerPane::BREAKPOINTS = _("Breakpoints");
-const wxString DebuggerPane::THREADS = _("Threads");
-const wxString DebuggerPane::MEMORY = _("Memory");
-const wxString DebuggerPane::ASCII_VIEWER = _("Ascii Viewer");
-const wxString DebuggerPane::DEBUGGER_OUTPUT = _("Output");
-const wxString DebuggerPane::DISASSEMBLY = _("Disassemble");
+const wxString DebuggerPane::LOCALS = wxTRANSLATE("Locals");
+const wxString DebuggerPane::WATCHES = wxTRANSLATE("Watches");
+const wxString DebuggerPane::FRAMES = wxTRANSLATE("Call Stack");
+const wxString DebuggerPane::BREAKPOINTS = wxTRANSLATE("Breakpoints");
+const wxString DebuggerPane::THREADS = wxTRANSLATE("Threads");
+const wxString DebuggerPane::MEMORY = wxTRANSLATE("Memory");
+const wxString DebuggerPane::ASCII_VIEWER = wxTRANSLATE("Ascii Viewer");
+const wxString DebuggerPane::DEBUGGER_OUTPUT = wxTRANSLATE("Output");
+const wxString DebuggerPane::DISASSEMBLY = wxTRANSLATE("Disassemble");
 
 #define IS_DETACHED(name) (detachedPanes.Index(name) != wxNOT_FOUND) ? true : false
 

--- a/LiteEditor/debuggersettingsdlg.cpp
+++ b/LiteEditor/debuggersettingsdlg.cpp
@@ -124,9 +124,9 @@ void DebuggerPage::OnBrowse(wxCommandEvent& e)
     wxUnusedVar(e);
     wxString newfilepath, filepath(m_textCtrDbgPath->GetValue());
     if((!filepath.IsEmpty()) && wxFileName::FileExists(filepath)) {
-        newfilepath = wxFileSelector(wxT("Select file:"), filepath.c_str());
+        newfilepath = wxFileSelector(_("Select file:"), filepath.c_str());
     } else {
-        newfilepath = wxFileSelector(wxT("Select file:"));
+        newfilepath = wxFileSelector(_("Select file:"));
     }
 
     if(!newfilepath.IsEmpty()) { m_textCtrDbgPath->SetValue(newfilepath); }
@@ -191,8 +191,8 @@ void DbgPagePreDefTypes::OnDeleteSet(wxCommandEvent& event)
 
     wxString name = m_notebookPreDefTypes->GetPageText((size_t)sel);
     if(wxMessageBox(
-           wxString::Format(wxT("You are about to delete 'PreDefined Types' set '%s'\nContinue ?"), name.c_str()),
-           wxT("Confirm deleting 'PreDefined Types' set"), wxYES_NO | wxCENTER | wxICON_QUESTION, this) == wxYES) {
+           wxString::Format(_("You are about to delete 'PreDefined Types' set '%s'\nContinue ?"), name.c_str()),
+           _("Confirm deleting 'PreDefined Types' set"), wxYES_NO | wxCENTER | wxICON_QUESTION, this) == wxYES) {
         m_notebookPreDefTypes->DeletePage((size_t)sel);
     }
 }
@@ -226,7 +226,7 @@ void DbgPagePreDefTypes::OnNewSet(wxCommandEvent& event)
         // Make sure that a set with this name does not already exists
         for(size_t i = 0; i < m_notebookPreDefTypes->GetPageCount(); i++) {
             if(m_notebookPreDefTypes->GetPageText((size_t)i) == newName) {
-                wxMessageBox(wxT("A set with this name already exist"), wxT("Name Already Exists"),
+                wxMessageBox(_("A set with this name already exist"), _("Name Already Exists"),
                              wxICON_WARNING | wxOK | wxCENTER);
                 return;
             }
@@ -271,20 +271,20 @@ void DebuggerSettingsDlg::Initialize()
     // for each debugger, add page
     m_pages.clear();
     DebuggerPage* p = new DebuggerPage(m_notebook, "GNU gdb debugger");
-    m_notebook->AddPage(p, wxT("GNU gdb debugger"), true);
+    m_notebook->AddPage(p, _("GNU gdb debugger"), true);
     m_pages.push_back(p);
 
     wxNotebook* innerBook = p->GetNotebook73();
     DebuggerPageMisc* misc = new DebuggerPageMisc(innerBook, "GNU gdb debugger");
-    innerBook->AddPage(misc, wxT("Misc"), false);
+    innerBook->AddPage(misc, _("Misc"), false);
     m_pages.push_back(misc);
 
     DebuggerPageStartupCmds* cmds = new DebuggerPageStartupCmds(innerBook, "GNU gdb debugger");
-    innerBook->AddPage(cmds, wxT("Startup Commands"), false);
+    innerBook->AddPage(cmds, _("Startup Commands"), false);
     m_pages.push_back(cmds);
 
     DbgPagePreDefTypes* types = new DbgPagePreDefTypes(m_notebook);
-    m_notebook->AddPage(types, wxT("Pre-Defined Types"), false);
+    m_notebook->AddPage(types, _("Pre-Defined Types"), false);
     m_pages.push_back(types);
 }
 

--- a/LiteEditor/editor_options_guides.wxcp
+++ b/LiteEditor/editor_options_guides.wxcp
@@ -345,11 +345,11 @@
 												}, {
 													"type":	"string",
 													"m_label":	"Label:",
-													"m_value":	"Enable Relative line numbers."
+													"m_value":	"Enable Relative line numbers"
 												}, {
 													"type":	"multi-string",
 													"m_label":	"Tooltip:",
-													"m_value":	"m_pgPropRelativeLineNumbers"
+													"m_value":	"Enable Relative line numbers"
 												}, {
 													"type":	"colour",
 													"m_label":	"Bg Colour:",

--- a/LiteEditor/editoroptionsgeneralguidespanelbase.cpp
+++ b/LiteEditor/editoroptionsgeneralguidespanelbase.cpp
@@ -43,8 +43,8 @@ EditorOptionsGeneralGuidesPanelBase::EditorOptionsGeneralGuidesPanelBase(wxWindo
     m_pgPropDisplayLineNumbers->SetHelpString(_("Show line numbers margin"));
 
     m_pgPropRelativeLineNumbers = m_pgMgrGeneral->AppendIn(
-        m_pgPropCategoryGeneral, new wxBoolProperty(_("Enable Relative line numbers."), wxPG_LABEL, 0));
-    m_pgPropRelativeLineNumbers->SetHelpString(_("m_pgPropRelativeLineNumbers"));
+        m_pgPropCategoryGeneral, new wxBoolProperty(_("Enable Relative line numbers"), wxPG_LABEL, 0));
+    m_pgPropRelativeLineNumbers->SetHelpString(_("Enable Relative line numbers"));
 
     m_pgPropHighlightMatchedBrace = m_pgMgrGeneral->AppendIn(
         m_pgPropCategoryGeneral, new wxBoolProperty(_("Highlight matched braces"), wxPG_LABEL, 1));

--- a/LiteEditor/editorsettingslocal.cpp
+++ b/LiteEditor/editorsettingslocal.cpp
@@ -37,9 +37,9 @@ EditorSettingsLocal::EditorSettingsLocal(OptionsConfigPtr hrOptions, wxXmlNode* 
 {
     wxString label = title;
     if(level == pLevel_workspace) {
-        label = wxT("Workspace local editor preferences");
+        label = _("Workspace local editor preferences");
     } else if(level == pLevel_project) {
-        label = wxT("Project local editor preferences");
+        label = _("Project local editor preferences");
     }
     SetTitle(label);
 

--- a/LiteEditor/findinfilesdlg.cpp
+++ b/LiteEditor/findinfilesdlg.cpp
@@ -239,8 +239,11 @@ SearchData FindInFilesDialog::DoGetSearchData()
             wxString projectName = rootDir.Mid(3);
             DoAddProjectFiles(projectName, files);
 
-        } else if((rootDir == wxGetTranslation(SEARCH_IN_WORKSPACE_FOLDER)) &&
-                  clWorkspaceManager::Get().IsWorkspaceOpened()) {
+        } else if((rootDir == wxGetTranslation(SEARCH_IN_WORKSPACE_FOLDER)) ||
+                  (rootDir == SEARCH_IN_WORKSPACE_FOLDER)) {
+            if(!clWorkspaceManager::Get().IsWorkspaceOpened()) {
+                continue;
+            }
             // Add the workspace folder
             rootDirs.Add(clWorkspaceManager::Get().GetWorkspace()->GetFileName().GetPath());
 
@@ -339,24 +342,24 @@ void FindInFilesDialog::OnAddPath(wxCommandEvent& event)
     // Show a popup menu
     wxMenu menu;
     int firstItem = 8994;
-    menu.Append(firstItem + 6, "Add Folder...");
+    menu.Append(firstItem + 6, _("Add Folder..."));
     menu.AppendSeparator();
-    menu.Append(firstItem + 0, SEARCH_IN_WORKSPACE_FOLDER);
-    menu.Append(firstItem + 1, SEARCH_IN_WORKSPACE);
-    menu.Append(firstItem + 2, SEARCH_IN_PROJECT);
-    menu.Append(firstItem + 3, SEARCH_IN_CURR_FILE_PROJECT);
-    menu.Append(firstItem + 4, SEARCH_IN_CURRENT_FILE);
-    menu.Append(firstItem + 5, SEARCH_IN_OPEN_FILES);
+    menu.Append(firstItem + 0, wxGetTranslation(SEARCH_IN_WORKSPACE_FOLDER));
+    menu.Append(firstItem + 1, wxGetTranslation(SEARCH_IN_WORKSPACE));
+    menu.Append(firstItem + 2, wxGetTranslation(SEARCH_IN_PROJECT));
+    menu.Append(firstItem + 3, wxGetTranslation(SEARCH_IN_CURR_FILE_PROJECT));
+    menu.Append(firstItem + 4, wxGetTranslation(SEARCH_IN_CURRENT_FILE));
+    menu.Append(firstItem + 5, wxGetTranslation(SEARCH_IN_OPEN_FILES));
     menu.AppendSeparator();
-    menu.Append(firstItem + 7, "Add Exclude Pattern");
+    menu.Append(firstItem + 7, _("Add Exclude Pattern"));
 
     std::map<int, wxString> options;
-    options.insert(std::make_pair(firstItem + 0, SEARCH_IN_WORKSPACE_FOLDER));
-    options.insert(std::make_pair(firstItem + 1, SEARCH_IN_WORKSPACE));
-    options.insert(std::make_pair(firstItem + 2, SEARCH_IN_PROJECT));
-    options.insert(std::make_pair(firstItem + 3, SEARCH_IN_CURR_FILE_PROJECT));
-    options.insert(std::make_pair(firstItem + 4, SEARCH_IN_CURRENT_FILE));
-    options.insert(std::make_pair(firstItem + 5, SEARCH_IN_OPEN_FILES));
+    options.insert(std::make_pair(firstItem + 0, wxGetTranslation(SEARCH_IN_WORKSPACE_FOLDER)));
+    options.insert(std::make_pair(firstItem + 1, wxGetTranslation(SEARCH_IN_WORKSPACE)));
+    options.insert(std::make_pair(firstItem + 2, wxGetTranslation(SEARCH_IN_PROJECT)));
+    options.insert(std::make_pair(firstItem + 3, wxGetTranslation(SEARCH_IN_CURR_FILE_PROJECT)));
+    options.insert(std::make_pair(firstItem + 4, wxGetTranslation(SEARCH_IN_CURRENT_FILE)));
+    options.insert(std::make_pair(firstItem + 5, wxGetTranslation(SEARCH_IN_OPEN_FILES)));
 
     // Menu will be shown in client coordinates
     wxRect size = m_btnAddPath->GetSize();

--- a/LiteEditor/frame.cpp
+++ b/LiteEditor/frame.cpp
@@ -4335,7 +4335,7 @@ void clMainFrame::OnDebugCoreDump(wxCommandEvent& e)
                 ManagerST::Get()->ShowDebuggerPane();
             }
 
-            clMainFrame::Get()->GetDebuggerPane()->SelectTab(DebuggerPane::FRAMES);
+            clMainFrame::Get()->GetDebuggerPane()->SelectTab(wxGetTranslation(DebuggerPane::FRAMES));
             ManagerST::Get()->UpdateDebuggerPane();
 
             // Finally, get the call-stack and 'continue' gdb (which seems to be necessary for things to work...)

--- a/LiteEditor/localstable.cpp
+++ b/LiteEditor/localstable.cpp
@@ -449,7 +449,7 @@ void LocalsTable::OnStackSelected(clCommandEvent& event)
     event.Skip();
     Clear();
     IDebugger* dbgr = DebuggerMgr::Get().GetActiveDebugger();
-    if(dbgr && dbgr->IsRunning() && ManagerST::Get()->IsDebuggerViewVisible(DebuggerPane::LOCALS)) {
+    if(dbgr && dbgr->IsRunning() && ManagerST::Get()->IsDebuggerViewVisible(wxGetTranslation(DebuggerPane::LOCALS))) {
         dbgr->QueryLocals();
     }
 }

--- a/LiteEditor/manager.cpp
+++ b/LiteEditor/manager.cpp
@@ -710,7 +710,7 @@ void Manager::ImportMSVSSolution(const wxString& path, const wxString& defaultCo
         wxCommandEvent event(wxEVT_COMMAND_MENU_SELECTED, XRCID("retag_workspace"));
         clMainFrame::Get()->GetEventHandler()->AddPendingEvent(event);
     } else {
-        wxMessageBox(wxT("Solution/workspace unsupported"), wxMessageBoxCaptionStr, wxOK | wxCENTRE | wxSTAY_ON_TOP);
+        wxMessageBox(_("Solution/workspace unsupported"), wxMessageBoxCaptionStr, wxOK | wxCENTRE | wxSTAY_ON_TOP);
     }
 }
 
@@ -1918,7 +1918,7 @@ void Manager::DoUpdateDebuggerTabControl(wxWindow* curpage)
     if(!IsPaneVisible(wxT("Debugger")))
         return;
 
-    if(curpage == (wxWindow*)pane->GetBreakpointView() || IsPaneVisible(DebuggerPane::BREAKPOINTS)) {
+    if(curpage == (wxWindow*)pane->GetBreakpointView() || IsPaneVisible(wxGetTranslation(DebuggerPane::BREAKPOINTS))) {
         pane->GetBreakpointView()->Initialize();
     }
 
@@ -2596,7 +2596,7 @@ void Manager::UpdateGotControl(const DebuggerEventData& e)
         // Print the stack trace
         if(showDialog) {
             // select the "Call Stack" tab
-            clMainFrame::Get()->GetDebuggerPane()->SelectTab(DebuggerPane::FRAMES);
+            clMainFrame::Get()->GetDebuggerPane()->SelectTab(wxGetTranslation(DebuggerPane::FRAMES));
         }
 
         if(!userTriggered) {
@@ -2620,7 +2620,7 @@ void Manager::UpdateGotControl(const DebuggerEventData& e)
         // Print the stack trace
         wxAuiPaneInfo& info = clMainFrame::Get()->GetDockingManager().GetPane(wxT("Debugger"));
         if(info.IsShown()) {
-            clMainFrame::Get()->GetDebuggerPane()->SelectTab(DebuggerPane::FRAMES);
+            clMainFrame::Get()->GetDebuggerPane()->SelectTab(wxGetTranslation(DebuggerPane::FRAMES));
             CallAfter(&Manager::UpdateDebuggerPane);
         }
     } break;
@@ -2743,8 +2743,8 @@ void Manager::UpdateTypeReolsved(const wxString& expr, const wxString& type_name
     bool get_tip(false);
 
     Notebook* book = clMainFrame::Get()->GetDebuggerPane()->GetNotebook();
-    if(book->GetPageText(book->GetSelection()) == DebuggerPane::ASCII_VIEWER ||
-       IsPaneVisible(DebuggerPane::ASCII_VIEWER)) {
+    if(book->GetPageText(book->GetSelection()) == wxGetTranslation(DebuggerPane::ASCII_VIEWER) ||
+       IsPaneVisible(wxGetTranslation(DebuggerPane::ASCII_VIEWER))) {
         get_tip = true;
     }
 

--- a/LiteEditor/new_quick_watch_dlg.cpp
+++ b/LiteEditor/new_quick_watch_dlg.cpp
@@ -338,7 +338,7 @@ void DisplayVariableDlg::OnMenuSelection(wxCommandEvent& e)
         if(e.GetId() == XRCID("tip_add_watch")) {
             wxString fullpath = DoGetItemPath(item);
             clMainFrame::Get()->GetDebuggerPane()->GetWatchesTable()->AddExpression(fullpath);
-            clMainFrame::Get()->GetDebuggerPane()->SelectTab(DebuggerPane::WATCHES);
+            clMainFrame::Get()->GetDebuggerPane()->SelectTab(wxGetTranslation(DebuggerPane::WATCHES));
             clMainFrame::Get()->GetDebuggerPane()->GetWatchesTable()->RefreshValues();
 
         } else if(e.GetId() == XRCID("tip_copy_value")) {

--- a/LiteEditor/output_pane.cpp
+++ b/LiteEditor/output_pane.cpp
@@ -106,50 +106,50 @@ void OutputPane::CreateGUIControls()
 #if PHP_BUILD
     m_buildWin->Hide();
 #else
-    m_book->AddPage(m_buildWin, wxGetTranslation(BUILD_WIN), true, images->Add(wxT("build")));
+    m_book->AddPage(m_buildWin, BUILD_WIN, true, images->Add(wxT("build")));
     m_tabs.insert(
-        std::make_pair(wxGetTranslation(BUILD_WIN), Tab(wxGetTranslation(BUILD_WIN), m_buildWin, wxNOT_FOUND)));
-    mgr->AddOutputTab(wxGetTranslation(BUILD_WIN));
+        std::make_pair(BUILD_WIN, Tab(BUILD_WIN, m_buildWin, wxNOT_FOUND)));
+    mgr->AddOutputTab(BUILD_WIN);
 #endif
 
     // Find in files
-    m_findResultsTab = new FindResultsTab(m_book, wxID_ANY, wxGetTranslation(FIND_IN_FILES_WIN));
-    m_book->AddPage(m_findResultsTab, wxGetTranslation(FIND_IN_FILES_WIN), false, images->Add(wxT("find")));
-    m_tabs.insert(std::make_pair(wxGetTranslation(FIND_IN_FILES_WIN),
-                                 Tab(wxGetTranslation(FIND_IN_FILES_WIN), m_findResultsTab, images->Add(wxT("find")))));
-    mgr->AddOutputTab(wxGetTranslation(FIND_IN_FILES_WIN));
+    m_findResultsTab = new FindResultsTab(m_book, wxID_ANY, FIND_IN_FILES_WIN);
+    m_book->AddPage(m_findResultsTab, FIND_IN_FILES_WIN, false, images->Add(wxT("find")));
+    m_tabs.insert(std::make_pair(FIND_IN_FILES_WIN,
+                                 Tab(FIND_IN_FILES_WIN, m_findResultsTab, images->Add(wxT("find")))));
+    mgr->AddOutputTab(FIND_IN_FILES_WIN);
 
     // Replace In Files
-    m_replaceResultsTab = new ReplaceInFilesPanel(m_book, wxID_ANY, wxGetTranslation(REPLACE_IN_FILES));
-    m_book->AddPage(m_replaceResultsTab, wxGetTranslation(REPLACE_IN_FILES), false,
+    m_replaceResultsTab = new ReplaceInFilesPanel(m_book, wxID_ANY, REPLACE_IN_FILES);
+    m_book->AddPage(m_replaceResultsTab, REPLACE_IN_FILES, false,
                     images->Add(wxT("find_and_replace")));
     m_tabs.insert(std::make_pair(REPLACE_IN_FILES,
                                  Tab(REPLACE_IN_FILES, m_replaceResultsTab, images->Add(wxT("find_and_replace")))));
     mgr->AddOutputTab(REPLACE_IN_FILES);
 
     // Show Usage ("References")
-    m_showUsageTab = new FindUsageTab(m_book, wxGetTranslation(SHOW_USAGE));
+    m_showUsageTab = new FindUsageTab(m_book, SHOW_USAGE);
 #if PHP_BUILD
     m_showUsageTab->Hide();
 #else
-    m_book->AddPage(m_showUsageTab, wxGetTranslation(SHOW_USAGE), false, images->Add(wxT("find")));
-    m_tabs.insert(std::make_pair(wxGetTranslation(SHOW_USAGE),
-                                 Tab(wxGetTranslation(SHOW_USAGE), m_showUsageTab, images->Add(wxT("find")))));
-    mgr->AddOutputTab(wxGetTranslation(SHOW_USAGE));
+    m_book->AddPage(m_showUsageTab, SHOW_USAGE, false, images->Add(wxT("find")));
+    m_tabs.insert(std::make_pair(SHOW_USAGE,
+                                 Tab(SHOW_USAGE, m_showUsageTab, images->Add(wxT("find")))));
+    mgr->AddOutputTab(SHOW_USAGE);
 #endif
     // Output tab
-    m_outputWind = new OutputTab(m_book, wxID_ANY, wxGetTranslation(OUTPUT_WIN));
-    m_book->AddPage(m_outputWind, wxGetTranslation(OUTPUT_WIN), false, images->Add(wxT("console")));
-    m_tabs.insert(std::make_pair(wxGetTranslation(OUTPUT_WIN),
-                                 Tab(wxGetTranslation(OUTPUT_WIN), m_outputWind, images->Add(wxT("console")))));
-    mgr->AddOutputTab(wxGetTranslation(OUTPUT_WIN));
+    m_outputWind = new OutputTab(m_book, wxID_ANY, OUTPUT_WIN);
+    m_book->AddPage(m_outputWind, OUTPUT_WIN, false, images->Add(wxT("console")));
+    m_tabs.insert(std::make_pair(OUTPUT_WIN,
+                                 Tab(OUTPUT_WIN, m_outputWind, images->Add(wxT("console")))));
+    mgr->AddOutputTab(OUTPUT_WIN);
 
     // Tasks panel
-    m_taskPanel = new TaskPanel(m_book, wxID_ANY, wxGetTranslation(TASKS));
-    m_book->AddPage(m_taskPanel, wxGetTranslation(TASKS), false, images->Add("tasks"));
+    m_taskPanel = new TaskPanel(m_book, wxID_ANY, TASKS);
+    m_book->AddPage(m_taskPanel, TASKS, false, images->Add("tasks"));
     m_tabs.insert(
-        std::make_pair(wxGetTranslation(TASKS), Tab(wxGetTranslation(TASKS), m_taskPanel, images->Add("tasks"))));
-    mgr->AddOutputTab(wxGetTranslation(TASKS));
+        std::make_pair(TASKS, Tab(TASKS, m_taskPanel, images->Add("tasks"))));
+    mgr->AddOutputTab(TASKS);
 
     SetMinSize(wxSize(200, 100));
     mainSizer->Layout();

--- a/LiteEditor/quickdebugbase.cpp
+++ b/LiteEditor/quickdebugbase.cpp
@@ -118,7 +118,7 @@ QuickDebugBase::QuickDebugBase(wxWindow* parent, wxWindowID id, const wxString& 
 
     m_buttonBrowseExe =
         new wxButton(m_panelLocal, wxID_ANY, _("..."), wxDefaultPosition, wxDLG_UNIT(m_panelLocal, wxSize(-1, -1)), 0);
-    m_buttonBrowseExe->SetToolTip(_("Select executale to debug"));
+    m_buttonBrowseExe->SetToolTip(_("Select executable to debug"));
 
     flexGridSizer24->Add(m_buttonBrowseExe, 0, wxRIGHT | wxALIGN_CENTER_VERTICAL, WXC_FROM_DIP(5));
 

--- a/LiteEditor/reconcileproject.cpp
+++ b/LiteEditor/reconcileproject.cpp
@@ -110,7 +110,7 @@ bool ReconcileProjectDlg::LoadData()
 
     m_allfiles.clear();
     {
-        wxBusyInfo wait("Searching for files...", this);
+        wxBusyInfo wait(_("Searching for files..."), this);
         wxSafeYield();
 
         clFilesScanner scanner;

--- a/LiteEditor/tabgroupspane.cpp
+++ b/LiteEditor/tabgroupspane.cpp
@@ -800,7 +800,7 @@ void TabgroupsPane::AddFile(const wxString& filename)
 
 wxTreeItemId TabgroupsPane::GetRootItemForTabgroup(bool global)
 {
-    wxString label = global ? "Global tabgroups" : "Workspace tabgroups";
+    wxString label = global ? _("Global tabgroups") : _("Workspace tabgroups");
 
     // First see if the appropriate tabgroup base-item has already been created
     wxTreeItemIdValue cookie;

--- a/LiteEditor/tags_options_base_dlg.cpp
+++ b/LiteEditor/tags_options_base_dlg.cpp
@@ -156,7 +156,7 @@ TagsOptionsBaseDlg::TagsOptionsBaseDlg(wxWindow* parent, wxWindowID id, const wx
     flexGridSizer127->Add(m_checkBoxDeepUsingNamespaceResolving, 0, wxALL, WXC_FROM_DIP(5));
 
     m_checkBoxGenCompileCommandsJSON =
-        new wxCheckBox(m_paneDisplayAndBehavior, wxID_ANY, _("Generate compile_commans.json file"), wxDefaultPosition,
+        new wxCheckBox(m_paneDisplayAndBehavior, wxID_ANY, _("Generate compile_commands.json file"), wxDefaultPosition,
                        wxDLG_UNIT(m_paneDisplayAndBehavior, wxSize(-1, -1)), 0);
     m_checkBoxGenCompileCommandsJSON->SetValue(false);
 
@@ -459,7 +459,7 @@ TagsOptionsBaseDlg::TagsOptionsBaseDlg(wxWindow* parent, wxWindowID id, const wx
     boxSizer130->Add(m_staticText9, 0, wxALL | wxEXPAND, WXC_FROM_DIP(5));
 
     m_hyperlink1 = new wxHyperlinkCtrl(m_panelClangGeneral, wxID_ANY, _("Macros Handling"),
-                                       wxT("http://codelite.org/LiteEditor/MacrosHandling101"), wxDefaultPosition,
+                                       wxT("https://wiki.codelite.org/pmwiki.php/Main/MacrosHandling101"), wxDefaultPosition,
                                        wxDLG_UNIT(m_panelClangGeneral, wxSize(-1, -1)), wxHL_DEFAULT_STYLE);
 
     boxSizer130->Add(m_hyperlink1, 0, wxALL | wxALIGN_CENTER_HORIZONTAL, WXC_FROM_DIP(5));

--- a/MemCheck/memcheck.cpp
+++ b/MemCheck/memcheck.cpp
@@ -130,23 +130,23 @@ void MemCheckPlugin::CreatePluginMenu(wxMenu* pluginsMenu)
     wxMenu* menu = new wxMenu();
     wxMenuItem* item(NULL);
 
-    item = new wxMenuItem(menu, XRCID("memcheck_check_active_project"), wxT("&Run MemCheck"), wxEmptyString,
+    item = new wxMenuItem(menu, XRCID("memcheck_check_active_project"), _("&Run MemCheck"), wxEmptyString,
                           wxITEM_NORMAL);
     item->SetBitmap(wxXmlResource::Get()->LoadBitmap(wxT("memcheck_check")));
     menu->Append(item);
 
-    item = new wxMenuItem(menu, XRCID("memcheck_import"), wxT("&Load MemCheck log from file..."), wxEmptyString,
+    item = new wxMenuItem(menu, XRCID("memcheck_import"), _("&Load MemCheck log from file..."), wxEmptyString,
                           wxITEM_NORMAL);
     item->SetBitmap(wxXmlResource::Get()->LoadBitmap(wxT("memcheck_import")));
     menu->Append(item);
 
     menu->AppendSeparator();
 
-    item = new wxMenuItem(menu, XRCID("memcheck_settings"), wxT("&Settings..."), wxEmptyString, wxITEM_NORMAL);
+    item = new wxMenuItem(menu, XRCID("memcheck_settings"), _("&Settings..."), wxEmptyString, wxITEM_NORMAL);
     item->SetBitmap(wxXmlResource::Get()->LoadBitmap(wxT("memcheck_settings")));
     menu->Append(item);
 
-    item = new wxMenuItem(pluginsMenu, wxID_ANY, wxT("MemCheck"), wxEmptyString, wxITEM_NORMAL, menu);
+    item = new wxMenuItem(pluginsMenu, wxID_ANY, _("MemCheck"), wxEmptyString, wxITEM_NORMAL, menu);
     item->SetBitmap(wxXmlResource::Get()->LoadBitmap(wxT("memcheck_check")));
     pluginsMenu->Append(item);
 }
@@ -159,12 +159,12 @@ void MemCheckPlugin::HookPopupMenu(wxMenu* menu, MenuType type)
             wxMenu* subMenu = new wxMenu();
             wxMenuItem* item(NULL);
 
-            item = new wxMenuItem(subMenu, XRCID("memcheck_check_popup_project"), wxT("&Run MemCheck"), wxEmptyString,
+            item = new wxMenuItem(subMenu, XRCID("memcheck_check_popup_project"), _("&Run MemCheck"), wxEmptyString,
                                   wxITEM_NORMAL);
             item->SetBitmap(wxXmlResource::Get()->LoadBitmap(wxT("memcheck_check")));
             subMenu->Append(item);
 
-            item = new wxMenuItem(subMenu, XRCID("memcheck_import"), wxT("&Load MemCheck log from file..."),
+            item = new wxMenuItem(subMenu, XRCID("memcheck_import"), _("&Load MemCheck log from file..."),
                                   wxEmptyString, wxITEM_NORMAL);
             item->SetBitmap(wxXmlResource::Get()->LoadBitmap(wxT("memcheck_import")));
             subMenu->Append(item);
@@ -172,7 +172,7 @@ void MemCheckPlugin::HookPopupMenu(wxMenu* menu, MenuType type)
             subMenu->AppendSeparator();
 
             item =
-                new wxMenuItem(subMenu, XRCID("memcheck_settings"), wxT("&Settings..."), wxEmptyString, wxITEM_NORMAL);
+                new wxMenuItem(subMenu, XRCID("memcheck_settings"), _("&Settings..."), wxEmptyString, wxITEM_NORMAL);
             item->SetBitmap(wxXmlResource::Get()->LoadBitmap(wxT("memcheck_settings")));
             subMenu->Append(item);
 
@@ -336,7 +336,7 @@ void MemCheckPlugin::CheckProject(const wxString& projectName)
     wxString cmdArgs;
     m_memcheckProcessor->GetExecutionCommand(command, cmd, cmdArgs);
     m_mgr->AppendOutputTabText(kOutputTab_Output, wxString()
-                                                      << "MemCheck command: " << command << " " << cmdArgs << "\n");
+                                                      << _("MemCheck command: ") << command << " " << cmdArgs << "\n");
     m_terminal.ExecuteConsole(cmd, true, cmdArgs, "", wxString::Format("MemCheck: %s", projectName));
 }
 
@@ -344,17 +344,17 @@ void MemCheckPlugin::OnImportLog(wxCommandEvent& event)
 {
     // CL_DEBUG1(PLUGIN_PREFIX("MemCheckPlugin::OnImportLog()"));
 
-    wxFileDialog openFileDialog(m_mgr->GetTheApp()->GetTopWindow(), wxT("Open log file"), "", "",
+    wxFileDialog openFileDialog(m_mgr->GetTheApp()->GetTopWindow(), _("Open log file"), "", "",
                                 "xml files (*.xml)|*.xml|all files (*.*)|*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if(openFileDialog.ShowModal() == wxID_CANCEL)
         return;
 
     wxWindowDisabler disableAll;
-    wxBusyInfo wait(wxT(BUSY_MESSAGE));
+    wxBusyInfo wait(BUSY_MESSAGE);
     m_mgr->GetTheApp()->Yield();
 
     if(!m_memcheckProcessor->Process(openFileDialog.GetPath()))
-        wxMessageBox(wxT("Output log file cannot be properly loaded."), wxT("Processing error."), wxICON_ERROR);
+        wxMessageBox(_("Output log file cannot be properly loaded."), _("Processing error."), wxICON_ERROR);
 
     m_outputView->LoadErrors();
     SwitchToMyPage();
@@ -388,7 +388,7 @@ void MemCheckPlugin::OnProcessOutput(clCommandEvent& event)
 void MemCheckPlugin::OnProcessTerminated(clCommandEvent& event)
 {
     m_mgr->AppendOutputTabText(kOutputTab_Output, _("\n-- MemCheck process completed\n"));
-    wxBusyInfo wait(wxT(BUSY_MESSAGE));
+    wxBusyInfo wait(BUSY_MESSAGE);
     m_mgr->GetTheApp()->Yield();
 
     m_memcheckProcessor->Process();

--- a/MemCheck/memcheckdefs.h
+++ b/MemCheck/memcheckdefs.h
@@ -36,7 +36,7 @@
 #define _MEMCHECKDEFS_H_
 
 #define PLUGIN_PREFIX(...) "[MemCheck] %s", wxString::Format(__VA_ARGS__)
-#define BUSY_MESSAGE "Please wait, working..."
+#define BUSY_MESSAGE _("Please wait, working...")
 #define SUPPRESSION_NAME_PLACEHOLDER "<insert_a_suppression_name_here>"
 #define FILTER_NONWORKSPACE_PLACEHOLDER "<nonworkspace_errors>"
 #define WAIT_UPDATE_PER_ITEMS 1000

--- a/MemCheck/memcheckoutputview.cpp
+++ b/MemCheck/memcheckoutputview.cpp
@@ -163,7 +163,7 @@ void MemCheckOutputView::ShowPageView(size_t page)
     if(m_currentPageIsEmptyView) return;
 
     wxWindowDisabler disableAll;
-    wxBusyInfo wait(wxT(BUSY_MESSAGE));
+    wxBusyInfo wait(BUSY_MESSAGE);
     m_mgr->GetTheApp()->Yield();
 
     unsigned int flags = 0;
@@ -464,24 +464,24 @@ void MemCheckOutputView::OnContextMenu(wxDataViewEvent& event)
     wxMenuItem* menuItem(NULL);
     wxMenu menu;
 
-    menuItem = menu.Append(XRCID("memcheck_jump_to_location"), wxT("Jump to location"));
+    menuItem = menu.Append(XRCID("memcheck_jump_to_location"), _("Jump to location"));
     menuItem->Enable(dataItem.IsOk() && !m_dataViewCtrlErrorsModel->IsContainer(dataItem));
     menu.AppendSeparator();
-    menuItem = menu.Append(XRCID("memcheck_mark_all_errors"), "Mark all");
+    menuItem = menu.Append(XRCID("memcheck_mark_all_errors"), _("Mark all"));
     menuItem->Enable(unmarked);
-    menuItem = menu.Append(XRCID("memcheck_unmark_all_errors"), wxT("Unmark all"));
+    menuItem = menu.Append(XRCID("memcheck_unmark_all_errors"), _("Unmark all"));
     menuItem->Enable(marked);
     menu.AppendSeparator();
-    menuItem = menu.Append(XRCID("memcheck_suppress_error"), wxT("Suppress this error"));
+    menuItem = menu.Append(XRCID("memcheck_suppress_error"), _("Suppress this error"));
     menuItem->Enable(dataItem.IsOk() && m_choiceSuppFile->GetSelection() != wxNOT_FOUND);
-    menuItem = menu.Append(XRCID("memcheck_suppress_marked_errors"), wxT("Suppress all marked errors"));
+    menuItem = menu.Append(XRCID("memcheck_suppress_marked_errors"), _("Suppress all marked errors"));
     menuItem->Enable(marked && m_choiceSuppFile->GetSelection() != wxNOT_FOUND);
     menu.AppendSeparator();
-    menuItem = menu.Append(XRCID("memcheck_row_to_clip"), wxT("Copy line as string to clipboard"));
+    menuItem = menu.Append(XRCID("memcheck_row_to_clip"), _("Copy line as string to clipboard"));
     menuItem->Enable(dataItem.IsOk());
-    menuItem = menu.Append(XRCID("memcheck_error_to_clip"), wxT("Copy error as string to clipboard"));
+    menuItem = menu.Append(XRCID("memcheck_error_to_clip"), _("Copy error as string to clipboard"));
     menuItem->Enable(dataItem.IsOk());
-    menuItem = menu.Append(XRCID("memcheck_marked_errors_to_clip"), wxT("Copy marked errors to clipboard"));
+    menuItem = menu.Append(XRCID("memcheck_marked_errors_to_clip"), _("Copy marked errors to clipboard"));
     menuItem->Enable(marked);
 
     menu.Connect(XRCID("memcheck_jump_to_location"), wxEVT_COMMAND_MENU_SELECTED,
@@ -663,7 +663,7 @@ void MemCheckOutputView::OnSuppFileOpen(wxCommandEvent& event)
 
 void MemCheckOutputView::UpdateStatusSupp()
 {
-    m_staticTextSuppStatus->SetLabel(wxString::Format("Total: %lu  Filtered: %lu  Selected: %d", m_totalErrorsSupp,
+    m_staticTextSuppStatus->SetLabel(wxString::Format(_("Total: %lu  Filtered: %lu  Selected: %d"), m_totalErrorsSupp,
         m_filterResults.size(), m_listCtrlErrors->GetSelectedItemCount()));
     m_staticTextSuppStatus->GetParent()->Layout();
 }
@@ -803,7 +803,7 @@ void MemCheckOutputView::ApplyFilterSupp(unsigned int mode)
         int pos = 0, len = 0;
         if(m_totalErrorsSupp > ITEMS_FOR_WAIT_DIALOG) {
             wxWindowDisabler disableAll;
-            wxBusyInfo wait(wxT(BUSY_MESSAGE));
+            wxBusyInfo wait(BUSY_MESSAGE);
             m_mgr->GetTheApp()->Yield();
         }
         size_t i = 0;

--- a/MemCheck/memchecksettingsdialog.cpp
+++ b/MemCheck/memchecksettingsdialog.cpp
@@ -97,7 +97,7 @@ void MemCheckSettingsDialog::OnAddSupp(wxCommandEvent& event)
 {
     // ATTN  m_mgr->GetTheApp()
     wxFileDialog openFileDialog(wxTheApp->GetTopWindow(),
-                                wxT("Add suppression file(s)"),
+                                _("Add suppression file(s)"),
                                 "",
                                 "",
                                 "suppression files (*.supp)|*.supp|all files (*.*)|*.*",
@@ -131,8 +131,8 @@ void MemCheckSettingsDialog::OnSuppListRightDown(wxMouseEvent& event)
         m_listBoxSuppFiles->SetSelection(index);
     }
 
-    menuItem = menu.Append(XRCID("memcheck_add_supp"), wxT("Add suppression file(s)..."));
-    menuItem = menu.Append(XRCID("memcheck_del_supp"), wxT("Remove suppression file(s)"));
+    menuItem = menu.Append(XRCID("memcheck_add_supp"), _("Add suppression file(s)..."));
+    menuItem = menu.Append(XRCID("memcheck_del_supp"), _("Remove suppression file(s)"));
     menuItem->Enable(m_listBoxSuppFiles->HitTest(event.GetPosition()) != wxNOT_FOUND);
 
     menu.Connect(XRCID("memcheck_add_supp"),

--- a/PHPRefactoring/phprefactoring.cpp
+++ b/PHPRefactoring/phprefactoring.cpp
@@ -135,13 +135,13 @@ void PHPRefactoring::OnExtractMethod(wxCommandEvent& e)
 
     int startLine = editor->LineFromPos(editor->GetSelectionStart()) + 1;
     int endLine = editor->LineFromPos(editor->GetSelectionEnd()) + 1;
-    wxString method = wxGetTextFromUser("Name the new methode");
+    wxString method = wxGetTextFromUser("Name the new method");
     if(method.IsEmpty()) {
         return;
     }
 
     if(method.Contains(" ")) {
-        ::wxMessageBox(_("Methode name may not contain spaces"), "PHPRefactoring", wxICON_ERROR | wxOK | wxCENTER);
+        ::wxMessageBox(_("Method name may not contain spaces"), "PHPRefactoring", wxICON_ERROR | wxOK | wxCENTER);
         return;
     }
 

--- a/Plugin/AddSSHAcountDlg.cpp
+++ b/Plugin/AddSSHAcountDlg.cpp
@@ -91,7 +91,7 @@ void AddSSHAcountDlg::OnTestConnection(wxCommandEvent& event)
 
         // Try the login methods:
         ssh->Login();
-        ::wxMessageBox("Successfully connected to host!");
+        ::wxMessageBox(_("Successfully connected to host!"));
 
     } catch(clException& e) {
         ::wxMessageBox(e.What(), "SSH", wxICON_WARNING | wxOK, this);

--- a/Plugin/EnvironmentVariablesDlg.cpp
+++ b/Plugin/EnvironmentVariablesDlg.cpp
@@ -116,7 +116,7 @@ void EnvironmentVariablesDlg::OnDeleteSet(wxCommandEvent& event)
     if(selection == wxNOT_FOUND) return;
 
     wxString name = m_book->GetPageText((size_t)selection);
-    if(wxMessageBox(wxString::Format(wxT("Delete environment variables set\n'%s' ?"), name.c_str()), wxT("Confirm"),
+    if(wxMessageBox(wxString::Format(_("Delete environment variables set\n'%s' ?"), name.c_str()), _("Confirm"),
                     wxYES_NO | wxICON_QUESTION, this) != wxYES)
         return;
     m_book->DeletePage((size_t)selection);

--- a/Plugin/FSConfigPage.cpp
+++ b/Plugin/FSConfigPage.cpp
@@ -23,7 +23,7 @@
 #include "sftp_settings.h"
 #endif
 
-#define OPEN_SSH_ACCOUNT_MANAGER "-- Open SSH Account Manager --"
+#define OPEN_SSH_ACCOUNT_MANAGER _("-- Open SSH Account Manager --")
 
 FSConfigPage::FSConfigPage(wxWindow* parent, clFileSystemWorkspaceConfig::Ptr_t config, bool enableRemotePage)
     : FSConfigPageBase(parent)

--- a/Plugin/SFTPBrowserDlg.cpp
+++ b/Plugin/SFTPBrowserDlg.cpp
@@ -437,7 +437,7 @@ void SFTPBrowserDlg::ClearView()
 
 void SFTPBrowserDlg::DoBrowse()
 {
-    wxBusyInfo wait("Please wait, connecting...", this);
+    wxBusyInfo wait(_("Please wait, connecting..."), this);
     wxBusyCursor bc;
     wxTheApp->Yield();
     DoCloseSession();

--- a/Plugin/builder_NMake.cpp
+++ b/Plugin/builder_NMake.cpp
@@ -253,7 +253,7 @@ bool BuilderNMake::Export(const wxString& project, const wxString& confToBuild, 
                 continue;
             }
 
-            text << wxT("\t@echo \"") << wxGetTranslation(BUILD_PROJECT_PREFIX) << dependProj->GetName() << wxT(" - ")
+            text << wxT("\t@echo \"") << BUILD_PROJECT_PREFIX << dependProj->GetName() << wxT(" - ")
                  << projectSelConf << wxT(" ]----------\"\n");
             // make the paths relative, if it's sensible to do so
             wxFileName fn(dependProj->GetFileName());
@@ -333,7 +333,7 @@ bool BuilderNMake::Export(const wxString& project, const wxString& confToBuild, 
         projectSelConf = confToBuild;
     }
 
-    text << wxT("\t@echo \"") << wxGetTranslation(BUILD_PROJECT_PREFIX) << project << wxT(" - ") << projectSelConf
+    text << wxT("\t@echo \"") << BUILD_PROJECT_PREFIX << project << wxT(" - ") << projectSelConf
          << wxT(" ]----------\"\n");
 
     // make the paths relative, if it's sensible to do so
@@ -372,7 +372,7 @@ bool BuilderNMake::Export(const wxString& project, const wxString& confToBuild, 
                 continue;
             }
 
-            text << wxT("\t@echo \"") << wxGetTranslation(CLEAN_PROJECT_PREFIX) << dependProj->GetName() << wxT(" - ")
+            text << wxT("\t@echo \"") << CLEAN_PROJECT_PREFIX << dependProj->GetName() << wxT(" - ")
                  << projectSelConf << wxT(" ]----------\"\n");
 
             // make the paths relative
@@ -446,7 +446,7 @@ bool BuilderNMake::Export(const wxString& project, const wxString& confToBuild, 
         projectSelConf = confToBuild;
     }
 
-    text << wxT("\t@echo \"") << wxGetTranslation(CLEAN_PROJECT_PREFIX) << project << wxT(" - ") << projectSelConf
+    text << wxT("\t@echo \"") << CLEAN_PROJECT_PREFIX << project << wxT(" - ") << projectSelConf
          << wxT(" ]----------\"\n");
     if(isPluginGeneratedMakefile) {
 

--- a/Plugin/builder_gnumake.cpp
+++ b/Plugin/builder_gnumake.cpp
@@ -238,7 +238,7 @@ bool BuilderGNUMakeClassic::Export(const wxString& project, const wxString& conf
                 continue;
             }
 
-            text << wxT("\t@echo \"") << wxGetTranslation(BUILD_PROJECT_PREFIX) << dependProj->GetName() << wxT(" - ")
+            text << wxT("\t@echo \"") << BUILD_PROJECT_PREFIX << dependProj->GetName() << wxT(" - ")
                  << projectSelConf << wxT(" ]----------\"\n");
             // make the paths relative, if it's sensible to do so
             wxFileName fn(dependProj->GetFileName());
@@ -318,7 +318,7 @@ bool BuilderGNUMakeClassic::Export(const wxString& project, const wxString& conf
         projectSelConf = confToBuild;
     }
 
-    text << wxT("\t@echo \"") << wxGetTranslation(BUILD_PROJECT_PREFIX) << project << wxT(" - ") << projectSelConf
+    text << wxT("\t@echo \"") << BUILD_PROJECT_PREFIX << project << wxT(" - ") << projectSelConf
          << wxT(" ]----------\"\n");
 
     // make the paths relative, if it's sensible to do so
@@ -357,7 +357,7 @@ bool BuilderGNUMakeClassic::Export(const wxString& project, const wxString& conf
                 continue;
             }
 
-            text << wxT("\t@echo \"") << wxGetTranslation(CLEAN_PROJECT_PREFIX) << dependProj->GetName() << wxT(" - ")
+            text << wxT("\t@echo \"") << CLEAN_PROJECT_PREFIX << dependProj->GetName() << wxT(" - ")
                  << projectSelConf << wxT(" ]----------\"\n");
 
             // make the paths relative
@@ -431,7 +431,7 @@ bool BuilderGNUMakeClassic::Export(const wxString& project, const wxString& conf
         projectSelConf = confToBuild;
     }
 
-    text << wxT("\t@echo \"") << wxGetTranslation(CLEAN_PROJECT_PREFIX) << project << wxT(" - ") << projectSelConf
+    text << wxT("\t@echo \"") << CLEAN_PROJECT_PREFIX << project << wxT(" - ") << projectSelConf
          << wxT(" ]----------\"\n");
     if(isPluginGeneratedMakefile) {
 

--- a/Plugin/builder_gnumake_default.cpp
+++ b/Plugin/builder_gnumake_default.cpp
@@ -270,7 +270,7 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
                 continue;
             }
 
-            text << wxT("\t@echo \"") << wxGetTranslation(BUILD_PROJECT_PREFIX) << dependProj->GetName() << wxT(" - ")
+            text << wxT("\t@echo \"") << BUILD_PROJECT_PREFIX << dependProj->GetName() << wxT(" - ")
                  << projectSelConf << wxT(" ]----------\"\n");
             // make the paths relative, if it's sensible to do so
             wxFileName fn(dependProj->GetFileName());
@@ -349,7 +349,7 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
         projectSelConf = confToBuild;
     }
 
-    text << wxT("\t@echo \"") << wxGetTranslation(BUILD_PROJECT_PREFIX) << project << wxT(" - ") << projectSelConf
+    text << wxT("\t@echo \"") << BUILD_PROJECT_PREFIX << project << wxT(" - ") << projectSelConf
          << wxT(" ]----------\"\n");
 
     // make the paths relative, if it's sensible to do so
@@ -388,7 +388,7 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
                 continue;
             }
 
-            text << wxT("\t@echo \"") << wxGetTranslation(CLEAN_PROJECT_PREFIX) << dependProj->GetName() << wxT(" - ")
+            text << wxT("\t@echo \"") << CLEAN_PROJECT_PREFIX << dependProj->GetName() << wxT(" - ")
                  << projectSelConf << wxT(" ]----------\"\n");
 
             // make the paths relative
@@ -462,7 +462,7 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
         projectSelConf = confToBuild;
     }
 
-    text << wxT("\t@echo \"") << wxGetTranslation(CLEAN_PROJECT_PREFIX) << project << wxT(" - ") << projectSelConf
+    text << wxT("\t@echo \"") << CLEAN_PROJECT_PREFIX << project << wxT(" - ") << projectSelConf
          << wxT(" ]----------\"\n");
     if(isPluginGeneratedMakefile) {
 

--- a/Plugin/clRemoteBuilder.cpp
+++ b/Plugin/clRemoteBuilder.cpp
@@ -44,7 +44,7 @@ void clRemoteBuilder::Build(const wxString& sshAccount, const wxString& command,
 
     wxFileName ssh;
     if(!clFindExecutable("ssh", ssh)) {
-        wxMessageBox(_("Could not locaet ssh executable"), "CodeLite", wxICON_WARNING | wxOK);
+        wxMessageBox(_("Could not locate ssh executable"), "CodeLite", wxICON_WARNING | wxOK);
         return;
     }
 

--- a/Plugin/clStatusBar.cpp
+++ b/Plugin/clStatusBar.cpp
@@ -487,11 +487,11 @@ void clStatusBar::DoFieldClicked(int fieldIndex)
             CHECK_PTR_RET(field);
             wxStyledTextCtrl* stc = m_mgr->GetActiveEditor()->GetCtrl();
             wxMenu menu;
-            wxMenuItem* idConvertToTabs = menu.Append(wxID_ANY, "Convert Indentations to Tabs");
-            wxMenuItem* idConvertToSpaces = menu.Append(wxID_ANY, "Convert Indentations to Spaces");
+            wxMenuItem* idConvertToTabs = menu.Append(wxID_ANY, _("Convert Indentations to Tabs"));
+            wxMenuItem* idConvertToSpaces = menu.Append(wxID_ANY, _("Convert Indentations to Spaces"));
             menu.AppendSeparator();
-            wxMenuItem* idUseTabs = menu.Append(wxID_ANY, "Use Tabs", "", wxITEM_CHECK);
-            wxMenuItem* idUseSpaces = menu.Append(wxID_ANY, "Use Spaces", "", wxITEM_CHECK);
+            wxMenuItem* idUseTabs = menu.Append(wxID_ANY, _("Use Tabs"), "", wxITEM_CHECK);
+            wxMenuItem* idUseSpaces = menu.Append(wxID_ANY, _("Use Spaces"), "", wxITEM_CHECK);
 
             // Check the proper tabs vs spaces option
             menu.Check(idUseSpaces->GetId(), !stc->GetUseTabs());

--- a/Plugin/clean_request.cpp
+++ b/Plugin/clean_request.cpp
@@ -143,7 +143,7 @@ void CleanRequest::Process(IManager* manager)
         // also, send another message to the main frame, indicating which project is being built
         // and what configuration
         wxString text;
-        text << wxGetTranslation(CLEAN_PROJECT_PREFIX) << m_info.GetProject() << wxT(" - ") << configName << wxT(" ]");
+        text << CLEAN_PROJECT_PREFIX << m_info.GetProject() << wxT(" - ") << configName << wxT(" ]");
         text << wxT("----------\n");
         AppendLine(text);
     }

--- a/Plugin/compile_request.cpp
+++ b/Plugin/compile_request.cpp
@@ -194,7 +194,7 @@ void CompileRequest::Process(IManager* manager)
         // also, send another message to the main frame, indicating which project is being built
         // and what configuration
         wxString text;
-        text << wxGetTranslation(BUILD_PROJECT_PREFIX) << m_info.GetProject() << wxT(" - ") << configName << wxT(" ]");
+        text << BUILD_PROJECT_PREFIX << m_info.GetProject() << wxT(" - ") << configName << wxT(" ]");
         if(m_fileName.IsEmpty()) {
             text << wxT("----------\n");
         } else if(m_preprocessOnly) {

--- a/Plugin/custombuildrequest.cpp
+++ b/Plugin/custombuildrequest.cpp
@@ -209,9 +209,9 @@ void CustomBuildRequest::Process(IManager* manager)
     // and what configuration
     wxString text;
     if(isClean) {
-        text << wxGetTranslation(CLEAN_PROJECT_PREFIX);
+        text << CLEAN_PROJECT_PREFIX;
     } else {
-        text << wxGetTranslation(BUILD_PROJECT_PREFIX);
+        text << BUILD_PROJECT_PREFIX;
     }
     text << m_info.GetProject() << wxT(" - ") << configName << wxT(" ]----------\n");
 

--- a/Plugin/macrosdlg.cpp
+++ b/Plugin/macrosdlg.cpp
@@ -52,7 +52,7 @@ void MacrosDlg::OnItemRightClick(wxListEvent& event)
 {
     m_item = event.m_itemIndex;
     wxMenu menu;
-    menu.Append(XRCID("copy_macro"), wxT("Copy macro name"), NULL);
+    menu.Append(XRCID("copy_macro"), _("Copy macro name"), NULL);
     PopupMenu(&menu);
 }
 
@@ -91,7 +91,7 @@ void MacrosDlg::Initialize()
         AddMacro(wxT("$(User)"), _("Expands to logged-in user as defined by the OS"));
         AddMacro(wxT("$(Date)"), _("Expands to current date"));
         AddMacro(wxT("$(CodeLitePath)"),
-                 _("Expands to CodeLite's startup directory on (e.g. on Unix it expands to ~/.codelite/"));
+                 _("Expands to CodeLite's startup directory on (e.g. on Unix it expands to ~/.codelite/)"));
         AddMacro(
             wxT("$(ProjectFiles)"),
             _("A space delimited string containing all of the project files in a relative path to the project file"));

--- a/Plugin/symbol_tree.cpp
+++ b/Plugin/symbol_tree.cpp
@@ -204,12 +204,12 @@ void SymbolTree::BuildTree(const wxFileName& fileName, const TagEntryPtrVector_t
     // add three items here:
     // the globals node, the mcros and the prototype node
     int nodeImgIdx = clGetManager()->GetStdIcons()->GetImageIndex(BitmapLoader::kAngleBrackets);
-    m_globalsNode = AppendItem(root, wxT("Global Functions and Variables"), nodeImgIdx, nodeImgIdx,
-                               new MyTreeItemData(wxT("Global Functions and Variables"), wxEmptyString));
-    m_prototypesNode = AppendItem(root, wxT("Functions Prototypes"), nodeImgIdx, nodeImgIdx,
-                                  new MyTreeItemData(wxT("Functions Prototypes"), wxEmptyString));
+    m_globalsNode = AppendItem(root, _("Global Functions and Variables"), nodeImgIdx, nodeImgIdx,
+                               new MyTreeItemData(_("Global Functions and Variables"), wxEmptyString));
+    m_prototypesNode = AppendItem(root, _("Functions Prototypes"), nodeImgIdx, nodeImgIdx,
+                                  new MyTreeItemData(_("Functions Prototypes"), wxEmptyString));
     m_macrosNode =
-        AppendItem(root, wxT("Macros"), nodeImgIdx, nodeImgIdx, new MyTreeItemData(wxT("Macros"), wxEmptyString));
+        AppendItem(root, _("Macros"), nodeImgIdx, nodeImgIdx, new MyTreeItemData(_("Macros"), wxEmptyString));
 
     for(; !walker.End(); walker++) {
         // Add the item to the tree

--- a/QmakePlugin/qmakeplugin.cpp
+++ b/QmakePlugin/qmakeplugin.cpp
@@ -121,7 +121,7 @@ void QMakePlugin::CreatePluginMenu(wxMenu* pluginsMenu)
     item = new wxMenuItem(menu, XRCID("qmake_settings"), _("Settings..."), wxEmptyString, wxITEM_NORMAL);
     menu->Append(item);
 
-    pluginsMenu->Append(wxID_ANY, wxT("QMake"), menu);
+    pluginsMenu->Append(wxID_ANY, _("QMake"), menu);
 
     wxTheApp->Connect(XRCID("new_qmake_project"), wxEVT_COMMAND_MENU_SELECTED,
                       wxCommandEventHandler(QMakePlugin::OnNewQmakeBasedProject), NULL, (wxEvtHandler*)this);
@@ -264,7 +264,7 @@ void QMakePlugin::OnBuildStarting(clBuildEvent& event)
     QMakeProFileGenerator generator(m_mgr, project, config);
     if(!wxFileName::Exists(generator.GetProFileName())) {
         // alert and return
-        ::wxMessageBox(_("Could not locate pro file.\nDid you remember to run qmake? (right click on the project"),
+        ::wxMessageBox(_("Could not locate pro file.\nDid you remember to run qmake? (right click on the project)"),
                        "QMake", wxICON_WARNING | wxCENTER);
         return;
     } else {

--- a/Runtime/config/accelerators.conf.default
+++ b/Runtime/config/accelerators.conf.default
@@ -150,7 +150,7 @@ cppcheck_editor_item|Plugins::CppCheck|Check current file|
 cppcheck_project_item|Plugins::CppCheck|Check current file's project|
 cppcheck_workspace_item|Plugins::CppCheck|Check workspace|
 options|Settings|Global Editor Preferences...|Alt-O
-synatx_highlight|Settings|Syntax Highlight & Fonts...|
+syntax_highlight|Settings|Syntax Highlight & Fonts...|
 configure_accelerators|Settings|Configure accelerators...|
 add_envvar|Settings|Environment Variables...|Ctrl-Shift-V
 advance_settings|Settings|Build Settings...|

--- a/Runtime/templates/projects/wxWidgets_ConsoleApp/wxWidgets_ConsoleApp.project
+++ b/Runtime/templates/projects/wxWidgets_ConsoleApp/wxWidgets_ConsoleApp.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeLite_Project Name="wxWidgets Console Application (with wxEvent loop)" InternalType="Console" IconIndex="wx16" Version="11000">
-  <Description>A wxWidgets console application with wxEvent loop (the main application class is a sublcass of wxAppConsole)</Description>
+  <Description>A wxWidgets console application with wxEvent loop (the main application class is a subclass of wxAppConsole)</Description>
   <Dependencies/>
   <VirtualDirectory Name="include">
     <File Name="main_app.h"/>

--- a/SmartCompletion/smartcompletion.cpp
+++ b/SmartCompletion/smartcompletion.cpp
@@ -55,7 +55,7 @@ void SmartCompletion::CreatePluginMenu(wxMenu* pluginsMenu)
     item = new wxMenuItem(menu, XRCID("smart_completion_settings"), _("Settings..."), _("Settings..."), wxITEM_NORMAL);
     menu->Append(item);
 
-    pluginsMenu->Append(wxID_ANY, wxT("SmartCompletions"), menu);
+    pluginsMenu->Append(wxID_ANY, _("SmartCompletions"), menu);
 
     m_mgr->GetTheApp()->Bind(wxEVT_MENU, &SmartCompletion::OnSettings, this, XRCID("smart_completion_settings"));
 }

--- a/SnipWiz/snipwiz.cpp
+++ b/SnipWiz/snipwiz.cpp
@@ -153,7 +153,7 @@ void SnipWiz::CreatePluginMenu(wxMenu* pluginsMenu)
     item = new wxMenuItem(menu, IDM_CLASS_WIZ, _("Template class..."), _("Template class..."), wxITEM_NORMAL);
     menu->Append(item);
 
-    pluginsMenu->Append(wxID_ANY, plugName, menu);
+    pluginsMenu->Append(wxID_ANY, _("SnipWiz"), menu);
 
     m_topWin->Connect(IDM_SETTINGS, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(SnipWiz::OnSettings), NULL,
                       this);

--- a/SpellChecker/IHunSpell.cpp
+++ b/SpellChecker/IHunSpell.cpp
@@ -422,7 +422,7 @@ void IHunSpell::InitLanguageList()
     m_languageList[_T( "German (Germany-neu ortho.)" )] = _T( "de_DE_neu" );
     m_languageList[_T( "Greek (Greece)" )] = _T( "el_GR" );
     m_languageList[_T( "English (Australia)" )] = _T( "en_AU" );
-    m_languageList[_T( "English (Canada)" )] = _("en_CA");
+    m_languageList[_T( "English (Canada)" )] = _T("en_CA");
     m_languageList[_T( "English (United Kingdom)" )] = _T( "en_GB" );
     m_languageList[_T( "English (New Zealand)" )] = _T( "en_NZ" );
     m_languageList[_T( "English (United States)" )] = _T( "en_US" );

--- a/SpellChecker/spellcheck.cpp
+++ b/SpellChecker/spellcheck.cpp
@@ -183,7 +183,7 @@ void SpellCheck::CreatePluginMenu(wxMenu* pluginsMenu)
 
     pItem = new wxMenuItem(pMenu, IDM_SETTINGS, _("Settings..."), _("Settings..."), wxITEM_NORMAL);
     pMenu->Append(pItem);
-    pluginsMenu->Append(wxID_ANY, s_plugName, pMenu);
+    pluginsMenu->Append(wxID_ANY, _("SpellCheck"), pMenu);
 
     m_topWin->Bind(wxEVT_MENU, &SpellCheck::OnSettings, this, IDM_SETTINGS);
 }

--- a/Subversion2/subversion2.cpp
+++ b/Subversion2/subversion2.cpp
@@ -227,7 +227,7 @@ void Subversion2::CreatePluginMenu(wxMenu* pluginsMenu)
     wxMenuItem* item(NULL);
     item = new wxMenuItem(menu, XRCID("subversion2_settings"), _("Subversion Options"), wxEmptyString, wxITEM_NORMAL);
     menu->Append(item);
-    pluginsMenu->Append(wxID_ANY, wxT("Subversion2"), menu);
+    pluginsMenu->Append(wxID_ANY, _("Subversion2"), menu);
 }
 
 wxMenu* Subversion2::CreateProjectPopMenu()

--- a/UnitTestCPP/unittestpp.cpp
+++ b/UnitTestCPP/unittestpp.cpp
@@ -140,7 +140,7 @@ void UnitTestPP::CreatePluginMenu(wxMenu* pluginsMenu)
                           wxITEM_NORMAL);
     menu->Append(item);
 
-    pluginsMenu->Append(wxID_ANY, wxT("UnitTest++"), menu);
+    pluginsMenu->Append(wxID_ANY, _("UnitTest++"), menu);
 
     // connect the events
     wxTheApp->Connect(XRCID("unittestpp_new_simple_test"), wxEVT_COMMAND_MENU_SELECTED,

--- a/WordCompletion/wordcompletion.cpp
+++ b/WordCompletion/wordcompletion.cpp
@@ -68,7 +68,7 @@ void WordCompletionPlugin::CreatePluginMenu(wxMenu* pluginsMenu)
 {
     wxMenu* menu = new wxMenu;
     menu->Append(XRCID("text_word_complete_settings"), _("Settings"));
-    pluginsMenu->Append(wxID_ANY, GetShortName(), menu);
+    pluginsMenu->Append(wxID_ANY, _("Word Completion"), menu);
 }
 
 void WordCompletionPlugin::UnPlug()

--- a/abbreviation/abbreviation.cpp
+++ b/abbreviation/abbreviation.cpp
@@ -104,7 +104,7 @@ void AbbreviationPlugin::CreatePluginMenu(wxMenu* pluginsMenu)
     item = new wxMenuItem(menu, XRCID("abbrev_settings"), _("Settings..."), _("Settings..."), wxITEM_NORMAL);
     menu->Append(item);
 
-    pluginsMenu->Append(XRCID("abbreviations_plugin_menu"), wxT("Abbreviation"), menu);
+    pluginsMenu->Append(XRCID("abbreviations_plugin_menu"), _("Abbreviation"), menu);
     m_topWindow->Bind(wxEVT_MENU, &AbbreviationPlugin::OnSettings, this, XRCID("abbrev_settings"));
     m_topWindow->Bind(wxEVT_MENU, &AbbreviationPlugin::OnShowAbbvreviations, this, XRCID("abbrev_insert"));
 }

--- a/codelitephp/php-plugin/php_ui.cpp
+++ b/codelitephp/php-plugin/php_ui.cpp
@@ -2205,7 +2205,7 @@ PHPSettersGettersDialogBase::PHPSettersGettersDialogBase(wxWindow* parent, wxWin
     m_checkBoxReurnThis = new wxCheckBox(this, wxID_ANY, _("Setter returns $this"), wxDefaultPosition,
                                          wxDLG_UNIT(this, wxSize(-1, -1)), 0);
     m_checkBoxReurnThis->SetValue(false);
-    m_checkBoxReurnThis->SetToolTip(_("The getter returns $this object"));
+    m_checkBoxReurnThis->SetToolTip(_("The setter returns $this object"));
 
     flexGridSizer667->Add(m_checkBoxReurnThis, 0, wxALL, WXC_FROM_DIP(5));
 

--- a/codelitephp/php-plugin/php_ui.wxcp
+++ b/codelitephp/php-plugin/php_ui.wxcp
@@ -17236,7 +17236,7 @@
 										}, {
 											"type":	"multi-string",
 											"m_label":	"Tooltip:",
-											"m_value":	"The getter returns $this object"
+											"m_value":	"The setter returns $this object"
 										}, {
 											"type":	"colour",
 											"m_label":	"Bg Colour:",

--- a/cppchecker/cppchecker.cpp
+++ b/cppchecker/cppchecker.cpp
@@ -149,7 +149,7 @@ void CppCheckPlugin::CreatePluginMenu(wxMenu* pluginsMenu)
     wxMenuItem* item =
         new wxMenuItem(menu, XRCID("cppcheck_settings_item"), _("Settings"), wxEmptyString, wxITEM_NORMAL);
     menu->Append(item);
-    pluginsMenu->Append(wxID_ANY, wxT("CppCheck"), menu);
+    pluginsMenu->Append(wxID_ANY, _("CppCheck"), menu);
 }
 
 void CppCheckPlugin::HookPopupMenu(wxMenu* menu, MenuType type)

--- a/cppchecker/cppcheckreportbasepage.cpp
+++ b/cppchecker/cppcheckreportbasepage.cpp
@@ -85,7 +85,7 @@ CppCheckReportBasePage::CppCheckReportBasePage(wxWindow* parent, wxWindowID id, 
     m_buttonStop =
         new clThemedButton(this, wxID_STOP, _("&Stop"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
     m_buttonStop->SetDefault();
-    m_buttonStop->SetToolTip(_("Stop the curreny analysis"));
+    m_buttonStop->SetToolTip(_("Stop the current analysis"));
 
     bSizer4->Add(m_buttonStop, 0, wxALL | wxEXPAND, WXC_FROM_DIP(5));
 

--- a/cppchecker/cppcheckreportbasepage.fbp
+++ b/cppchecker/cppcheckreportbasepage.fbp
@@ -341,7 +341,7 @@
                                         <property name="size" />
                                         <property name="style" />
                                         <property name="subclass" />
-                                        <property name="tooltip">Stop the curreny analysis</property>
+                                        <property name="tooltip">Stop the current analysis</property>
                                         <property name="validator_data_type" />
                                         <property name="validator_style">wxFILTER_NONE</property>
                                         <property name="validator_type">wxDefaultValidator</property>

--- a/cppchecker/cppcheckreportbasepage.wxcp
+++ b/cppchecker/cppcheckreportbasepage.wxcp
@@ -471,7 +471,7 @@
             }, {
              "type": "multi-string",
              "m_label": "Tooltip:",
-             "m_value": "Stop the curreny analysis"
+             "m_value": "Stop the current analysis"
             }, {
              "type": "colour",
              "m_label": "Bg Colour:",

--- a/formbuilder/quickdebug.wxcp
+++ b/formbuilder/quickdebug.wxcp
@@ -1127,7 +1127,7 @@
 																				}, {
 																					"type":	"multi-string",
 																					"m_label":	"Tooltip:",
-																					"m_value":	"Select executale to debug"
+																					"m_value":	"Select executable to debug"
 																				}, {
 																					"type":	"colour",
 																					"m_label":	"Bg Colour:",

--- a/formbuilder/tags_options_base_dlg.wxcp
+++ b/formbuilder/tags_options_base_dlg.wxcp
@@ -1504,7 +1504,7 @@
 																		}, {
 																			"type":	"string",
 																			"m_label":	"Label:",
-																			"m_value":	"Generate compile_commans.json file"
+																			"m_value":	"Generate compile_commands.json file"
 																		}, {
 																			"type":	"bool",
 																			"m_label":	"Value:",
@@ -3973,7 +3973,7 @@
 																														}, {
 																															"type":	"string",
 																															"m_label":	"URL:",
-																															"m_value":	"http://codelite.org/LiteEditor/MacrosHandling101"
+																															"m_value":	"https://wiki.codelite.org/pmwiki.php/Main/MacrosHandling101"
 																														}, {
 																															"type":	"colour",
 																															"m_label":	"Normal Colour:",

--- a/git/GitConsole.cpp
+++ b/git/GitConsole.cpp
@@ -132,7 +132,7 @@ void PopulateToolbarOverflow(clToolBar* toolbar)
     auto images = toolbar->GetBitmapsCreateIfNeeded();
     for(size_t n = 0; n < IDsize; ++n) {
         if(IDs[n] != 0) {
-            toolbar->AddTool(IDs[n], labels[n], images->Add(bitmapnames[n]));
+            toolbar->AddTool(IDs[n], wxGetTranslation(labels[n]), images->Add(bitmapnames[n]));
         } else {
             toolbar->AddSeparator();
         }

--- a/git/gitui.cpp
+++ b/git/gitui.cpp
@@ -114,7 +114,7 @@ GitSettingsDlgBase::GitSettingsDlgBase(wxWindow* parent, wxWindowID id, const wx
 
     m_textCtrlGlobalEmail =
         new wxTextCtrl(m_panel234, wxID_ANY, wxT(""), wxDefaultPosition, wxDLG_UNIT(m_panel234, wxSize(-1, -1)), 0);
-    m_textCtrlGlobalEmail->SetToolTip(_("Set the current repository email"));
+    m_textCtrlGlobalEmail->SetToolTip(_("Set the global email"));
 #if wxVERSION_NUMBER >= 3000
     m_textCtrlGlobalEmail->SetHint(wxT(""));
 #endif
@@ -129,7 +129,7 @@ GitSettingsDlgBase::GitSettingsDlgBase(wxWindow* parent, wxWindowID id, const wx
     m_textCtrlLocalName =
         new wxTextCtrl(m_panel234, wxID_ANY, wxT(""), wxDefaultPosition, wxDLG_UNIT(m_panel234, wxSize(-1, -1)), 0);
     m_textCtrlLocalName->SetToolTip(_("Set the current repository user name (this name will tell git who you are).\nIf "
-                                      "this field letf empty, the global one is used"));
+                                      "this field left empty, the global one is used"));
 #if wxVERSION_NUMBER >= 3000
     m_textCtrlLocalName->SetHint(wxT(""));
 #endif
@@ -144,7 +144,7 @@ GitSettingsDlgBase::GitSettingsDlgBase(wxWindow* parent, wxWindowID id, const wx
     m_textCtrlLocalEmail =
         new wxTextCtrl(m_panel234, wxID_ANY, wxT(""), wxDefaultPosition, wxDLG_UNIT(m_panel234, wxSize(-1, -1)), 0);
     m_textCtrlLocalEmail->SetToolTip(
-        _("Set the current repository email\nIf this field letf empty, the global one is used"));
+        _("Set the current repository email\nIf this field left empty, the global one is used"));
 #if wxVERSION_NUMBER >= 3000
     m_textCtrlLocalEmail->SetHint(wxT(""));
 #endif

--- a/git/gitui.wxcp
+++ b/git/gitui.wxcp
@@ -1278,7 +1278,7 @@
 																}, {
 																	"type":	"multi-string",
 																	"m_label":	"Tooltip:",
-																	"m_value":	"Set the current repository email"
+																	"m_value":	"Set the global email"
 																}, {
 																	"type":	"colour",
 																	"m_label":	"Bg Colour:",
@@ -1447,7 +1447,7 @@
 																}, {
 																	"type":	"multi-string",
 																	"m_label":	"Tooltip:",
-																	"m_value":	"Set the current repository user name (this name will tell git who you are).\\nIf this field letf empty, the global one is used"
+																	"m_value":	"Set the current repository user name (this name will tell git who you are).\\nIf this field left empty, the global one is used"
 																}, {
 																	"type":	"colour",
 																	"m_label":	"Bg Colour:",
@@ -1623,7 +1623,7 @@
 																}, {
 																	"type":	"multi-string",
 																	"m_label":	"Tooltip:",
-																	"m_value":	"Set the current repository email\\nIf this field letf empty, the global one is used"
+																	"m_value":	"Set the current repository email\\nIf this field left empty, the global one is used"
 																}, {
 																	"type":	"colour",
 																	"m_label":	"Bg Colour:",

--- a/wxcrafter/BitmapComboxWrapper.cpp
+++ b/wxcrafter/BitmapComboxWrapper.cpp
@@ -10,19 +10,19 @@ BitmapComboxWrapper::BitmapComboxWrapper()
     : wxcWidget(ID_WXBITMAPCOMBOBOX)
 {
     SetPropertyString(_("Common Settings"), "wxBitmapComboBox");
-    AddProperty(new BitmapTextArrayProperty(PROP_CB_CHOICES, "", wxT("Combobox drop down choices")));
+    AddProperty(new BitmapTextArrayProperty(PROP_CB_CHOICES, "", _("Combobox drop down choices")));
     AddProperty(new StringProperty(
         PROP_SELECTION, wxT("-1"),
-        wxT("The zero-based position of any initially selected string, or -1 if none are to be selected")));
-    AddProperty(new StringProperty(PROP_VALUE, "", wxT("The combobox initial value")));
+        _("The zero-based position of any initially selected string, or -1 if none are to be selected")));
+    AddProperty(new StringProperty(PROP_VALUE, "", _("The combobox initial value")));
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_COMBOBOX_SELECTED"),
-                         wxT("Process a wxEVT_COMMAND_COMBOBOX_SELECTED event, when an item on the list is selected. "
+                         _("Process a wxEVT_COMMAND_COMBOBOX_SELECTED event, when an item on the list is selected. "
                              "Note that calling GetValue returns the new value of selection."));
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_UPDATED"),
-                         wxT("Process a wxEVT_COMMAND_TEXT_UPDATED event, when the combobox text changes."));
+                         _("Process a wxEVT_COMMAND_TEXT_UPDATED event, when the combobox text changes."));
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_ENTER"),
-                         wxT("Process a wxEVT_COMMAND_TEXT_ENTER event, when <RETURN> is pressed in the combobox."));
+                         _("Process a wxEVT_COMMAND_TEXT_ENTER event, when <RETURN> is pressed in the combobox."));
 
     PREPEND_STYLE(wxCB_READONLY, false);
     PREPEND_STYLE(wxCB_SORT, false);

--- a/wxcrafter/FontPickerDlg.cpp
+++ b/wxcrafter/FontPickerDlg.cpp
@@ -26,7 +26,7 @@ FontPickerDlg::FontPickerDlg(wxWindow* parent, const wxString& font)
 
     if(f.IsOk()) {
         m_staticTextSample->SetFont(f);
-        m_staticTextSample->SetLabel(wxT("Sample Text"));
+        m_staticTextSample->SetLabel(_("Sample Text"));
     }
     SetName("FontPickerDlg");
     WindowAttrManager::Load(this);
@@ -86,7 +86,7 @@ void FontPickerDlg::DoUpdateSelectionToPreDefinedFont()
                 m_fontname << wxT(",normal");
 
             m_staticTextSample->SetFont(font);
-            m_staticTextSample->SetLabel(wxT("Sample Text"));
+            m_staticTextSample->SetLabel(_("Sample Text"));
 
         } else {
             m_fontname = wxCrafter::FontToString(font);
@@ -99,5 +99,5 @@ void FontPickerDlg::DoUpdateSelectionToCustomFont()
     m_fontname = wxCrafter::FontToString(font);
 
     m_staticTextSample->SetFont(font);
-    m_staticTextSample->SetLabel(wxT("Sample Text"));
+    m_staticTextSample->SetLabel(_("Sample Text"));
 }

--- a/wxcrafter/SimpleHtmlListBoxWrapper.cpp
+++ b/wxcrafter/SimpleHtmlListBoxWrapper.cpp
@@ -21,10 +21,10 @@ SimpleHtmlListBoxWrapper::SimpleHtmlListBoxWrapper()
                   _("A wxHtmlCell which contains an hyperlink was clicked. See wxHtmlLinkEvent"));
     SetPropertyString(_("Common Settings"), "wxSimpleHtmlListBox");
     AddProperty(new MultiStringsProperty(
-        PROP_OPTIONS, wxT("The List Box Items. A semi-colon list of strings. This list may contain HTML fragements")));
+        PROP_OPTIONS, _("The List Box Items. A semi-colon list of strings. This list may contain HTML fragements")));
     AddProperty(new StringProperty(
         PROP_SELECTION, wxT("-1"),
-        wxT("The zero-based position of any initially selected string, or -1 if none are to be selected")));
+        _("The zero-based position of any initially selected string, or -1 if none are to be selected")));
 
     // Basic name pattern
     m_namePattern = "m_htmlListBox";

--- a/wxcrafter/allocator_mgr.cpp
+++ b/wxcrafter/allocator_mgr.cpp
@@ -474,9 +474,9 @@ wxMenu* Allocator::CreateSizersMenu() const
     MENU_ENTRY(ID_WXGRIDBAGSIZER, wxT("wxGridBagSizer"), wxT("wxgridbagsizer"));
     MENU_SEPARATOR();
     MENU_ENTRY(ID_WXSTDDLGBUTTONSIZER, wxT("wxStdDialogButtonSizer"), wxT("stddlgbuttonsizer"));
-    MENU_ENTRY(ID_WXSTDBUTTON, wxT("Standard wxButton"), wxT("wxbutton"));
+    MENU_ENTRY(ID_WXSTDBUTTON, _("Standard wxButton"), wxT("wxbutton"));
     MENU_SEPARATOR();
-    MENU_ENTRY(ID_WXSPACER, wxT("Spacer"), wxT("spacer"));
+    MENU_ENTRY(ID_WXSPACER, _("Spacer"), wxT("spacer"));
     // ADD_NEW_CONTROL
     return menu;
 }
@@ -487,14 +487,14 @@ wxMenu* Allocator::CreateTopLevelMenu() const
     wxMenuItem* menuItem = NULL;
     wxCrafter::ResourceLoader bmpLoader;
 
-    MENU_ENTRY(ID_WXFRAME, wxT("New wxFrame"), wxT("wxframe"));
-    MENU_ENTRY(ID_WXDIALOG, wxT("New wxDialog"), wxT("wxdialog"));
-    MENU_ENTRY(ID_WXWIZARD, wxT("New wxWizard"), wxT("wxwizard"));
-    MENU_ENTRY(ID_WXPANEL_TOPLEVEL, wxT("New wxPanel"), wxT("wxpanel"));
-    MENU_ENTRY(ID_WXAUITOOLBARTOPLEVEL, wxT("wxAuiToolBar"), wxT("wxauitoolbar"));
+    MENU_ENTRY(ID_WXFRAME, _("New wxFrame"), wxT("wxframe"));
+    MENU_ENTRY(ID_WXDIALOG, _("New wxDialog"), wxT("wxdialog"));
+    MENU_ENTRY(ID_WXWIZARD, _("New wxWizard"), wxT("wxwizard"));
+    MENU_ENTRY(ID_WXPANEL_TOPLEVEL, _("New wxPanel"), wxT("wxpanel"));
+    MENU_ENTRY(ID_WXAUITOOLBARTOPLEVEL, _("wxAuiToolBar"), wxT("wxauitoolbar"));
     MENU_SEPARATOR();
-    MENU_ENTRY(ID_WXIMAGELIST, wxT("New wxImageList"), wxT("wximglist"));
-    MENU_ENTRY(ID_WXPOPUPWINDOW, wxT("New wxPopupWindow"), wxT("wxpopupwindow"));
+    MENU_ENTRY(ID_WXIMAGELIST, _("New wxImageList"), wxT("wximglist"));
+    MENU_ENTRY(ID_WXPOPUPWINDOW, _("New wxPopupWindow"), wxT("wxpopupwindow"));
 
     // ADD_NEW_CONTROL
     return menu;
@@ -631,17 +631,17 @@ void Allocator::PrepareMenu(wxMenu& menu, wxcWidget* item)
     if(flags & MT_RIBBON_GALLERY) { menu.Append(ID_WXRIBBONGALLERYITME, _("Add Gallery Item")); }
 
     if(flags & MT_NOTEBOOK_PAGES) {
-        menu.Append(ID_WXPANEL_NOTEBOOK_PAGE, wxT("Add Notebook Page"));
-        if(isChildOfTreeBook) { menu.Append(ID_WXTREEBOOK_SUB_PAGE, wxT("Add Sub Page")); }
+        menu.Append(ID_WXPANEL_NOTEBOOK_PAGE, _("Add Notebook Page"));
+        if(isChildOfTreeBook) { menu.Append(ID_WXTREEBOOK_SUB_PAGE, _("Add Sub Page")); }
     }
 
     if(flags & MT_SPLITTERWIN_PAGES) { menu.Append(ID_WXSPLITTERWINDOW_PAGE, _("Add Panel"), _("Add Panel")); }
 
-    if(flags & MT_DV_LIST_CTRL_COL) { menu.Append(ID_WXDATAVIEWCOL, wxT("Add Column")); }
+    if(flags & MT_DV_LIST_CTRL_COL) { menu.Append(ID_WXDATAVIEWCOL, _("Add Column")); }
 
-    if(flags & MT_LIST_CTRL_COLUMNS) { menu.Append(ID_WXLISTCTRL_COL, wxT("Add List Column")); }
+    if(flags & MT_LIST_CTRL_COLUMNS) { menu.Append(ID_WXLISTCTRL_COL, _("Add List Column")); }
 
-    if(flags & MT_TREE_LIST_CTRL_COLUMNS) { menu.Append(ID_WXTREELISTCTRLCOL, wxT("Add Column")); }
+    if(flags & MT_TREE_LIST_CTRL_COLUMNS) { menu.Append(ID_WXTREELISTCTRLCOL, _("Add Column")); }
 
     if(flags & MT_EVENTS) { DoAddEventsMenu(menu); }
 
@@ -959,18 +959,18 @@ FLAGS_t Allocator::DoGetValidMenus(wxcWidget* item) const
 void Allocator::DoAddCommonMenu(wxMenu& menu) const
 {
     if(menu.GetMenuItemCount() != 0) { menu.AppendSeparator(); }
-    menu.Append(ID_MOVE_NODE_UP, wxT("Move Up"));
-    menu.Append(ID_MOVE_NODE_DOWN, wxT("Move Down"));
-    menu.Append(ID_MOVE_NODE_INTO_SIZER, wxT("Move Left into Higher Sizer"));
-    menu.Append(ID_MOVE_NODE_INTO_SIBLING, wxT("Move Right into Sibling Sizer"));
+    menu.Append(ID_MOVE_NODE_UP, _("Move Up"));
+    menu.Append(ID_MOVE_NODE_DOWN, _("Move Down"));
+    menu.Append(ID_MOVE_NODE_INTO_SIZER, _("Move Left into Higher Sizer"));
+    menu.Append(ID_MOVE_NODE_INTO_SIBLING, _("Move Right into Sibling Sizer"));
     menu.AppendSeparator();
-    menu.Append(ID_DELETE_NODE, wxT("Delete"));
+    menu.Append(ID_DELETE_NODE, _("Delete"));
 }
 
 void Allocator::DoAddProjectMenu(wxMenu& menu) const
 {
     if(menu.GetMenuItemCount() != 0) { menu.AppendSeparator(); }
-    menu.Append(ID_SAVE_WXGUI_PROJECT, wxT("Save"));
+    menu.Append(ID_SAVE_WXGUI_PROJECT, _("Save"));
 }
 
 void Allocator::DoAddControlEventsMenu(wxMenu& menu) const

--- a/wxcrafter/aui_manager_wrapper.cpp
+++ b/wxcrafter/aui_manager_wrapper.cpp
@@ -26,16 +26,16 @@ AuiManagerWrapper::AuiManagerWrapper()
     // wxAUI_DOCKART_GRADIENT_TYPE
 
     SetPropertyString(_("Common Settings"), "wxAuiManager");
-    AddProperty(new CategoryProperty("General"));
+    AddProperty(new CategoryProperty(_("General")));
     AddProperty(new StringProperty(PROP_NAME, "", _("wxAuiManager member name")));
     AddProperty(new ColorProperty(PROP_BG, "<Default>", _("Background Colour")));
     AddProperty(new IntProperty(PROP_AUI_PANE_BORDER_SIZE, -1, _("Pane border size")));
 
-    AddProperty(new CategoryProperty("Sash"));
+    AddProperty(new CategoryProperty(_("Sash")));
     AddProperty(new ColorProperty(PROP_AUI_SASH_COLOUR, "<Default>", _("Sash colour")));
     AddProperty(new IntProperty(PROP_AUI_SASH_SIZE, -1, _("Set the wxAUI sash size")));
 
-    AddProperty(new CategoryProperty("Caption"));
+    AddProperty(new CategoryProperty(_("Caption")));
     wxArrayString gradientTypes;
     gradientTypes.Add("wxAUI_GRADIENT_NONE");
     gradientTypes.Add("wxAUI_GRADIENT_VERTICAL");

--- a/wxcrafter/banner_window_wrapper.cpp
+++ b/wxcrafter/banner_window_wrapper.cpp
@@ -32,7 +32,7 @@ BannerWindowWrapper::BannerWindowWrapper()
                              "position, this is supposed to be taken care of in the usual way, e.g. using sizers")));
     AddProperty(new BitmapPickerProperty(
         PROP_BITMAP_PATH, wxT(""),
-        wxT("Select the bitmap file\nImportant: You can set text and title OR a bitmap, but not both")));
+        _("Select the bitmap file\nImportant: You can set text and title OR a bitmap, but not both")));
     AddProperty(new ColorProperty(PROP_COLOR_GRADIENT_START));
     AddProperty(new ColorProperty(PROP_COLOR_GRADIENT_END));
 

--- a/wxcrafter/bitmap_button_wrapper.cpp
+++ b/wxcrafter/bitmap_button_wrapper.cpp
@@ -19,13 +19,13 @@ BitmapButtonWrapper::BitmapButtonWrapper()
     PREPEND_STYLE(wxBU_TOP, false);
 
     RegisterEvent(wxT("wxEVT_COMMAND_BUTTON_CLICKED"), wxT("wxCommandEvent"),
-                  wxT("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),
+                  _("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),
                   wxT("wxCommandEventHandler"));
 
     m_namePattern = wxT("m_bmpButton");
     SetPropertyString(_("Common Settings"), "wxBitmapButton");
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), wxT("Select the bitmap file")));
-    AddProperty(new BoolProperty(PROP_DEFAULT_BUTTON, false, wxT("Make this button the default button")));
+    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file")));
+    AddProperty(new BoolProperty(PROP_DEFAULT_BUTTON, false, _("Make this button the default button")));
 
     wxCrafter::ResourceLoader bl;
     m_properties.Item(PROP_BITMAP_PATH)->SetValue(bl.GetPlaceHolder16ImagePath().GetFullPath());

--- a/wxcrafter/bitmap_wrapepr.cpp
+++ b/wxcrafter/bitmap_wrapepr.cpp
@@ -17,7 +17,7 @@ BitmapWrapepr::BitmapWrapepr()
     AddProperty(new StringProperty(
         PROP_NAME, wxT(""),
         _("A unique name for the bitmap (across your project)\nThis name can be used later to load the bitmap from the "
-          "generated class\nby simply calling: wxBitmap bmp = myimglist.Bitmap(\"my-bitmap-name\"")));
+          "generated class\nby simply calling: wxBitmap bmp = myimglist.Bitmap(\"my-bitmap-name\")")));
     AddProperty(new FilePickerProperty(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file")));
     m_namePattern = "m_bmp";
     SetName(GenerateName());

--- a/wxcrafter/bitmaptogglebuttonwrapper.cpp
+++ b/wxcrafter/bitmaptogglebuttonwrapper.cpp
@@ -7,8 +7,8 @@ BitmapToggleButtonWrapper::BitmapToggleButtonWrapper()
     : wxcWidget(ID_WXBITMAPTOGGLEBUTTON)
 {
     SetPropertyString(_("Common Settings"), "wxBitmapToggleButton");
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", wxT("The bitmap")));
-    AddProperty(new BoolProperty(PROP_CHECKED, wxT("Initial state"), wxT("The button initial state")));
+    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", _("The bitmap")));
+    AddProperty(new BoolProperty(PROP_CHECKED, wxT("Initial state"), _("The button initial state")));
 
     PREPEND_STYLE(wxBU_BOTTOM, false);
     PREPEND_STYLE(wxBU_EXACTFIT, false);
@@ -16,7 +16,7 @@ BitmapToggleButtonWrapper::BitmapToggleButtonWrapper()
     PREPEND_STYLE(wxBU_RIGHT, false);
     PREPEND_STYLE(wxBU_TOP, false);
 
-    RegisterEventCommand(wxT("wxEVT_COMMAND_TOGGLEBUTTON_CLICKED"), wxT("Handles a toggle button click event."));
+    RegisterEventCommand(wxT("wxEVT_COMMAND_TOGGLEBUTTON_CLICKED"), _("Handles a toggle button click event."));
 
     m_namePattern = "m_bmpToggleBtn";
     SetName(GenerateName());

--- a/wxcrafter/box_sizer_wrapper.cpp
+++ b/wxcrafter/box_sizer_wrapper.cpp
@@ -15,7 +15,7 @@ BoxSizerWrapper::BoxSizerWrapper()
     arr.Add(wxT("wxHORIZONTAL"));
 
     SetPropertyString(_("Common Settings"), "wxBoxSizer");
-    AddProperty(new ChoiceProperty(PROP_ORIENTATION, arr, 0, wxT("Sizer orientation")));
+    AddProperty(new ChoiceProperty(PROP_ORIENTATION, arr, 0, _("Sizer orientation")));
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);

--- a/wxcrafter/button_wrapper.cpp
+++ b/wxcrafter/button_wrapper.cpp
@@ -34,7 +34,7 @@ ButtonWrapper::ButtonWrapper()
 
     m_namePattern = wxT("m_button");
     SetPropertyString(_("Common Settings"), "wxButton");
-    AddProperty(new StringProperty(PROP_LABEL, wxT("My Button"), _("The button label")));
+    AddProperty(new StringProperty(PROP_LABEL, _("My Button"), _("The button label")));
     AddProperty(new BoolProperty(PROP_DEFAULT_BUTTON, false, _("Make this button the default button")));
     AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file (wx2.9.X and later)")));
     AddProperty(new ChoiceProperty(PROP_DIRECTION, directions, 0,

--- a/wxcrafter/check_box_wrapper.cpp
+++ b/wxcrafter/check_box_wrapper.cpp
@@ -10,8 +10,8 @@ CheckBoxWrapper::CheckBoxWrapper()
     : wxcWidget(ID_WXCHECKBOX)
 {
     SetPropertyString(_("Common Settings"), "wxCheckBox");
-    AddProperty(new StringProperty(PROP_LABEL, wxT("My CheckBox"), wxT("The Checkbox label")));
-    AddProperty(new BoolProperty(PROP_VALUE, false, wxT("Value")));
+    AddProperty(new StringProperty(PROP_LABEL, _("My CheckBox"), _("The Checkbox label")));
+    AddProperty(new BoolProperty(PROP_VALUE, false, _("Value")));
 
     PREPEND_STYLE(wxCHK_2STATE, false);
     PREPEND_STYLE(wxCHK_3STATE, false);
@@ -19,7 +19,7 @@ CheckBoxWrapper::CheckBoxWrapper()
     PREPEND_STYLE(wxALIGN_RIGHT, false);
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_CHECKBOX_CLICKED"),
-                         wxT("Process a wxEVT_COMMAND_CHECKBOX_CLICKED event, when the checkbox is clicked."));
+                         _("Process a wxEVT_COMMAND_CHECKBOX_CLICKED event, when the checkbox is clicked."));
     m_namePattern = wxT("m_checkBox");
     SetName(GenerateName());
 }

--- a/wxcrafter/check_list_box_wrapper.cpp
+++ b/wxcrafter/check_list_box_wrapper.cpp
@@ -18,17 +18,17 @@ CheckListBoxWrapper::CheckListBoxWrapper()
     PREPEND_STYLE(wxLB_SORT, false);
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_LISTBOX_SELECTED"),
-                         wxT("Process a wxEVT_COMMAND_LISTBOX_SELECTED event\nwhen an item on the list is selected or "
-                             "the selection changes."));
+                         _("Process a wxEVT_COMMAND_LISTBOX_SELECTED event\nwhen an item on the list is selected or "
+                           "the selection changes."));
     RegisterEventCommand(
         wxT("wxEVT_COMMAND_LISTBOX_DOUBLECLICKED"),
-        wxT("Process a wxEVT_COMMAND_LISTBOX_DOUBLECLICKED event\nwhen the listbox is double-clicked."));
+        _("Process a wxEVT_COMMAND_LISTBOX_DOUBLECLICKED event\nwhen the listbox is double-clicked."));
     RegisterEventCommand(wxT("wxEVT_COMMAND_CHECKLISTBOX_TOGGLED"),
-                         wxT("Process a wxEVT_COMMAND_CHECKLISTBOX_TOGGLED event\nwhen an item in the check list box "
-                             "is checked or unchecked."));
+                         _("Process a wxEVT_COMMAND_CHECKLISTBOX_TOGGLED event\nwhen an item in the check list box "
+                           "is checked or unchecked."));
 
     SetPropertyString(_("Common Settings"), "wxCheckListBox");
-    AddProperty(new MultiStringsProperty(PROP_OPTIONS, wxT("The List Box Items. A semi-colon list of strings")));
+    AddProperty(new MultiStringsProperty(PROP_OPTIONS, _("The List Box Items. A semi-colon list of strings")));
 
     m_namePattern = wxT("m_checkListBox");
     SetName(GenerateName());

--- a/wxcrafter/choice_wrapper.cpp
+++ b/wxcrafter/choice_wrapper.cpp
@@ -12,11 +12,11 @@ ChoiceWrapper::ChoiceWrapper()
 {
     SetPropertyString(_("Common Settings"), "wxChoice");
     AddProperty(
-        new MultiStringsProperty(PROP_OPTIONS, wxT("The Choice drop down options. A semi-colon list of strings")));
-    AddProperty(new StringProperty(PROP_SELECTION, wxT(""), wxT("Selected string index")));
+        new MultiStringsProperty(PROP_OPTIONS, _("The Choice drop down options. A semi-colon list of strings")));
+    AddProperty(new StringProperty(PROP_SELECTION, wxT(""), _("Selected string index")));
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_CHOICE_SELECTED"),
-                         wxT("Process a wxEVT_COMMAND_CHOICE_SELECTED event, when an item on the list is selected."));
+                         _("Process a wxEVT_COMMAND_CHOICE_SELECTED event, when an item on the list is selected."));
 
     m_namePattern = wxT("m_choice");
     SetName(GenerateName());

--- a/wxcrafter/combox_wrapper.cpp
+++ b/wxcrafter/combox_wrapper.cpp
@@ -11,20 +11,20 @@ ComboxWrapper::ComboxWrapper()
     : wxcWidget(ID_WXCOMBOBOX)
 {
     SetPropertyString(_("Common Settings"), "wxComboBox");
-    AddProperty(new MultiStringsProperty(PROP_CB_CHOICES, wxT("Combobox drop down choices")));
+    AddProperty(new MultiStringsProperty(PROP_CB_CHOICES, _("Combobox drop down choices")));
     AddProperty(new StringProperty(PROP_HINT, "", _("Sets a hint shown in an empty unfocused text control")));
     AddProperty(new StringProperty(
         PROP_SELECTION, wxT("-1"),
-        wxT("The zero-based position of any initially selected string, or -1 if none are to be selected")));
-    AddProperty(new StringProperty(PROP_VALUE, "", wxT("The combobox initial value")));
+        _("The zero-based position of any initially selected string, or -1 if none are to be selected")));
+    AddProperty(new StringProperty(PROP_VALUE, "", _("The combobox initial value")));
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_COMBOBOX_SELECTED"),
-                         wxT("Process a wxEVT_COMMAND_COMBOBOX_SELECTED event, when an item on the list is selected. "
+                         _("Process a wxEVT_COMMAND_COMBOBOX_SELECTED event, when an item on the list is selected. "
                              "Note that calling GetValue returns the new value of selection."));
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_UPDATED"),
-                         wxT("Process a wxEVT_COMMAND_TEXT_UPDATED event, when the combobox text changes."));
+                         _("Process a wxEVT_COMMAND_TEXT_UPDATED event, when the combobox text changes."));
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_ENTER"),
-                         wxT("Process a wxEVT_COMMAND_TEXT_ENTER event, when <RETURN> is pressed in the combobox."));
+                         _("Process a wxEVT_COMMAND_TEXT_ENTER event, when <RETURN> is pressed in the combobox."));
 
     PREPEND_STYLE(wxCB_DROPDOWN, false);
     PREPEND_STYLE(wxCB_READONLY, false);

--- a/wxcrafter/command_link_button_wrapper.cpp
+++ b/wxcrafter/command_link_button_wrapper.cpp
@@ -23,14 +23,14 @@ CommandLinkButtonWrapper::CommandLinkButtonWrapper()
     AddProperty(new CategoryProperty("wxCommandLinkButton"));
 
     RegisterEvent(wxT("wxEVT_COMMAND_BUTTON_CLICKED"), wxT("wxCommandEvent"),
-                  wxT("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),
+                  _("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),
                   wxT("wxCommandEventHandler"));
 
     AddProperty(new StringProperty(PROP_LABEL, _("Label"),
                                    _("First line of text on the button, typically the label of an action that will be "
                                      "made when the button is pressed")));
     AddProperty(new StringProperty(
-        PROP_NOTE, _(""), _("Second line of text describing the action performed when the button is pressed")));
+        PROP_NOTE, wxT(""), _("Second line of text describing the action performed when the button is pressed")));
     AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file")));
     AddProperty(new BoolProperty(PROP_DEFAULT_BUTTON, false, _("Make this button the default button")));
 

--- a/wxcrafter/custom_pg_properties.h
+++ b/wxcrafter/custom_pg_properties.h
@@ -65,7 +65,7 @@ public:
         if(str.IsEmpty() == false) { str.RemoveLast(); }
 
         EnterStringsDlg dlg(wxCrafter::TopFrame(), str);
-        dlg.SetMessage(_(""));
+        dlg.SetMessage(wxT(""));
         if(dlg.ShowModal() == wxID_OK) {
 
             wxString value = dlg.GetValue();

--- a/wxcrafter/data_view_list_ctrl_column.cpp
+++ b/wxcrafter/data_view_list_ctrl_column.cpp
@@ -33,7 +33,7 @@ DataViewListCtrlColumn::DataViewListCtrlColumn()
     cellType.Add("wxDATAVIEW_CELL_EDITABLE");
 
     AddProperty(new CategoryProperty(_("wxDataViewListCtrl Column")));
-    AddProperty(new StringProperty(PROP_NAME, wxT("My Column"), _("Column Caption")));
+    AddProperty(new StringProperty(PROP_NAME, _("My Column"), _("Column Caption")));
     AddProperty(new StringProperty(PROP_WIDTH, wxT("-2"),
                                    _("Column Width (in pixels)\n-1 - special value for column width meaning "
                                      "unspecified/default\n-2 - size the column automatically to fit all values")));

--- a/wxcrafter/dialog_wrapper.cpp
+++ b/wxcrafter/dialog_wrapper.cpp
@@ -24,7 +24,7 @@ DialogWrapper::DialogWrapper()
     RegisterEvent(wxT("wxEVT_ACTIVATE_APP"), wxT("wxActivateEvent"), _("Process a wxEVT_ACTIVATE_APP event"));
 
     SetPropertyString(_("Common Settings"), "wxDialog");
-    DoSetPropertyStringValue(PROP_TITLE, wxT("My Dialog"));
+    DoSetPropertyStringValue(PROP_TITLE, _("My Dialog"));
     m_namePattern = wxT("MyDialog");
 
     AddCategory(_("Dialog Icons"));

--- a/wxcrafter/events_database.cpp
+++ b/wxcrafter/events_database.cpp
@@ -105,65 +105,65 @@ void EventsDatabase::FillCommonEvents()
     // Key Events
     m_events.PushBack(wxT("wxEVT_KEY_DOWN"),
                       ConnectDetails(wxT("wxEVT_KEY_DOWN"), wxT("wxKeyEvent"),
-                                     wxT("Process a wxEVT_KEY_DOWN event (any key has been pressed)"),
+                                     _("Process a wxEVT_KEY_DOWN event (any key has been pressed)"),
                                      wxT("wxKeyEventHandler")));
     m_events.PushBack(wxT("wxEVT_KEY_UP"),
                       ConnectDetails(wxT("wxEVT_KEY_UP"), wxT("wxKeyEvent"),
-                                     wxT("Process a wxEVT_KEY_UP event (any key has been released)"),
+                                     _("Process a wxEVT_KEY_UP event (any key has been released)"),
                                      wxT("wxKeyEventHandler")));
     m_events.PushBack(wxT("wxEVT_CHAR"), ConnectDetails(wxT("wxEVT_CHAR"), wxT("wxKeyEvent"),
-                                                        wxT("Process a wxEVT_CHAR event"), wxT("wxKeyEventHandler")));
+                                                        _("Process a wxEVT_CHAR event"), wxT("wxKeyEventHandler")));
 
     // Menu
     m_events.PushBack(
         wxT("wxEVT_CONTEXT_MENU"),
         ConnectDetails(wxT("wxEVT_CONTEXT_MENU"), wxT("wxContextMenuEvent"),
-                       wxT("A right click (or other context menu command depending on platform) has been detected"),
+                       _("A right click (or other context menu command depending on platform) has been detected"),
                        wxT("wxContextMenuEventHandler")));
 
     // Mouse Events
     m_events.PushBack(wxT("wxEVT_LEFT_DOWN"),
                       ConnectDetails(wxT("wxEVT_LEFT_DOWN"), wxT("wxMouseEvent"),
-                                     wxT("Process a wxEVT_LEFT_DOWN event. The handler of this event should normally "
-                                         "call event.Skip() to allow the default processing to take place as otherwise "
-                                         "the window under mouse wouldn't get the focus."),
+                                     _("Process a wxEVT_LEFT_DOWN event. The handler of this event should normally "
+                                       "call event.Skip() to allow the default processing to take place as otherwise "
+                                       "the window under mouse wouldn't get the focus."),
                                      wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_LEFT_UP"),
-                      ConnectDetails(wxT("wxEVT_LEFT_UP"), wxT("wxMouseEvent"), wxT("Process a wxEVT_LEFT_UP event."),
+                      ConnectDetails(wxT("wxEVT_LEFT_UP"), wxT("wxMouseEvent"), _("Process a wxEVT_LEFT_UP event."),
                                      wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_LEFT_DCLICK"),
                       ConnectDetails(wxT("wxEVT_LEFT_DCLICK"), wxT("wxMouseEvent"),
-                                     wxT("Process a wxEVT_LEFT_DCLICK event."), wxT("wxMouseEventHandler")));
+                                     _("Process a wxEVT_LEFT_DCLICK event."), wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_MIDDLE_DOWN"),
                       ConnectDetails(wxT("wxEVT_MIDDLE_DOWN"), wxT("wxMouseEvent"),
-                                     wxT("Process a wxEVT_MIDDLE_DOWN event"), wxT("wxMouseEventHandler")));
+                                     _("Process a wxEVT_MIDDLE_DOWN event"), wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_MIDDLE_UP"),
                       ConnectDetails(wxT("wxEVT_MIDDLE_UP"), wxT("wxMouseEvent"),
-                                     wxT("Process a wxEVT_MIDDLE_UP event"), wxT("wxMouseEventHandler")));
+                                     _("Process a wxEVT_MIDDLE_UP event"), wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_MIDDLE_DCLICK"),
                       ConnectDetails(wxT("wxEVT_MIDDLE_DCLICK"), wxT("wxMouseEvent"),
-                                     wxT("Process a wxEVT_MIDDLE_DCLICK event."), wxT("wxMouseEventHandler")));
+                                     _("Process a wxEVT_MIDDLE_DCLICK event."), wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_RIGHT_DOWN"),
                       ConnectDetails(wxT("wxEVT_RIGHT_DOWN"), wxT("wxMouseEvent"),
-                                     wxT("Process a wxEVT_RIGHT_DOWN event"), wxT("wxMouseEventHandler")));
+                                     _("Process a wxEVT_RIGHT_DOWN event"), wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_RIGHT_UP"),
-                      ConnectDetails(wxT("wxEVT_RIGHT_UP"), wxT("wxMouseEvent"), wxT("Process a wxEVT_RIGHT_UP event"),
+                      ConnectDetails(wxT("wxEVT_RIGHT_UP"), wxT("wxMouseEvent"), _("Process a wxEVT_RIGHT_UP event"),
                                      wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_RIGHT_DCLICK"),
                       ConnectDetails(wxT("wxEVT_RIGHT_DCLICK"), wxT("wxMouseEvent"),
-                                     wxT("Process a wxEVT_RIGHT_DCLICK event"), wxT("wxMouseEventHandler")));
+                                     _("Process a wxEVT_RIGHT_DCLICK event"), wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_MOTION"),
-                      ConnectDetails(wxT("wxEVT_MOTION"), wxT("wxMouseEvent"), wxT("Process a wxEVT_MOTION event"),
+                      ConnectDetails(wxT("wxEVT_MOTION"), wxT("wxMouseEvent"), _("Process a wxEVT_MOTION event"),
                                      wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_ENTER_WINDOW"),
                       ConnectDetails(wxT("wxEVT_ENTER_WINDOW"), wxT("wxMouseEvent"),
-                                     wxT("Process a wxEVT_ENTER_WINDOW event"), wxT("wxMouseEventHandler")));
+                                     _("Process a wxEVT_ENTER_WINDOW event"), wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_LEAVE_WINDOW"),
                       ConnectDetails(wxT("wxEVT_LEAVE_WINDOW"), wxT("wxMouseEvent"),
-                                     wxT("Process a wxEVT_LEAVE_WINDOW event."), wxT("wxMouseEventHandler")));
+                                     _("Process a wxEVT_LEAVE_WINDOW event."), wxT("wxMouseEventHandler")));
     m_events.PushBack(wxT("wxEVT_MOUSEWHEEL"),
                       ConnectDetails(wxT("wxEVT_MOUSEWHEEL"), wxT("wxMouseEvent"),
-                                     wxT("Process a wxEVT_MOUSEWHEEL event"), wxT("wxMouseEventHandler")));
+                                     _("Process a wxEVT_MOUSEWHEEL event"), wxT("wxMouseEventHandler")));
     m_events.PushBack(
         wxT("wxEVT_MOUSE_CAPTURE_LOST"),
         ConnectDetails(wxT("wxEVT_MOUSE_CAPTURE_LOST"), wxT("wxMouseCaptureLostEvent"),
@@ -175,31 +175,31 @@ void EventsDatabase::FillCommonEvents()
     // Focus
     m_events.PushBack(wxT("wxEVT_SET_FOCUS"),
                       ConnectDetails(wxT("wxEVT_SET_FOCUS"), wxT("wxFocusEvent"),
-                                     wxT("Process a wxEVT_SET_FOCUS event"), wxT("wxFocusEventHandler")));
+                                     _("Process a wxEVT_SET_FOCUS event"), wxT("wxFocusEventHandler")));
     m_events.PushBack(wxT("wxEVT_KILL_FOCUS"),
                       ConnectDetails(wxT("wxEVT_KILL_FOCUS"), wxT("wxFocusEvent"),
-                                     wxT("Process a wxEVT_KILL_FOCUS event"), wxT("wxFocusEventHandler")));
+                                     _("Process a wxEVT_KILL_FOCUS event"), wxT("wxFocusEventHandler")));
 
     // UI
     m_events.PushBack(wxT("wxEVT_PAINT"),
-                      ConnectDetails(wxT("wxEVT_PAINT"), wxT("wxPaintEvent"), wxT("Process a wxEVT_PAINT event"),
+                      ConnectDetails(wxT("wxEVT_PAINT"), wxT("wxPaintEvent"), _("Process a wxEVT_PAINT event"),
                                      wxT("wxPaintEventHandler")));
     m_events.PushBack(wxT("wxEVT_ERASE_BACKGROUND"),
                       ConnectDetails(wxT("wxEVT_ERASE_BACKGROUND"), wxT("wxEraseEvent"),
-                                     wxT("Process a wxEVT_ERASE_BACKGROUND event."), wxT("wxEraseEventHandler")));
+                                     _("Process a wxEVT_ERASE_BACKGROUND event."), wxT("wxEraseEventHandler")));
     m_events.PushBack(wxT("wxEVT_SIZE"), ConnectDetails(wxT("wxEVT_SIZE"), wxT("wxSizeEvent"),
-                                                        wxT("Process a wxEVT_SIZE event"), wxT("wxSizeEventHandler")));
+                                                        _("Process a wxEVT_SIZE event"), wxT("wxSizeEventHandler")));
     m_events.PushBack(wxT("wxEVT_MOVE"),
                       ConnectDetails(wxT("wxEVT_MOVE"), wxT("wxMoveEvent"),
-                                     wxT("Process a wxEVT_MOVE event, which is generated when a window is moved."),
+                                     _("Process a wxEVT_MOVE event, which is generated when a window is moved."),
                                      wxT("wxMoveEventHandler")));
     m_events.PushBack(wxT("wxEVT_UPDATE_UI"),
                       ConnectDetails(wxT("wxEVT_UPDATE_UI"), wxT("wxUpdateUIEvent"),
-                                     wxT("Process a wxEVT_UPDATE_UI event"), wxT("wxUpdateUIEventHandler")));
+                                     _("Process a wxEVT_UPDATE_UI event"), wxT("wxUpdateUIEventHandler")));
 
     // Misc
     m_events.PushBack(wxT("wxEVT_IDLE"), ConnectDetails(wxT("wxEVT_IDLE"), wxT("wxIdleEvent"),
-                                                        wxT("Process a wxEVT_IDLE event"), wxT("wxIdleEventHandler")));
+                                                        _("Process a wxEVT_IDLE event"), wxT("wxIdleEventHandler")));
 
     MapEvents_t::const_iterator iter = m_events.begin();
     for(; iter != m_events.end(); iter++) {

--- a/wxcrafter/flexgridsizer_wrapper.cpp
+++ b/wxcrafter/flexgridsizer_wrapper.cpp
@@ -9,14 +9,14 @@ FlexGridSizerWrapper::FlexGridSizerWrapper()
     m_styles.Clear(); // Sizer has no styles
 
     SetPropertyString(_("Common Settings"), "wxFlexGridSizer");
-    AddProperty(new StringProperty(PROP_COLS, wxT("2"), wxT("Number of columns in the grid")));
-    AddProperty(new StringProperty(PROP_ROWS, wxT("0"), wxT("Number of rows in the grid")));
+    AddProperty(new StringProperty(PROP_COLS, wxT("2"), _("Number of columns in the grid")));
+    AddProperty(new StringProperty(PROP_ROWS, wxT("0"), _("Number of rows in the grid")));
     AddProperty(
-        new StringProperty(PROP_GROW_COLS, wxT(""), wxT("Which columns are allowed to grow. Comma separated list")));
+        new StringProperty(PROP_GROW_COLS, wxT(""), _("Which columns are allowed to grow. Comma separated list")));
     AddProperty(
-        new StringProperty(PROP_GROW_ROWS, wxT(""), wxT("Which rows are allowed to grow. Comma separated list")));
-    AddProperty(new StringProperty(PROP_HGAP, wxT("0"), wxT("The horizontal gap between grid cells")));
-    AddProperty(new StringProperty(PROP_VGAP, wxT("0"), wxT("The vertical gap between grid cells")));
+        new StringProperty(PROP_GROW_ROWS, wxT(""), _("Which rows are allowed to grow. Comma separated list")));
+    AddProperty(new StringProperty(PROP_HGAP, wxT("0"), _("The horizontal gap between grid cells")));
+    AddProperty(new StringProperty(PROP_VGAP, wxT("0"), _("The vertical gap between grid cells")));
     m_namePattern = wxT("flexGridSizer");
 
     EnableSizerFlag("wxEXPAND", true);

--- a/wxcrafter/frame_wrapper.cpp
+++ b/wxcrafter/frame_wrapper.cpp
@@ -26,14 +26,14 @@ FrameWrapper::FrameWrapper()
     PREPEND_STYLE(wxDEFAULT_FRAME_STYLE, true);
 
     SetPropertyString(_("Common Settings"), "wxFrame");
-    DoSetPropertyStringValue(PROP_TITLE, wxT("My Frame"));
+    DoSetPropertyStringValue(PROP_TITLE, _("My Frame"));
 
     RegisterEvent(wxT("wxEVT_CLOSE_WINDOW"), wxT("wxCloseEvent"),
-                  wxT("Process a close event. This event applies to wxFrame and wxDialog classes"));
-    RegisterEvent(wxT("wxEVT_ACTIVATE"), wxT("wxActivateEvent"), wxT("Process a wxEVT_ACTIVATE event"));
-    RegisterEvent(wxT("wxEVT_ACTIVATE_APP"), wxT("wxActivateEvent"), wxT("Process a wxEVT_ACTIVATE_APP event"));
+                  _("Process a close event. This event applies to wxFrame and wxDialog classes"));
+    RegisterEvent(wxT("wxEVT_ACTIVATE"), wxT("wxActivateEvent"), _("Process a wxEVT_ACTIVATE event"));
+    RegisterEvent(wxT("wxEVT_ACTIVATE_APP"), wxT("wxActivateEvent"), _("Process a wxEVT_ACTIVATE_APP event"));
 
-    AddCategory("Frame Type");
+    AddCategory(_("Frame Type"));
     wxArrayString frameTypes;
     frameTypes.Add("wxFrame");
     frameTypes.Add("wxDocMDIParentFrame");

--- a/wxcrafter/generic_dir_ctrl_wrapper.cpp
+++ b/wxcrafter/generic_dir_ctrl_wrapper.cpp
@@ -23,41 +23,41 @@ GenericDirCtrlWrapper::GenericDirCtrlWrapper()
     PREPEND_STYLE_FALSE(wxDIRCTRL_EDIT_LABELS);
 
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_BEGIN_DRAG"), wxT("wxTreeEvent"),
-                  wxT("The user has started dragging an item with the left mouse button.\nThe event handler must call "
+                  _("The user has started dragging an item with the left mouse button.\nThe event handler must call "
                       "wxTreeEvent::Allow() for the drag operation to continue."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_BEGIN_RDRAG"), wxT("wxTreeEvent"),
-                  wxT("The user has started dragging an item with the right mouse button.\nThe event handler must call "
+                  _("The user has started dragging an item with the right mouse button.\nThe event handler must call "
                       "wxTreeEvent::Allow() for the drag operation to continue."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_END_DRAG"), wxT("wxTreeEvent"),
-                  wxT("The user has released the mouse after dragging an item."));
+                  _("The user has released the mouse after dragging an item."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_BEGIN_LABEL_EDIT"), wxT("wxTreeEvent"),
-                  wxT("Begin editing a label. This can be prevented by calling Veto()."));
+                  _("Begin editing a label. This can be prevented by calling Veto()."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_END_LABEL_EDIT"), wxT("wxTreeEvent"),
-                  wxT("The user has finished editing a label. This can be prevented by calling Veto()."));
-    RegisterEvent(wxT("wxEVT_COMMAND_TREE_DELETE_ITEM"), wxT("wxTreeEvent"), wxT("A tree item has been deleted."));
-    RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_EXPANDED"), wxT("wxTreeEvent"), wxT("The item has been expanded."));
+                  _("The user has finished editing a label. This can be prevented by calling Veto()."));
+    RegisterEvent(wxT("wxEVT_COMMAND_TREE_DELETE_ITEM"), wxT("wxTreeEvent"), _("A tree item has been deleted."));
+    RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_EXPANDED"), wxT("wxTreeEvent"), _("The item has been expanded."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_EXPANDING"), wxT("wxTreeEvent"),
-                  wxT("The item is being expanded. This can be prevented by calling Veto()."));
-    RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_COLLAPSED"), wxT("wxTreeEvent"), wxT("The item has been collapsed."));
+                  _("The item is being expanded. This can be prevented by calling Veto()."));
+    RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_COLLAPSED"), wxT("wxTreeEvent"), _("The item has been collapsed."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_COLLAPSING"), wxT("wxTreeEvent"),
-                  wxT("The item is being collapsed. This can be prevented by calling Veto()."));
-    RegisterEvent(wxT("wxEVT_COMMAND_TREE_SEL_CHANGED"), wxT("wxTreeEvent"), wxT("Selection has changed."));
+                  _("The item is being collapsed. This can be prevented by calling Veto()."));
+    RegisterEvent(wxT("wxEVT_COMMAND_TREE_SEL_CHANGED"), wxT("wxTreeEvent"), _("Selection has changed."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_SEL_CHANGING"), wxT("wxTreeEvent"),
-                  wxT("Selection is changing. This can be prevented by calling Veto()."));
-    RegisterEvent(wxT("wxEVT_COMMAND_TREE_KEY_DOWN"), wxT("wxTreeEvent"), wxT("A key has been pressed."));
+                  _("Selection is changing. This can be prevented by calling Veto()."));
+    RegisterEvent(wxT("wxEVT_COMMAND_TREE_KEY_DOWN"), wxT("wxTreeEvent"), _("A key has been pressed."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_ACTIVATED"), wxT("wxTreeEvent"),
-                  wxT("An item has been activated (e.g. double clicked)."));
+                  _("An item has been activated (e.g. double clicked)."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_RIGHT_CLICK"), wxT("wxTreeEvent"),
-                  wxT("The user has clicked the item with the right mouse button."));
+                  _("The user has clicked the item with the right mouse button."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_MIDDLE_CLICK"), wxT("wxTreeEvent"),
-                  wxT("The user has clicked the item with the middle mouse button."));
+                  _("The user has clicked the item with the middle mouse button."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_STATE_IMAGE_CLICK"), wxT("wxTreeEvent"),
-                  wxT("The state image has been clicked. Windows only."));
+                  _("The state image has been clicked. Windows only."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_GETTOOLTIP"), wxT("wxTreeEvent"),
-                  wxT("The opportunity to set the item tooltip is being given to the application\n (call "
+                  _("The opportunity to set the item tooltip is being given to the application\n (call "
                       "wxTreeEvent::SetToolTip). Windows only."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_MENU"), wxT("wxTreeEvent"),
-                  wxT("The context menu for the selected item has been requested,\neither by a right click or by using "
+                  _("The context menu for the selected item has been requested,\neither by a right click or by using "
                       "the menu key."));
 
     m_namePattern = wxT("m_genericDirCtrl");

--- a/wxcrafter/gl_canvas_wrapper.cpp
+++ b/wxcrafter/gl_canvas_wrapper.cpp
@@ -10,7 +10,7 @@ GLCanvasWrapper::GLCanvasWrapper()
 
     SetPropertyString(_("Common Settings"), "wxGLCanvas");
     DelProperty(PROP_CONTROL_SPECIFIC_SETTINGS);
-    AddCategory("wxGLCanvas Attribute List");
+    AddCategory(_("wxGLCanvas Attribute List"));
 
     AddProperty(new StringProperty("WX_GL_RGBA", _("Use true color palette (on if no attrs specified)")));
     m_attrs.Add("WX_GL_RGBA");

--- a/wxcrafter/grid_bag_sizer_wrapper.cpp
+++ b/wxcrafter/grid_bag_sizer_wrapper.cpp
@@ -9,11 +9,11 @@ GridBagSizerWrapper::GridBagSizerWrapper()
     m_styles.Clear(); // Sizer has no styles
     SetPropertyString(_("Common Settings"), "wxGridBagSizer");
     AddProperty(
-        new StringProperty(PROP_GROW_COLS, wxT(""), wxT("Which columns are allowed to grow. Comma separated list")));
+        new StringProperty(PROP_GROW_COLS, wxT(""), _("Which columns are allowed to grow. Comma separated list")));
     AddProperty(
-        new StringProperty(PROP_GROW_ROWS, wxT(""), wxT("Which rows are allowed to grow. Comma separated list")));
-    AddProperty(new StringProperty(PROP_HGAP, wxT("0"), wxT("The horizontal gap between grid cells")));
-    AddProperty(new StringProperty(PROP_VGAP, wxT("0"), wxT("The vertical gap between grid cells")));
+        new StringProperty(PROP_GROW_ROWS, wxT(""), _("Which rows are allowed to grow. Comma separated list")));
+    AddProperty(new StringProperty(PROP_HGAP, wxT("0"), _("The horizontal gap between grid cells")));
+    AddProperty(new StringProperty(PROP_VGAP, wxT("0"), _("The vertical gap between grid cells")));
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);

--- a/wxcrafter/grid_column_wrapper.cpp
+++ b/wxcrafter/grid_column_wrapper.cpp
@@ -12,7 +12,7 @@ GridColumnWrapper::GridColumnWrapper()
 
     SetPropertyString(_("Common Settings"), "wxGridColumn");
     AddProperty(new CategoryProperty(_("wxGrid Column")));
-    AddText(PROP_NAME, _("The Column Label"), "My Column");
+    AddText(PROP_NAME, _("The Column Label"), _("My Column"));
     AddInteger(PROP_WIDTH,
                _("Sets the width of the specified column.\nThe new column width in pixels, 0 to hide the column or -1 "
                  "to fit the column width to its label width"),

--- a/wxcrafter/grid_row_wrapper.cpp
+++ b/wxcrafter/grid_row_wrapper.cpp
@@ -11,7 +11,7 @@ GridRowWrapper::GridRowWrapper()
 
     SetPropertyString(_("Common Settings"), "wxGridRow");
     AddProperty(new CategoryProperty(_("wxGrid Row")));
-    AddText(PROP_NAME, _("The Row Label"), "My Row");
+    AddText(PROP_NAME, _("The Row Label"), _("My Row"));
     AddInteger(PROP_HEIGHT, _("Sets the height of the row\nDefault -1 fits to the label height"), -1);
 
     m_namePattern = "Row";

--- a/wxcrafter/grid_sizer_wrapper.cpp
+++ b/wxcrafter/grid_sizer_wrapper.cpp
@@ -9,10 +9,10 @@ GridSizerWrapper::GridSizerWrapper()
     m_styles.Clear(); // Sizer has no styles
 
     SetPropertyString(_("Common Settings"), "wxGridSizer");
-    AddProperty(new StringProperty(PROP_COLS, wxT("2"), wxT("Number of columns in the grid")));
-    AddProperty(new StringProperty(PROP_ROWS, wxT("0"), wxT("Number of rows in the grid")));
-    AddProperty(new StringProperty(PROP_HGAP, wxT("0"), wxT("The horizontal gap between grid cells")));
-    AddProperty(new StringProperty(PROP_VGAP, wxT("0"), wxT("The vertical gap between grid cells")));
+    AddProperty(new StringProperty(PROP_COLS, wxT("2"), _("Number of columns in the grid")));
+    AddProperty(new StringProperty(PROP_ROWS, wxT("0"), _("Number of rows in the grid")));
+    AddProperty(new StringProperty(PROP_HGAP, wxT("0"), _("The horizontal gap between grid cells")));
+    AddProperty(new StringProperty(PROP_VGAP, wxT("0"), _("The vertical gap between grid cells")));
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);

--- a/wxcrafter/grid_wrapper.cpp
+++ b/wxcrafter/grid_wrapper.cpp
@@ -23,89 +23,89 @@ GridWrapper::GridWrapper()
     hOpts.Add("wxALIGN_RIGHT");
 
     SetPropertyString(_("Common Settings"), "wxGrid");
-    AddProperty(new CategoryProperty("wxGrid Header"));
-    AddProperty(new BoolProperty(PROP_AUTOSIZE_COL, true, wxT("Auto size column content to fit the column header")));
+    AddProperty(new CategoryProperty(_("wxGrid Header")));
+    AddProperty(new BoolProperty(PROP_AUTOSIZE_COL, true, _("Auto size column content to fit the column header")));
     AddProperty(
-        new BoolProperty(PROP_GRID_NATIVE_LOOK, true, wxT("Enable the use of native header window for column labels")));
-    // AddProperty(new BoolProperty(PROP_GRID_NATIVE_COL_LABELS, true, wxT("Call this in order to make the column labels
+        new BoolProperty(PROP_GRID_NATIVE_LOOK, true, _("Enable the use of native header window for column labels")));
+    // AddProperty(new BoolProperty(PROP_GRID_NATIVE_COL_LABELS, true, _("Call this in order to make the column labels
     // use a native look")));
 
-    AddProperty(new CategoryProperty("wxGrid Columns Labels"));
+    AddProperty(new CategoryProperty(_("wxGrid Columns Labels")));
     AddInteger(PROP_HEIGHT, _("Sets the height of the column label"), -1);
     AddProperty(new ChoiceProperty(PROP_COL_LABEL_H_ALIGN, hOpts, 1, _("Sets the horizontal alignment of the label")));
     AddProperty(new ChoiceProperty(PROP_COL_LABEL_V_ALIGN, vOpts, 1, _("Sets the vertical alignment of the label")));
 
-    AddProperty(new CategoryProperty("wxGrid Rows Labels"));
+    AddProperty(new CategoryProperty(_("wxGrid Rows Labels")));
     AddInteger(PROP_WIDTH, _("Sets the width of the row labels"), -1);
     AddProperty(new ChoiceProperty(PROP_ROW_LABEL_H_ALIGN, hOpts, 2, _("Sets the horizontal alignment of the label")));
     AddProperty(new ChoiceProperty(PROP_ROW_LABEL_V_ALIGN, vOpts, 1, _("Sets the vertical alignment of the label")));
 
-    AddProperty(new CategoryProperty("wxGrid Cells"));
-    AddProperty(new BoolProperty(PROP_ALLOW_EDITING, true, wxT("Allow editing grid content")));
+    AddProperty(new CategoryProperty(_("wxGrid Cells")));
+    AddProperty(new BoolProperty(PROP_ALLOW_EDITING, true, _("Allow editing grid content")));
 
     RegisterEvent(wxT("wxEVT_GRID_CELL_CHANGING"), wxT("wxGridEvent"),
-                  wxT("The user is about to change the data in a cell. The new cell value as string is available from "
-                      "GetString() event object method. This event can be vetoed if the change is not allowed. "
-                      "Processes a wxEVT_GRID_CELL_CHANGING event type"));
+                  _("The user is about to change the data in a cell. The new cell value as string is available from "
+                    "GetString() event object method. This event can be vetoed if the change is not allowed. "
+                    "Processes a wxEVT_GRID_CELL_CHANGING event type"));
     RegisterEvent(wxT("wxEVT_GRID_CELL_CHANGED"), wxT("wxGridEvent"),
-                  wxT("The user changed the data in a cell. The old cell value as string is available from GetString() "
-                      "event object method. Notice that vetoing this event still works for backwards compatibility "
-                      "reasons but any new code should only veto EVT_GRID_CELL_CHANGING event and not this one. "
-                      "Processes a wxEVT_GRID_CELL_CHANGED event type."));
+                  _("The user changed the data in a cell. The old cell value as string is available from GetString() "
+                    "event object method. Notice that vetoing this event still works for backwards compatibility "
+                    "reasons but any new code should only veto EVT_GRID_CELL_CHANGING event and not this one. "
+                    "Processes a wxEVT_GRID_CELL_CHANGED event type."));
     RegisterEvent(wxT("wxEVT_GRID_CELL_LEFT_CLICK"), wxT("wxGridEvent"),
-                  wxT("The user clicked a cell with the left mouse button. Processes a wxEVT_GRID_CELL_LEFT_CLICK."));
+                  _("The user clicked a cell with the left mouse button. Processes a wxEVT_GRID_CELL_LEFT_CLICK."));
     RegisterEvent(
         wxT("wxEVT_GRID_CELL_LEFT_DCLICK"), wxT("wxGridEvent"),
-        wxT("The user double-clicked a cell with the left mouse button. Processes a wxEVT_GRID_CELL_LEFT_DCLICK"));
+        _("The user double-clicked a cell with the left mouse button. Processes a wxEVT_GRID_CELL_LEFT_DCLICK"));
     RegisterEvent(wxT("wxEVT_GRID_CELL_RIGHT_CLICK"), wxT("wxGridEvent"),
-                  wxT("The user clicked a cell with the right mouse button. Processes a wxEVT_GRID_CELL_RIGHT_CLICK."));
+                  _("The user clicked a cell with the right mouse button. Processes a wxEVT_GRID_CELL_RIGHT_CLICK."));
     RegisterEvent(
         wxT("wxEVT_GRID_CELL_RIGHT_DCLICK"), wxT("wxGridEvent"),
-        wxT("The user double-clicked a cell with the right mouse button. Processes a wxEVT_GRID_CELL_RIGHT_DCLICK."));
+        _("The user double-clicked a cell with the right mouse button. Processes a wxEVT_GRID_CELL_RIGHT_DCLICK."));
     RegisterEvent(wxT("wxEVT_GRID_EDITOR_HIDDEN"), wxT("wxGridEvent"),
-                  wxT("The editor for a cell was hidden. Processes a wxEVT_GRID_EDITOR_HIDDEN event type."));
+                  _("The editor for a cell was hidden. Processes a wxEVT_GRID_EDITOR_HIDDEN event type."));
     RegisterEvent(wxT("wxEVT_GRID_EDITOR_SHOWN"), wxT("wxGridEvent"),
-                  wxT("The editor for a cell was shown. Processes a wxEVT_GRID_EDITOR_SHOWN event type"));
+                  _("The editor for a cell was shown. Processes a wxEVT_GRID_EDITOR_SHOWN event type"));
     RegisterEvent(wxT("wxEVT_GRID_LABEL_LEFT_CLICK"), wxT("wxGridEvent"),
-                  wxT("The user clicked a label with the left mouse button. Processes a wxEVT_GRID_LABEL_LEFT_CLICK."));
+                  _("The user clicked a label with the left mouse button. Processes a wxEVT_GRID_LABEL_LEFT_CLICK."));
     RegisterEvent(
         wxT("wxEVT_GRID_LABEL_LEFT_DCLICK"), wxT("wxGridEvent"),
-        wxT("The user double-clicked a label with the left mouse button. Processes a wxEVT_GRID_LABEL_LEFT_DCLICK."));
+        _("The user double-clicked a label with the left mouse button. Processes a wxEVT_GRID_LABEL_LEFT_DCLICK."));
     RegisterEvent(
         wxT("wxEVT_GRID_LABEL_RIGHT_CLICK"), wxT("wxGridEvent"),
-        wxT("The user clicked a label with the right mouse button. Processes a wxEVT_GRID_LABEL_RIGHT_CLICK."));
+        _("The user clicked a label with the right mouse button. Processes a wxEVT_GRID_LABEL_RIGHT_CLICK."));
     RegisterEvent(
         wxT("wxEVT_GRID_LABEL_RIGHT_DCLICK"), wxT("wxGridEvent"),
-        wxT("The user double-clicked a label with the right mouse button. Processes a wxEVT_GRID_LABEL_RIGHT_DCLICK."));
+        _("The user double-clicked a label with the right mouse button. Processes a wxEVT_GRID_LABEL_RIGHT_DCLICK."));
     RegisterEvent(wxT("wxEVT_GRID_SELECT_CELL"), wxT("wxGridEvent"),
-                  wxT("The user moved to, and selected a cell. Processes a wxEVT_GRID_SELECT_CELL."));
+                  _("The user moved to, and selected a cell. Processes a wxEVT_GRID_SELECT_CELL."));
     RegisterEvent(
         wxT("wxEVT_GRID_COL_MOVE"), wxT("wxGridEvent"),
-        "The user tries to change the order of the columns in the grid by dragging the column specified by GetCol()."
-        "This event can be vetoed to either prevent the user from reordering the column change completely (but notice "
-        "that if you don't want to allow it at all, you simply shouldn't call wxGrid::EnableDragColMove() in the first "
-        "place), "
-        "vetoed but handled in some way in the handler, e.g. by really moving the column to the new position at the "
-        "associated table level, "
-        "or allowed to proceed in which case wxGrid::SetColPos() is used to reorder the columns display order without "
-        "affecting the use of "
-        "the column indices otherwise. This event macro corresponds to wxEVT_GRID_COL_MOVE event type.");
+        _("The user tries to change the order of the columns in the grid by dragging the column specified by GetCol(). "
+          "This event can be vetoed to either prevent the user from reordering the column change completely (but notice "
+          "that if you don't want to allow it at all, you simply shouldn't call wxGrid::EnableDragColMove() in the first "
+          "place), "
+          "vetoed but handled in some way in the handler, e.g. by really moving the column to the new position at the "
+          "associated table level, "
+          "or allowed to proceed in which case wxGrid::SetColPos() is used to reorder the columns display order without "
+          "affecting the use of "
+          "the column indices otherwise. This event macro corresponds to wxEVT_GRID_COL_MOVE event type."));
     RegisterEvent(wxT("wxEVT_GRID_COL_SORT"), wxT("wxGridEvent"),
-                  "This event is generated when a column is clicked by the user and its name is explained by the fact "
-                  "that the custom reaction to a "
-                  "click on a column is to sort the grid contents by this column. However the grid itself has no "
-                  "special support for sorting and it's "
-                  "up to the handler of this event to update the associated table. But if the event is handled (and "
-                  "not vetoed) the grid supposes that "
-                  "the table was indeed resorted and updates the column to indicate the new sort order and refreshes "
-                  "itself. This event macro corresponds"
-                  "to wxEVT_GRID_COL_SORT event type.");
+                  _("This event is generated when a column is clicked by the user and its name is explained by the fact "
+                    "that the custom reaction to a "
+                    "click on a column is to sort the grid contents by this column. However the grid itself has no "
+                    "special support for sorting and it's "
+                    "up to the handler of this event to update the associated table. But if the event is handled (and "
+                    "not vetoed) the grid supposes that "
+                    "the table was indeed resorted and updates the column to indicate the new sort order and refreshes "
+                    "itself. This event macro corresponds "
+                    "to wxEVT_GRID_COL_SORT event type."));
     RegisterEvent(wxT("wxEVT_GRID_TABBING"), wxT("wxGridEvent"),
-                  "This event is generated when the user presses TAB or Shift-TAB in the grid. It can be used to "
-                  "customize the simple default TAB handling "
-                  "logic, e.g. to go to the next non-empty cell instead of just the next cell. See also "
-                  "wxGrid::SetTabBehaviour()."
-                  " This event is new since wxWidgets 2.9.5.");
+                  _("This event is generated when the user presses TAB or Shift-TAB in the grid. It can be used to "
+                    "customize the simple default TAB handling "
+                    "logic, e.g. to go to the next non-empty cell instead of just the next cell. See also "
+                    "wxGrid::SetTabBehaviour()."
+                    " This event is new since wxWidgets 2.9.5."));
     m_namePattern = wxT("m_grid");
     SetName(GenerateName());
 }

--- a/wxcrafter/html_window_wrapper.cpp
+++ b/wxcrafter/html_window_wrapper.cpp
@@ -13,14 +13,14 @@ HtmlWindowWrapper::HtmlWindowWrapper()
     PREPEND_STYLE(wxHW_NO_SELECTION, false);
 
     SetPropertyString(_("Common Settings"), "wxHtmlWindow");
-    AddProperty(new StringProperty(PROP_HTMLCODE, wxT("<b>wxHtmlWindow control!</b>"), wxT("HTML code to load")));
-    AddProperty(new StringProperty(PROP_URL, wxT(""), wxT("URL to load")));
+    AddProperty(new StringProperty(PROP_HTMLCODE, wxT("<b>wxHtmlWindow control!</b>"), _("HTML code to load")));
+    AddProperty(new StringProperty(PROP_URL, wxT(""), _("URL to load")));
 
-    RegisterEvent(wxT("wxEVT_COMMAND_HTML_CELL_CLICKED"), wxT("wxHtmlCellEvent"), wxT("A wxHtmlCell was clicked."));
+    RegisterEvent(wxT("wxEVT_COMMAND_HTML_CELL_CLICKED"), wxT("wxHtmlCellEvent"), _("A wxHtmlCell was clicked."));
     RegisterEvent(wxT("wxEVT_COMMAND_HTML_CELL_HOVER"), wxT("wxHtmlCellEvent"),
-                  wxT("The mouse passed over a wxHtmlCell."));
+                  _("The mouse passed over a wxHtmlCell."));
     RegisterEvent(wxT("wxEVT_COMMAND_HTML_LINK_CLICKED"), wxT("wxHtmlLinkEvent"),
-                  wxT("A wxHtmlCell which contains an hyperlink was clicked."));
+                  _("A wxHtmlCell which contains an hyperlink was clicked."));
 
     m_namePattern = wxT("m_htmlWin");
     SetName(GenerateName());

--- a/wxcrafter/info_bar_button_wrapper.cpp
+++ b/wxcrafter/info_bar_button_wrapper.cpp
@@ -15,12 +15,12 @@ InfoBarButtonWrapper::InfoBarButtonWrapper()
     AddProperty(new WinIdProperty());
     AddProperty(new StringProperty(PROP_NAME, "", _("Name")));
     AddProperty(
-        new StringProperty(PROP_LABEL, "My Label",
+        new StringProperty(PROP_LABEL, _("My Label"),
                            _("The label of the button. It may only be empty if the button ID is one of the stock ids "
                              "in which case the corresponding stock label (see wxGetStockLabel()) will be used")));
 
     RegisterEvent(wxT("wxEVT_COMMAND_BUTTON_CLICKED"), wxT("wxCommandEvent"),
-                  wxT("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),
+                  _("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),
                   wxT("wxCommandEventHandler"));
 
     m_namePattern = "m_infoBarButton";

--- a/wxcrafter/list_box_wrapper.cpp
+++ b/wxcrafter/list_box_wrapper.cpp
@@ -18,17 +18,17 @@ ListBoxWrapper::ListBoxWrapper()
     PREPEND_STYLE(wxLB_SORT, false);
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_LISTBOX_SELECTED"),
-                         wxT("Process a wxEVT_COMMAND_LISTBOX_SELECTED event, when an item on the list is selected or "
-                             "the selection changes."));
+                         _("Process a wxEVT_COMMAND_LISTBOX_SELECTED event, when an item on the list is selected or "
+                           "the selection changes."));
     RegisterEventCommand(
         wxT("wxEVT_COMMAND_LISTBOX_DOUBLECLICKED"),
-        wxT("Process a wxEVT_COMMAND_LISTBOX_DOUBLECLICKED event, when the listbox is double-clicked."));
+        _("Process a wxEVT_COMMAND_LISTBOX_DOUBLECLICKED event, when the listbox is double-clicked."));
 
     SetPropertyString(_("Common Settings"), "wxListBox");
-    AddProperty(new MultiStringsProperty(PROP_OPTIONS, wxT("The List Box Items. A semi-colon list of strings")));
+    AddProperty(new MultiStringsProperty(PROP_OPTIONS, _("The List Box Items. A semi-colon list of strings")));
     AddProperty(new StringProperty(
         PROP_SELECTION, wxT("-1"),
-        wxT("The zero-based position of any initially selected string, or -1 if none are to be selected")));
+        _("The zero-based position of any initially selected string, or -1 if none are to be selected")));
 
     m_namePattern = wxT("m_listBox");
     SetName(GenerateName());

--- a/wxcrafter/list_ctrl_column_wrapper.cpp
+++ b/wxcrafter/list_ctrl_column_wrapper.cpp
@@ -12,11 +12,11 @@ ListCtrlColumnWrapper::ListCtrlColumnWrapper()
 
     SetPropertyString(_("Common Settings"), "wxListCtrlColumn");
     AddProperty(new CategoryProperty(_("wxListCtrl Column")));
-    AddProperty(new StringProperty(PROP_NAME, wxT("My Column"), wxT("Column caption")));
+    AddProperty(new StringProperty(PROP_NAME, _("My Column"), _("Column caption")));
     AddProperty(new StringProperty(
         PROP_WIDTH, wxT("-1"),
-        wxT("Column Width\nSet it to -1 for auto sizing.\nOr set it to -2 to fit the column width to heading or to "
-            "extend to fill all the remaining space for the last column\nValue > 0 will set the width in pixels")));
+        _("Column Width\nSet it to -1 for auto sizing.\nOr set it to -2 to fit the column width to heading or to "
+          "extend to fill all the remaining space for the last column\nValue > 0 will set the width in pixels")));
 }
 
 ListCtrlColumnWrapper::~ListCtrlColumnWrapper() {}

--- a/wxcrafter/list_ctrl_wrapper.cpp
+++ b/wxcrafter/list_ctrl_wrapper.cpp
@@ -23,40 +23,40 @@ ListCtrlWrapper::ListCtrlWrapper()
     PREPEND_STYLE(wxLC_HRULES, false);
     PREPEND_STYLE(wxLC_VRULES, false);
 
-    RegisterEvent(wxT("wxEVT_COMMAND_LIST_ITEM_SELECTED"), wxT("wxListEvent"), wxT("The item has been selected"));
-    RegisterEvent(wxT("wxEVT_COMMAND_LIST_ITEM_DESELECTED"), wxT("wxListEvent"), wxT("The item has been deselected"));
+    RegisterEvent(wxT("wxEVT_COMMAND_LIST_ITEM_SELECTED"), wxT("wxListEvent"), _("The item has been selected"));
+    RegisterEvent(wxT("wxEVT_COMMAND_LIST_ITEM_DESELECTED"), wxT("wxListEvent"), _("The item has been deselected"));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_ITEM_RIGHT_CLICK"), wxT("wxListEvent"),
-                  wxT("The right mouse button has been clicked on an item"));
+                  _("The right mouse button has been clicked on an item"));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_ITEM_MIDDLE_CLICK"), wxT("wxListEvent"),
-                  wxT("The middle mouse button has been clicked on an item"));
+                  _("The middle mouse button has been clicked on an item"));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_ITEM_ACTIVATED"), wxT("wxListEvent"),
-                  wxT("The item has been activated (ENTER or double click)"));
+                  _("The item has been activated (ENTER or double click)"));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_ITEM_FOCUSED"), wxT("wxListEvent"),
-                  wxT("The currently focused item has changed"));
-    RegisterEvent(wxT("wxEVT_COMMAND_LIST_KEY_DOWN"), wxT("wxListEvent"), wxT("A key has been pressed"));
+                  _("The currently focused item has changed"));
+    RegisterEvent(wxT("wxEVT_COMMAND_LIST_KEY_DOWN"), wxT("wxListEvent"), _("A key has been pressed"));
 
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_COL_CLICK"), wxT("wxListEvent"),
-                  wxT("A column (m_col) has been left-clicked"));
+                  _("A column (m_col) has been left-clicked"));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_COL_RIGHT_CLICK"), wxT("wxListEvent"),
-                  wxT("A column (m_col) has been right-clicked"));
+                  _("A column (m_col) has been right-clicked"));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_COL_BEGIN_DRAG"), wxT("wxListEvent"),
-                  wxT("The user started resizing a column - can be vetoed"));
+                  _("The user started resizing a column - can be vetoed"));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_COL_DRAGGING"), wxT("wxListEvent"),
-                  wxT("The divider between columns is being dragged"));
+                  _("The divider between columns is being dragged"));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_COL_END_DRAG"), wxT("wxListEvent"),
-                  wxT("A column has been resized by the user"));
+                  _("A column has been resized by the user"));
 
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_BEGIN_DRAG"), wxT("wxListEvent"),
-                  wxT("Begin dragging with the left mouse button"));
+                  _("Begin dragging with the left mouse button"));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_BEGIN_RDRAG"), wxT("wxListEvent"),
-                  wxT("Begin dragging with the right mouse button."));
+                  _("Begin dragging with the right mouse button."));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_BEGIN_LABEL_EDIT"), wxT("wxListEvent"),
-                  wxT("Begin editing a label. This can be prevented by calling Veto()"));
+                  _("Begin editing a label. This can be prevented by calling Veto()"));
     RegisterEvent(wxT("wxEVT_COMMAND_LIST_END_LABEL_EDIT"), wxT("wxListEvent"),
-                  wxT("Finish editing a label. This can be prevented by calling Veto()"));
-    RegisterEvent(wxT("wxEVT_COMMAND_LIST_DELETE_ITEM"), wxT("wxListEvent"), wxT("Delete an item"));
-    RegisterEvent(wxT("wxEVT_COMMAND_LIST_DELETE_ALL_ITEMS"), wxT("wxListEvent"), wxT("Delete all items"));
-    RegisterEvent(wxT("wxEVT_COMMAND_LIST_INSERT_ITEM"), wxT("wxListEvent"), wxT("An item has been inserted"));
+                  _("Finish editing a label. This can be prevented by calling Veto()"));
+    RegisterEvent(wxT("wxEVT_COMMAND_LIST_DELETE_ITEM"), wxT("wxListEvent"), _("Delete an item"));
+    RegisterEvent(wxT("wxEVT_COMMAND_LIST_DELETE_ALL_ITEMS"), wxT("wxListEvent"), _("Delete all items"));
+    RegisterEvent(wxT("wxEVT_COMMAND_LIST_INSERT_ITEM"), wxT("wxListEvent"), _("An item has been inserted"));
 
     m_namePattern = wxT("m_listCtrl");
     SetName(GenerateName());

--- a/wxcrafter/media_ctrl_wrapper.cpp
+++ b/wxcrafter/media_ctrl_wrapper.cpp
@@ -40,7 +40,7 @@ MediaCtrlWrapper::MediaCtrlWrapper()
     RegisterEvent("wxEVT_MEDIA_PLAY", "wxMediaEvent",
                   _("Sent when a media has switched to the wxMEDIASTATE_PLAYING state"));
     RegisterEvent("wxEVT_MEDIA_PAUSE", "wxMediaEvent",
-                  _("Sent when a media has switched to the wxMEDIASTATE_PAUSED statee"));
+                  _("Sent when a media has switched to the wxMEDIASTATE_PAUSED state"));
 
     m_namePattern = "m_mediaCtrl";
     SetName(GenerateName());

--- a/wxcrafter/properties_list_view.cpp
+++ b/wxcrafter/properties_list_view.cpp
@@ -262,16 +262,16 @@ void PropertiesListView::OnCellChanged(wxPropertyGridEvent& e)
         p = m_pg->GetProperty(PROP_OUTPUT_FILE_NAME);
         if(p) { wxcProjectMetadata::Get().SetOutputFileName(p->GetValueAsString()); }
 
-        p = m_pg->GetProperty("Generate Window ID");
+        p = m_pg->GetProperty(_("Generate Window ID"));
         if(p) { wxcProjectMetadata::Get().SetUseEnum(p->GetValue().GetBool()); }
 
-        p = m_pg->GetProperty("First Window ID");
+        p = m_pg->GetProperty(_("First Window ID"));
         if(p) { wxcProjectMetadata::Get().SetFirstWindowId(p->GetValue().GetInteger()); }
 
-        p = m_pg->GetProperty("Generate Translatable Strings");
+        p = m_pg->GetProperty(_("Generate Translatable Strings"));
         if(p) { wxcProjectMetadata::Get().SetUseUnderscoreMacro(p->GetValue().GetBool()); }
 
-        p = m_pg->GetProperty("Add wxWidgets Handlers if missing");
+        p = m_pg->GetProperty(_("Add wxWidgets Handlers if missing"));
         if(p) { wxcProjectMetadata::Get().SetAddHandlers(p->GetValue().GetBool()); }
 
         wxCommandEvent evt(wxEVT_PROJECT_METADATA_MODIFIED);

--- a/wxcrafter/property_grid_manager_wrapper.cpp
+++ b/wxcrafter/property_grid_manager_wrapper.cpp
@@ -59,11 +59,11 @@ PropertyGridManagerWrapper::PropertyGridManagerWrapper()
     RegisterEvent("wxEVT_PG_COL_END_DRAG", "wxPropertyGridEvent",
                   _("Respond to wxEVT_PG_COL_END_DRAG event, generated after column resize by user has finished."));
     RegisterEvent("wxEVT_COMMAND_BUTTON_CLICKED", "wxCommandEvent",
-                  "Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the custom editor button is clicked.");
+                  _("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the custom editor button is clicked."));
 
-    AddInteger(PROP_SASH_POS, "Sets x coordinate of the splitter", -1);
+    AddInteger(PROP_SASH_POS, _("Sets x coordinate of the splitter"), -1);
     AddBool(PROP_SPLITTER_LEFT,
-            "Moves splitter as left as possible, while still allowing all labels to be shown in full", false);
+            _("Moves splitter as left as possible, while still allowing all labels to be shown in full"), false);
 
     m_namePattern = "m_pgMgr";
     SetName(GenerateName());

--- a/wxcrafter/radio_box_wrapper.cpp
+++ b/wxcrafter/radio_box_wrapper.cpp
@@ -13,15 +13,15 @@ RadioBoxWrapper::RadioBoxWrapper()
     PREPEND_STYLE(wxRA_SPECIFY_COLS, false);
 
     SetPropertyString(_("Common Settings"), "wxRadioBox");
-    AddProperty(new StringProperty(PROP_LABEL, wxT("My RadioBox"), wxT("Label")));
+    AddProperty(new StringProperty(PROP_LABEL, _("My RadioBox"), _("Label")));
     AddProperty(new MultiStringsProperty(PROP_OPTIONS, _("An array of choices with which to initialize the radiobox")));
-    AddProperty(new StringProperty(PROP_SELECTION, wxT("0"), wxT("The zero-based position of the selected button")));
+    AddProperty(new StringProperty(PROP_SELECTION, wxT("0"), _("The zero-based position of the selected button")));
     AddProperty(new StringProperty(PROP_MAJORDIM, wxT("1"),
                                    _("Specifies the maximum number of rows (if style contains wxRA_SPECIFY_ROWS) or "
                                      "columns (if style contains wxRA_SPECIFY_COLS) for a two-dimensional radiobox")));
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_RADIOBOX_SELECTED"),
-                         wxT("Process a wxEVT_COMMAND_RADIOBOX_SELECTED event, when a radiobutton is clicked."));
+                         _("Process a wxEVT_COMMAND_RADIOBOX_SELECTED event, when a radiobutton is clicked."));
     DoSetPropertyStringValue(PROP_OPTIONS, wxT("An option;Second Option"));
 
     m_namePattern = wxT("m_radioBox");

--- a/wxcrafter/radio_button_wrapper.cpp
+++ b/wxcrafter/radio_button_wrapper.cpp
@@ -11,11 +11,11 @@ RadioButtonWrapper::RadioButtonWrapper()
     PREPEND_STYLE(wxRB_SINGLE, false);
 
     SetPropertyString(_("Common Settings"), "wxRadioButton");
-    AddProperty(new StringProperty(PROP_LABEL, wxT("My RadioButton"), wxT("Label")));
-    AddProperty(new BoolProperty(PROP_VALUE, true, wxT("Initial value")));
+    AddProperty(new StringProperty(PROP_LABEL, _("My RadioButton"), _("Label")));
+    AddProperty(new BoolProperty(PROP_VALUE, true, _("Initial value")));
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_RADIOBUTTON_SELECTED"),
-                         wxT("Process a wxEVT_COMMAND_RADIOBUTTON_SELECTED event, when the radiobutton is clicked."));
+                         _("Process a wxEVT_COMMAND_RADIOBUTTON_SELECTED event, when the radiobutton is clicked."));
 
     m_namePattern = wxT("m_radioButton");
     SetName(GenerateName());

--- a/wxcrafter/rich_text_ctrl_wrapper.cpp
+++ b/wxcrafter/rich_text_ctrl_wrapper.cpp
@@ -15,47 +15,47 @@ RichTextCtrlWrapper::RichTextCtrlWrapper()
     EnableStyle(wxT("wxWANTS_CHARS"), true);
 
     RegisterEvent(wxT("wxEVT_COMMAND_RICHTEXT_CHARACTER"), wxT("wxRichTextEvent"),
-                  wxT("Process a wxEVT_COMMAND_RICHTEXT_CHARACTER event, generated when the user presses a character "
-                      "key.\nValid event functions: GetFlags, GetPosition, GetCharacter."));
+                  _("Process a wxEVT_COMMAND_RICHTEXT_CHARACTER event, generated when the user presses a character "
+                    "key.\nValid event functions: GetFlags, GetPosition, GetCharacter."));
     RegisterEvent(wxT("wxEVT_COMMAND_RICHTEXT_DELETE"), wxT("wxRichTextEvent"),
-                  wxT("Process a wxEVT_COMMAND_RICHTEXT_DELETE event, generated when the user presses the backspace or "
-                      "delete key.\nValid event functions: GetFlags, GetPosition"));
+                  _("Process a wxEVT_COMMAND_RICHTEXT_DELETE event, generated when the user presses the backspace or "
+                    "delete key.\nValid event functions: GetFlags, GetPosition"));
     RegisterEvent(wxT("wxEVT_COMMAND_RICHTEXT_RETURN"), wxT("wxRichTextEvent"),
-                  wxT("Process a wxEVT_COMMAND_RICHTEXT_RETURN event, generated when the user presses the return "
-                      "key.\nValid event functions: GetFlags, GetPosition."));
+                  _("Process a wxEVT_COMMAND_RICHTEXT_RETURN event, generated when the user presses the return "
+                    "key.\nValid event functions: GetFlags, GetPosition."));
     RegisterEvent(wxT("wxEVT_COMMAND_RICHTEXT_STYLE_CHANGED"), wxT("wxRichTextEvent"),
-                  wxT("Process a wxEVT_COMMAND_RICHTEXT_STYLE_CHANGED event, generated when styling has been applied "
-                      "to the control.\nValid event functions: GetPosition, GetRange."));
+                  _("Process a wxEVT_COMMAND_RICHTEXT_STYLE_CHANGED event, generated when styling has been applied "
+                    "to the control.\nValid event functions: GetPosition, GetRange."));
     RegisterEvent(wxT("wxEVT_COMMAND_RICHTEXT_STYLESHEET_CHANGING"), wxT("wxRichTextEvent"),
-                  wxT("Process a wxEVT_COMMAND_RICHTEXT_STYLESHEET_CHANGING event, generated when the control's "
-                      "stylesheet has changed,\nfor example the user added, edited or deleted a style.\nValid event "
-                      "functions: GetRange, GetPosition."));
+                  _("Process a wxEVT_COMMAND_RICHTEXT_STYLESHEET_CHANGING event, generated when the control's "
+                    "stylesheet has changed,\nfor example the user added, edited or deleted a style.\nValid event "
+                    "functions: GetRange, GetPosition."));
     RegisterEvent(wxT("wxEVT_COMMAND_RICHTEXT_STYLESHEET_REPLACING"), wxT("wxRichTextEvent"),
-                  wxT("Process a wxEVT_COMMAND_RICHTEXT_STYLESHEET_REPLACING event, generated when the control's "
-                      "stylesheet is about to be replaced\nfor example when a file is loaded into the control.\nValid "
-                      "event functions: Veto, GetOldStyleSheet, GetNewStyleSheet."));
+                  _("Process a wxEVT_COMMAND_RICHTEXT_STYLESHEET_REPLACING event, generated when the control's "
+                    "stylesheet is about to be replaced\nfor example when a file is loaded into the control.\nValid "
+                    "event functions: Veto, GetOldStyleSheet, GetNewStyleSheet."));
     RegisterEvent(wxT("wxEVT_COMMAND_RICHTEXT_STYLESHEET_REPLACED"), wxT("wxRichTextEvent"),
-                  wxT("Process a wxEVT_COMMAND_RICHTEXT_STYLESHEET_REPLACED event, generated when the control's "
-                      "stylesheet has been replaced\nfor example when a file is loaded into the control\nValid event "
-                      "functions: GetOldStyleSheet, GetNewStyleSheet."));
+                  _("Process a wxEVT_COMMAND_RICHTEXT_STYLESHEET_REPLACED event, generated when the control's "
+                    "stylesheet has been replaced\nfor example when a file is loaded into the control\nValid event "
+                    "functions: GetOldStyleSheet, GetNewStyleSheet."));
     RegisterEvent(wxT("wxEVT_COMMAND_RICHTEXT_CONTENT_INSERTED"), wxT("wxRichTextEvent"),
-                  wxT("Process a wxEVT_COMMAND_RICHTEXT_CONTENT_INSERTED event generated when content has been "
-                      "inserted into the control.\nValid event functions: GetPosition, GetRange."));
+                  _("Process a wxEVT_COMMAND_RICHTEXT_CONTENT_INSERTED event generated when content has been "
+                    "inserted into the control.\nValid event functions: GetPosition, GetRange."));
     RegisterEvent(wxT("wxEVT_COMMAND_RICHTEXT_CONTENT_DELETED"), wxT("wxRichTextEvent"),
-                  wxT("Process a wxEVT_COMMAND_RICHTEXT_CONTENT_DELETED event, generated when content has been deleted "
-                      "from the control\nValid event functions: GetPosition, GetRange."));
+                  _("Process a wxEVT_COMMAND_RICHTEXT_CONTENT_DELETED event, generated when content has been deleted "
+                    "from the control\nValid event functions: GetPosition, GetRange."));
     RegisterEvent(
         wxT("wxEVT_COMMAND_RICHTEXT_BUFFER_RESET"), wxT("wxRichTextEvent"),
-        wxT("Process a wxEVT_COMMAND_RICHTEXT_BUFFER_RESET event, generated when the buffer has been reset by deleting "
-            "all content.\nYou can use this to set a default style for the first new paragraph."));
+        _("Process a wxEVT_COMMAND_RICHTEXT_BUFFER_RESET event, generated when the buffer has been reset by deleting "
+          "all content.\nYou can use this to set a default style for the first new paragraph."));
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_UPDATED"),
-                         wxT("Respond to a wxEVT_COMMAND_TEXT_UPDATED event, generated when the text changes.\nNotice "
-                             "that this event will be sent when the text controls contents changes\n - whether this is "
-                             "due to user input or comes from the program itself\n(for example, if SetValue() is "
-                             "called); see ChangeValue() for a function which does not send this event."));
+                         _("Respond to a wxEVT_COMMAND_TEXT_UPDATED event, generated when the text changes.\nNotice "
+                           "that this event will be sent when the text controls contents changes\n - whether this is "
+                           "due to user input or comes from the program itself\n(for example, if SetValue() is "
+                           "called); see ChangeValue() for a function which does not send this event."));
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_ENTER"),
-                         wxT("Respond to a wxEVT_COMMAND_TEXT_ENTER event, generated when enter is pressed in a text "
-                             "control\n(which must have wxTE_PROCESS_ENTER style for this event to be generated)."));
+                         _("Respond to a wxEVT_COMMAND_TEXT_ENTER event, generated when enter is pressed in a text "
+                           "control\n(which must have wxTE_PROCESS_ENTER style for this event to be generated)."));
 
     SetPropertyString(_("Common Settings"), "wxRichTextCtrl");
     AddProperty(new StringProperty(PROP_VALUE, wxT("wxRichTextCtrl!"), _("Value")));

--- a/wxcrafter/scroll_bar_wrapper.cpp
+++ b/wxcrafter/scroll_bar_wrapper.cpp
@@ -12,22 +12,22 @@ ScrollBarWrapper::ScrollBarWrapper()
     PREPEND_STYLE_STR(wxT("wxSB_VERTICAL"), wxSB_VERTICAL, false);
 
     RegisterEvent(wxT("wxEVT_SCROLL_TOP"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_TOP scroll-to-top events (minimum position)"));
+                  _("Process wxEVT_SCROLL_TOP scroll-to-top events (minimum position)"));
     RegisterEvent(wxT("wxEVT_SCROLL_BOTTOM"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_BOTTOM scroll-to-bottom events (maximum position)."));
-    RegisterEvent(wxT("wxEVT_SCROLL_LINEUP"), wxT("wxScrollEvent"), wxT("Process wxEVT_SCROLL_LINEUP line up events."));
+                  _("Process wxEVT_SCROLL_BOTTOM scroll-to-bottom events (maximum position)."));
+    RegisterEvent(wxT("wxEVT_SCROLL_LINEUP"), wxT("wxScrollEvent"), _("Process wxEVT_SCROLL_LINEUP line up events."));
     RegisterEvent(wxT("wxEVT_SCROLL_LINEDOWN"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_LINEDOWN line down events."));
-    RegisterEvent(wxT("wxEVT_SCROLL_PAGEUP"), wxT("wxScrollEvent"), wxT("Process wxEVT_SCROLL_PAGEUP page up events."));
+                  _("Process wxEVT_SCROLL_LINEDOWN line down events."));
+    RegisterEvent(wxT("wxEVT_SCROLL_PAGEUP"), wxT("wxScrollEvent"), _("Process wxEVT_SCROLL_PAGEUP page up events."));
     RegisterEvent(wxT("wxEVT_SCROLL_PAGEDOWN"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_PAGEDOWN page down events"));
+                  _("Process wxEVT_SCROLL_PAGEDOWN page down events"));
     RegisterEvent(wxT("wxEVT_SCROLL_THUMBTRACK"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_THUMBTRACK thumbtrack events (frequent events sent as the user drags the "
+                  _("Process wxEVT_SCROLL_THUMBTRACK thumbtrack events (frequent events sent as the user drags the "
                       "thumbtrack)."));
     RegisterEvent(wxT("wxEVT_SCROLL_THUMBRELEASE"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_THUMBRELEASE thumb release events."));
+                  _("Process wxEVT_SCROLL_THUMBRELEASE thumb release events."));
     RegisterEvent(wxT("wxEVT_SCROLL_CHANGED"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_CHANGED end of scrolling events (MSW only)."));
+                  _("Process wxEVT_SCROLL_CHANGED end of scrolling events (MSW only)."));
 
     SetPropertyString(_("Common Settings"), "wxScrollBar");
     AddProperty(new StringProperty(PROP_VALUE, wxT("0"), _("The position of the scrollbar in scroll units.")));

--- a/wxcrafter/scrolled_window_wrapper.cpp
+++ b/wxcrafter/scrolled_window_wrapper.cpp
@@ -15,7 +15,7 @@ ScrolledWindowWrapper::ScrolledWindowWrapper()
     AddProperty(
         new StringProperty(PROP_SCROLL_RATE_X, wxT("5"), _("Pixels per scroll unit in the horizontal direction")));
     AddProperty(
-        new StringProperty(PROP_SCROLL_RATE_Y, wxT("5"), _("Pixels per scroll unit in the vertical direction.")));
+        new StringProperty(PROP_SCROLL_RATE_Y, wxT("5"), _("Pixels per scroll unit in the vertical direction")));
 
     RegisterEvent("wxEVT_SCROLLWIN_TOP", "wxScrollWinEvent",
                   _("Since wxWidgets 2.9.X\nProcess wxEVT_SCROLLWIN_TOP scroll-to-top events"));

--- a/wxcrafter/slider_wrapper.cpp
+++ b/wxcrafter/slider_wrapper.cpp
@@ -7,9 +7,9 @@ SliderWrapper::SliderWrapper()
     : wxcWidget(ID_WXSLIDER)
 {
     SetPropertyString(_("Common Settings"), "wxSlider");
-    AddProperty(new StringProperty(PROP_VALUE, wxT("50"), wxT("Value")));
-    AddProperty(new StringProperty(PROP_MINVALUE, wxT("0"), wxT("Minimum slider value")));
-    AddProperty(new StringProperty(PROP_MAXVALUE, wxT("100"), wxT("Maximum slider value")));
+    AddProperty(new StringProperty(PROP_VALUE, wxT("50"), _("Value")));
+    AddProperty(new StringProperty(PROP_MINVALUE, wxT("0"), _("Minimum slider value")));
+    AddProperty(new StringProperty(PROP_MAXVALUE, wxT("100"), _("Maximum slider value")));
 
     PREPEND_STYLE(wxSL_HORIZONTAL, true);
     PREPEND_STYLE(wxSL_VERTICAL, false);
@@ -23,22 +23,22 @@ SliderWrapper::SliderWrapper()
     PREPEND_STYLE(wxSL_INVERSE, false);
 
     RegisterEvent(wxT("wxEVT_SCROLL_TOP"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_TOP scroll-to-top events (minimum position)"));
+                  _("Process wxEVT_SCROLL_TOP scroll-to-top events (minimum position)"));
     RegisterEvent(wxT("wxEVT_SCROLL_BOTTOM"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_BOTTOM scroll-to-bottom events (maximum position)."));
-    RegisterEvent(wxT("wxEVT_SCROLL_LINEUP"), wxT("wxScrollEvent"), wxT("Process wxEVT_SCROLL_LINEUP line up events."));
+                  _("Process wxEVT_SCROLL_BOTTOM scroll-to-bottom events (maximum position)."));
+    RegisterEvent(wxT("wxEVT_SCROLL_LINEUP"), wxT("wxScrollEvent"), _("Process wxEVT_SCROLL_LINEUP line up events."));
     RegisterEvent(wxT("wxEVT_SCROLL_LINEDOWN"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_LINEDOWN line down events."));
-    RegisterEvent(wxT("wxEVT_SCROLL_PAGEUP"), wxT("wxScrollEvent"), wxT("Process wxEVT_SCROLL_PAGEUP page up events."));
+                  _("Process wxEVT_SCROLL_LINEDOWN line down events."));
+    RegisterEvent(wxT("wxEVT_SCROLL_PAGEUP"), wxT("wxScrollEvent"), _("Process wxEVT_SCROLL_PAGEUP page up events."));
     RegisterEvent(wxT("wxEVT_SCROLL_PAGEDOWN"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_PAGEDOWN page down events"));
+                  _("Process wxEVT_SCROLL_PAGEDOWN page down events"));
     RegisterEvent(wxT("wxEVT_SCROLL_THUMBTRACK"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_THUMBTRACK thumbtrack events (frequent events sent as the user drags the "
+                  _("Process wxEVT_SCROLL_THUMBTRACK thumbtrack events (frequent events sent as the user drags the "
                       "thumbtrack)."));
     RegisterEvent(wxT("wxEVT_SCROLL_THUMBRELEASE"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_THUMBRELEASE thumb release events."));
+                  _("Process wxEVT_SCROLL_THUMBRELEASE thumb release events."));
     RegisterEvent(wxT("wxEVT_SCROLL_CHANGED"), wxT("wxScrollEvent"),
-                  wxT("Process wxEVT_SCROLL_CHANGED end of scrolling events (MSW only)."));
+                  _("Process wxEVT_SCROLL_CHANGED end of scrolling events (MSW only)."));
 
     m_namePattern = wxT("m_slider");
     SetName(GenerateName());

--- a/wxcrafter/spin_ctrl_wrapper.cpp
+++ b/wxcrafter/spin_ctrl_wrapper.cpp
@@ -15,7 +15,7 @@ SpinCtrlWrapper::SpinCtrlWrapper()
     RegisterEvent(wxT("wxEVT_SPINCTRL"), wxT("wxSpinEvent"),
                   _("Generated whenever the numeric value of the spinctrl is updated"));
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_UPDATED"),
-                         wxT("Process a wxEVT_COMMAND_TEXT_UPDATED event, when the combobox text changes."));
+                         _("Process a wxEVT_COMMAND_TEXT_UPDATED event, when the combobox text changes."));
 
     SetPropertyString(_("Common Settings"), "wxSpinCtrl");
     AddProperty(new StringProperty(PROP_VALUE, wxT("0"), _("The initial value")));

--- a/wxcrafter/splitter_window_wrapper.cpp
+++ b/wxcrafter/splitter_window_wrapper.cpp
@@ -22,7 +22,7 @@ SplitterWindowWrapper::SplitterWindowWrapper()
         << _("Gravity tells wxSplitterWindow how much will left/top window grow while resizing.\n")
         << _("Example values:\n") << _("0.0 - only the bottom/right window is automatically resized\n")
         << _("0.5 - both windows grow by equal size\n") << _("1.0 - only left/top window grows\n")
-        << _("Gravity should be a real value between 0.0 and 1.0)");
+        << _("(Gravity should be a real value between 0.0 and 1.0)");
 
     AddProperty(new StringProperty(PROP_SASH_GRAVITY, wxT("0.5"), tip));
     AddProperty(new StringProperty(PROP_MIN_PANE_SIZE, wxT("10"), _("Sets the minimum pane size")));

--- a/wxcrafter/static_bitmap_wrapper.cpp
+++ b/wxcrafter/static_bitmap_wrapper.cpp
@@ -10,7 +10,7 @@ StaticBitmapWrapper::StaticBitmapWrapper()
     : wxcWidget(ID_WXSTATICBITMAP)
 {
     SetPropertyString(_("Common Settings"), "wxStaticBitmap");
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), wxT("Select the bitmap file")));
+    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file")));
     m_namePattern = wxT("m_staticBitmap");
     SetName(GenerateName());
 }

--- a/wxcrafter/static_box_sizer_wrapper.cpp
+++ b/wxcrafter/static_box_sizer_wrapper.cpp
@@ -15,7 +15,7 @@ StaticBoxSizerWrapper::StaticBoxSizerWrapper()
     arr.Add(wxT("Horizontal"));
 
     SetPropertyString(_("Common Settings"), "wxStaticBoxSizer");
-    AddProperty(new ChoiceProperty(PROP_ORIENTATION, arr, 0, wxT("Sizer orientation")));
+    AddProperty(new ChoiceProperty(PROP_ORIENTATION, arr, 0, _("Sizer orientation")));
     AddProperty(new StringProperty(PROP_LABEL, _("My Label"), _("Label")));
 
     m_namePattern = wxT("staticBoxSizer");

--- a/wxcrafter/static_text_wrapper.cpp
+++ b/wxcrafter/static_text_wrapper.cpp
@@ -17,7 +17,7 @@ StaticTextWrapper::StaticTextWrapper()
     m_properties.Item(PROP_LABEL)->SetValue(_("Static Text Label"));
 
     AddProperty(
-        new StringProperty(PROP_WRAP, wxT("-1"), wxT("Wrap the text after N pixels. If set to -1, don't wrap")));
+        new StringProperty(PROP_WRAP, wxT("-1"), _("Wrap the text after N pixels. If set to -1, don't wrap")));
 
     m_namePattern = wxT("m_staticText");
     SetName(GenerateName());

--- a/wxcrafter/std_button_wrapper.cpp
+++ b/wxcrafter/std_button_wrapper.cpp
@@ -22,7 +22,7 @@ StdButtonWrapper::StdButtonWrapper()
     ids.Add("wxID_CONTEXT_HELP");
 
     RegisterEvent(wxT("wxEVT_COMMAND_BUTTON_CLICKED"), wxT("wxCommandEvent"),
-                  wxT("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),
+                  _("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),
                   wxT("wxCommandEventHandler"));
 
     AddProperty(new CategoryProperty(_("Standard wxButton")));

--- a/wxcrafter/styled_text_ctrl_wrapper.cpp
+++ b/wxcrafter/styled_text_ctrl_wrapper.cpp
@@ -205,7 +205,7 @@ StyledTextCtrlWrapper::StyledTextCtrlWrapper()
     int sel = lexersArr.Index("wxSTC_LEX_NULL");
     AddProperty(
         new ChoiceProperty(PROP_STC_LEXER, lexersArr, sel,
-                           _("Set the wxStyledTextCtrl lexer.\nThe lexer affects the synatx highlight of control")));
+                           _("Set the wxStyledTextCtrl lexer.\nThe lexer affects the syntax highlight of control")));
     AddProperty(new FontProperty(PROP_FONT, "", _("Set the basic styles font")));
 
     AddProperty(new CategoryProperty(_("Keywords")));

--- a/wxcrafter/text_ctrl_wrapper.cpp
+++ b/wxcrafter/text_ctrl_wrapper.cpp
@@ -26,23 +26,23 @@ TextCtrlWrapper::TextCtrlWrapper()
     PREPEND_STYLE(wxTE_WORDWRAP, false);
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_UPDATED"),
-                         wxT("Respond to a wxEVT_COMMAND_TEXT_UPDATED event, generated when the text changes.\nNotice "
-                             "that this event will be sent when the text controls contents changes\n - whether this is "
-                             "due to user input or comes from the program itself\n(for example, if SetValue() is "
-                             "called); see ChangeValue() for a function which does not send this event."));
+                         _("Respond to a wxEVT_COMMAND_TEXT_UPDATED event, generated when the text changes.\nNotice "
+                           "that this event will be sent when the text controls contents changes\n - whether this is "
+                           "due to user input or comes from the program itself\n(for example, if SetValue() is "
+                           "called); see ChangeValue() for a function which does not send this event."));
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_ENTER"),
-                         wxT("Respond to a wxEVT_COMMAND_TEXT_ENTER event, generated when enter is pressed in a text "
-                             "control\n(which must have wxTE_PROCESS_ENTER style for this event to be generated)."));
+                         _("Respond to a wxEVT_COMMAND_TEXT_ENTER event, generated when enter is pressed in a text "
+                           "control\n(which must have wxTE_PROCESS_ENTER style for this event to be generated)."));
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_MAXLEN"),
-                         wxT("User tried to enter more text into the control than the limit set by SetMaxLength."));
+                         _("User tried to enter more text into the control than the limit set by SetMaxLength."));
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_URL"),
-                         wxT("A mouse event occurred over an URL in the text control (wxMSW and wxGTK2 only)"));
+                         _("A mouse event occurred over an URL in the text control (wxMSW and wxGTK2 only)"));
 
     SetPropertyString(_("Common Settings"), "wxTextCtrl");
-    AddProperty(new StringProperty(PROP_VALUE, wxT(""), wxT("Default text control value")));
+    AddProperty(new StringProperty(PROP_VALUE, wxT(""), _("Default text control value")));
     AddProperty(new StringProperty(PROP_HINT, "", _("Sets a hint shown in an empty unfocused text control")));
     AddProperty(new StringProperty(PROP_MAXLENGTH, wxT("0"),
-                                   wxT("The maximum length of user entered text. Only for single-line wxTextCtrls.")));
+                                   _("The maximum length of user entered text. Only for single-line wxTextCtrls.")));
     AddProperty(new BoolProperty(
         PROP_AUTO_COMPLETE_DIRS, false,
         _("Enable auto-completion of the text using the file system directories. Notice that currently this function "

--- a/wxcrafter/timer_wrapper.cpp
+++ b/wxcrafter/timer_wrapper.cpp
@@ -15,7 +15,7 @@ TimerWrapper::TimerWrapper()
 
     SetPropertyString(_("Common Settings"), "wxTimer");
     AddProperty(new CategoryProperty(_("wxTimer")));
-    AddProperty(new StringProperty(PROP_NAME, _(""), _("Control name")));
+    AddProperty(new StringProperty(PROP_NAME, "", _("Control name")));
     AddProperty(new IntProperty(PROP_INTERVAL, 1000, _("Sets the current interval for the timer (in milliseconds)")));
     AddProperty(new BoolProperty(PROP_START_TIMER, true, _("Start the timer")));
     AddProperty(

--- a/wxcrafter/toggle_button_wrapper.cpp
+++ b/wxcrafter/toggle_button_wrapper.cpp
@@ -10,8 +10,8 @@ ToggleButtonWrapper::ToggleButtonWrapper()
     : wxcWidget(ID_WXTOGGLEBUTTON)
 {
     SetPropertyString(_("Common Settings"), "wxToggleButton");
-    AddProperty(new StringProperty(PROP_LABEL, wxT("My Button"), wxT("The button label")));
-    AddProperty(new BoolProperty(PROP_CHECKED, wxT("Initial state"), wxT("The button initial state")));
+    AddProperty(new StringProperty(PROP_LABEL, _("My Button"), _("The button label")));
+    AddProperty(new BoolProperty(PROP_CHECKED, wxT("Initial state"), _("The button initial state")));
 
     PREPEND_STYLE(wxBU_BOTTOM, false);
     PREPEND_STYLE(wxBU_EXACTFIT, false);
@@ -19,7 +19,7 @@ ToggleButtonWrapper::ToggleButtonWrapper()
     PREPEND_STYLE(wxBU_RIGHT, false);
     PREPEND_STYLE(wxBU_TOP, false);
 
-    RegisterEventCommand(wxT("wxEVT_COMMAND_TOGGLEBUTTON_CLICKED"), wxT("Handles a toggle button click event."));
+    RegisterEventCommand(wxT("wxEVT_COMMAND_TOGGLEBUTTON_CLICKED"), _("Handles a toggle button click event."));
 
     m_namePattern = wxT("m_toggleButton");
     SetName(GenerateName());

--- a/wxcrafter/tool_bar_item_wrapper.cpp
+++ b/wxcrafter/tool_bar_item_wrapper.cpp
@@ -373,7 +373,7 @@ ToolBarItemSeparatorWrapper::ToolBarItemSeparatorWrapper()
     wxArrayString kinds;
     kinds.Add(ITEM_SEPARATOR);
 
-    AddCategory("ToolBar Item Separator");
+    AddCategory(_("ToolBar Item Separator"));
     AddProperty(new StringProperty(PROP_NAME, "", "Name"));
     AddProperty(new ChoiceProperty(PROP_KIND, kinds, 0, _("The tool kind")));
 
@@ -401,7 +401,7 @@ ToolBarItemSpaceWrapper::ToolBarItemSpaceWrapper()
     wxArrayString kinds;
     kinds.Add(ITEM_SPACE);
 
-    AddCategory("ToolBar Item Space");
+    AddCategory(_("ToolBar Item Space"));
     AddProperty(new StringProperty(PROP_NAME, "", "Name"));
     AddProperty(new ChoiceProperty(PROP_KIND, kinds, 0, _("The tool kind")));
 
@@ -424,7 +424,7 @@ AuiToolBarItemNonStretchSpaceWrapper::AuiToolBarItemNonStretchSpaceWrapper()
     m_properties.DeleteValues();
     m_sizerFlags.Clear();
 
-    AddCategory("AuiToolBar Item Space");
+    AddCategory(_("AuiToolBar Item Space"));
     AddProperty(new StringProperty(PROP_NAME, "", "Name"));
     AddProperty(new StringProperty(PROP_WIDTH, "0", _("The width of the space in pixels")));
 
@@ -453,7 +453,7 @@ AuiToolBarItemSpaceWrapper::AuiToolBarItemSpaceWrapper()
     m_properties.DeleteValues();
     m_sizerFlags.Clear();
 
-    AddCategory("ToolBar Item Space");
+    AddCategory(_("ToolBar Item Space"));
     AddProperty(new StringProperty(PROP_NAME, "", "Name"));
     AddProperty(new StringProperty("Proportion:", "1", _("How stretchable the space is. The normal value is 1.")));
 
@@ -483,7 +483,7 @@ AuiToolBarLabelWrapper::AuiToolBarLabelWrapper(int type)
     m_properties.DeleteValues();
 
     wxCrafter::ResourceLoader bmps;
-    AddProperty(new CategoryProperty("wxAuiToolBar Label"));
+    AddProperty(new CategoryProperty(_("wxAuiToolBar Label")));
     AddProperty(new WinIdProperty());
     AddProperty(new StringProperty(PROP_NAME, "", _("C++ variable name")));
     AddProperty(new StringProperty(PROP_LABEL, _("My toolbar label"), _("The label's text")));

--- a/wxcrafter/top_level_win_wrapper.cpp
+++ b/wxcrafter/top_level_win_wrapper.cpp
@@ -27,16 +27,16 @@ TopLevelWinWrapper::TopLevelWinWrapper(int type)
     if(type == ID_WXFRAME || type == ID_WXDIALOG) {
         // a real top level windows
         // add support for wxTopLevelWindow events
-        RegisterEvent(wxT("wxEVT_MAXIMIZE"), wxT("wxMaximizeEvent"), wxT("Process a wxEVT_MAXIMIZE event"));
+        RegisterEvent(wxT("wxEVT_MAXIMIZE"), wxT("wxMaximizeEvent"), _("Process a wxEVT_MAXIMIZE event"));
         RegisterEvent(wxT("wxEVT_MOVE"), wxT("wxMoveEvent"),
-                      wxT("Process a wxEVT_MOVE event, which is generated when a window is moved"));
+                      _("Process a wxEVT_MOVE event, which is generated when a window is moved"));
         RegisterEvent(wxT("wxEVT_MOVE_START"), wxT("wxMoveEvent"),
-                      wxT("Process a wxEVT_MOVE_START event, which is generated when the "
+                      _("Process a wxEVT_MOVE_START event, which is generated when the "
                           "user starts to move or size a window. Windows only"));
         RegisterEvent(wxT("wxEVT_MOVE_END"), wxT("wxMoveEvent"),
-                      wxT("Process a wxEVT_MOVE_END event, which is generated when "
+                      _("Process a wxEVT_MOVE_END event, which is generated when "
                           "the user stops moving or sizing a window. Windows only"));
-        RegisterEvent(wxT("wxEVT_SHOW"), wxT("wxShowEvent"), wxT("Process a wxEVT_SHOW event"));
+        RegisterEvent(wxT("wxEVT_SHOW"), wxT("wxShowEvent"), _("Process a wxEVT_SHOW event"));
     }
 
     // Default size for top level windows

--- a/wxcrafter/tree_ctrl_wrapper.cpp
+++ b/wxcrafter/tree_ctrl_wrapper.cpp
@@ -22,42 +22,42 @@ TreeCtrlWrapper::TreeCtrlWrapper()
     PREPEND_STYLE(wxTR_DEFAULT_STYLE, true);
 
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_BEGIN_DRAG"), wxT("wxTreeEvent"),
-                  wxT("The user has started dragging an item with the left mouse button.\nThe event handler must call "
-                      "wxTreeEvent::Allow() for the drag operation to continue."));
+                  _("The user has started dragging an item with the left mouse button.\nThe event handler must call "
+                    "wxTreeEvent::Allow() for the drag operation to continue."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_BEGIN_RDRAG"), wxT("wxTreeEvent"),
-                  wxT("The user has started dragging an item with the right mouse button.\nThe event handler must call "
-                      "wxTreeEvent::Allow() for the drag operation to continue."));
+                  _("The user has started dragging an item with the right mouse button.\nThe event handler must call "
+                    "wxTreeEvent::Allow() for the drag operation to continue."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_END_DRAG"), wxT("wxTreeEvent"),
-                  wxT("The user has released the mouse after dragging an item."));
+                  _("The user has released the mouse after dragging an item."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_BEGIN_LABEL_EDIT"), wxT("wxTreeEvent"),
-                  wxT("Begin editing a label. This can be prevented by calling Veto()."));
+                  _("Begin editing a label. This can be prevented by calling Veto()."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_END_LABEL_EDIT"), wxT("wxTreeEvent"),
-                  wxT("The user has finished editing a label. This can be prevented by calling Veto()."));
-    RegisterEvent(wxT("wxEVT_COMMAND_TREE_DELETE_ITEM"), wxT("wxTreeEvent"), wxT("A tree item has been deleted."));
-    RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_EXPANDED"), wxT("wxTreeEvent"), wxT("The item has been expanded."));
+                  _("The user has finished editing a label. This can be prevented by calling Veto()."));
+    RegisterEvent(wxT("wxEVT_COMMAND_TREE_DELETE_ITEM"), wxT("wxTreeEvent"), _("A tree item has been deleted."));
+    RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_EXPANDED"), wxT("wxTreeEvent"), _("The item has been expanded."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_EXPANDING"), wxT("wxTreeEvent"),
-                  wxT("The item is being expanded. This can be prevented by calling Veto()."));
-    RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_COLLAPSED"), wxT("wxTreeEvent"), wxT("The item has been collapsed."));
+                  _("The item is being expanded. This can be prevented by calling Veto()."));
+    RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_COLLAPSED"), wxT("wxTreeEvent"), _("The item has been collapsed."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_COLLAPSING"), wxT("wxTreeEvent"),
-                  wxT("The item is being collapsed. This can be prevented by calling Veto()."));
-    RegisterEvent(wxT("wxEVT_COMMAND_TREE_SEL_CHANGED"), wxT("wxTreeEvent"), wxT("Selection has changed."));
+                  _("The item is being collapsed. This can be prevented by calling Veto()."));
+    RegisterEvent(wxT("wxEVT_COMMAND_TREE_SEL_CHANGED"), wxT("wxTreeEvent"), _("Selection has changed."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_SEL_CHANGING"), wxT("wxTreeEvent"),
-                  wxT("Selection is changing. This can be prevented by calling Veto()."));
-    RegisterEvent(wxT("wxEVT_COMMAND_TREE_KEY_DOWN"), wxT("wxTreeEvent"), wxT("A key has been pressed."));
+                  _("Selection is changing. This can be prevented by calling Veto()."));
+    RegisterEvent(wxT("wxEVT_COMMAND_TREE_KEY_DOWN"), wxT("wxTreeEvent"), _("A key has been pressed."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_ACTIVATED"), wxT("wxTreeEvent"),
-                  wxT("An item has been activated (e.g. double clicked)."));
+                  _("An item has been activated (e.g. double clicked)."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_RIGHT_CLICK"), wxT("wxTreeEvent"),
-                  wxT("The user has clicked the item with the right mouse button."));
+                  _("The user has clicked the item with the right mouse button."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_MIDDLE_CLICK"), wxT("wxTreeEvent"),
-                  wxT("The user has clicked the item with the middle mouse button."));
+                  _("The user has clicked the item with the middle mouse button."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_STATE_IMAGE_CLICK"), wxT("wxTreeEvent"),
-                  wxT("The state image has been clicked. Windows only."));
+                  _("The state image has been clicked. Windows only."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_GETTOOLTIP"), wxT("wxTreeEvent"),
-                  wxT("The opportunity to set the item tooltip is being given to the application\n (call "
-                      "wxTreeEvent::SetToolTip). Windows only."));
+                  _("The opportunity to set the item tooltip is being given to the application\n (call "
+                    "wxTreeEvent::SetToolTip). Windows only."));
     RegisterEvent(wxT("wxEVT_COMMAND_TREE_ITEM_MENU"), wxT("wxTreeEvent"),
-                  wxT("The context menu for the selected item has been requested,\neither by a right click or by using "
-                      "the menu key."));
+                  _("The context menu for the selected item has been requested,\neither by a right click or by using "
+                    "the menu key."));
 
     m_namePattern = wxT("m_treeCtrl");
     SetName(GenerateName());

--- a/wxcrafter/tree_list_ctrl_column_wrapper.cpp
+++ b/wxcrafter/tree_list_ctrl_column_wrapper.cpp
@@ -20,7 +20,7 @@ TreeListCtrlColumnWrapper::TreeListCtrlColumnWrapper()
 
     // FIXME: add alignment + column flags here
     AddProperty(new CategoryProperty(_("wxTreeListCtrl Column")));
-    AddProperty(new StringProperty(PROP_NAME, wxT("My Column"), wxT("Column caption")));
+    AddProperty(new StringProperty(PROP_NAME, _("My Column"), _("Column caption")));
     AddProperty(new ChoiceProperty(PROP_DV_LISTCTRL_COL_ALIGN, alignment, 0,
                                    _("Alignment of both the column header and its items")));
     AddProperty(new StringProperty(

--- a/wxcrafter/tree_list_ctrl_wrapper.cpp
+++ b/wxcrafter/tree_list_ctrl_wrapper.cpp
@@ -15,32 +15,32 @@ TreeListCtrlWrapper::TreeListCtrlWrapper()
     PREPEND_STYLE(wxTL_DEFAULT_STYLE, true);
 
     RegisterEvent("wxEVT_TREELIST_SELECTION_CHANGED", "wxTreeListEvent",
-                  "Process wxEVT_TREELIST_SELECTION_CHANGED event and notifies about the selection change in the "
-                  "control. In the single selection case the item indicated by the event has been selected and "
-                  "previously selected item, if any, was deselected. In multiple selection case, the selection of this "
-                  "item has just changed (it may have been either selected or deselected) but notice that the "
-                  "selection of other items could have changed as well, use wxTreeListCtrl::GetSelections() to "
-                  "retrieve the new selection if necessary.");
+                  _("Process wxEVT_TREELIST_SELECTION_CHANGED event and notifies about the selection change in the "
+                    "control. In the single selection case the item indicated by the event has been selected and "
+                    "previously selected item, if any, was deselected. In multiple selection case, the selection of this "
+                    "item has just changed (it may have been either selected or deselected) but notice that the "
+                    "selection of other items could have changed as well, use wxTreeListCtrl::GetSelections() to "
+                    "retrieve the new selection if necessary."));
     RegisterEvent("wxEVT_TREELIST_ITEM_EXPANDING", "wxTreeListEvent",
-                  "Process wxEVT_TREELIST_ITEM_EXPANDING event notifying about the given branch being expanded. This "
-                  "event is sent before the expansion occurs and can be vetoed to prevent it from happening.");
+                  _("Process wxEVT_TREELIST_ITEM_EXPANDING event notifying about the given branch being expanded. This "
+                    "event is sent before the expansion occurs and can be vetoed to prevent it from happening."));
     RegisterEvent("wxEVT_TREELIST_ITEM_EXPANDED", "wxTreeListEvent",
-                  "Process wxEVT_TREELIST_ITEM_EXPANDED event notifying about the expansion of the given branch. This "
-                  "event is sent after the expansion occurs and can't be vetoed.");
+                  _("Process wxEVT_TREELIST_ITEM_EXPANDED event notifying about the expansion of the given branch. This "
+                    "event is sent after the expansion occurs and can't be vetoed."));
     RegisterEvent("wxEVT_TREELIST_ITEM_CHECKED", "wxTreeListEvent",
-                  "Process wxEVT_TREELIST_ITEM_CHECKED event notifying about the user checking or unchecking the item. "
-                  "You can use wxTreeListCtrl::GetCheckedState() to retrieve the new item state and "
-                  "wxTreeListEvent::GetOldCheckedState() to get the previous one.");
+                  _("Process wxEVT_TREELIST_ITEM_CHECKED event notifying about the user checking or unchecking the item. "
+                    "You can use wxTreeListCtrl::GetCheckedState() to retrieve the new item state and "
+                    "wxTreeListEvent::GetOldCheckedState() to get the previous one."));
     RegisterEvent("wxEVT_TREELIST_ITEM_ACTIVATED", "wxTreeListEvent",
-                  "Process wxEVT_TREELIST_ITEM_ACTIVATED event notifying about the user double clicking the item or "
-                  "activating it from keyboard.");
+                  _("Process wxEVT_TREELIST_ITEM_ACTIVATED event notifying about the user double clicking the item or "
+                    "activating it from keyboard."));
     RegisterEvent("wxEVT_TREELIST_ITEM_CONTEXT_MENU", "wxTreeListEvent",
-                  "Process wxEVT_TREELIST_ITEM_CONTEXT_MENU event indicating that the popup menu for the given item "
-                  "should be displayed.");
+                  _("Process wxEVT_TREELIST_ITEM_CONTEXT_MENU event indicating that the popup menu for the given item "
+                    "should be displayed."));
     RegisterEvent("wxEVT_TREELIST_COLUMN_SORTED", "wxTreeListEvent",
-                  "Process wxEVT_TREELIST_COLUMN_SORTED event indicating that the control contents has just been "
-                  "resorted using the specified column. The event doesn't carry the sort direction, use "
-                  "GetSortColumn() method if you need to know it.");
+                  _("Process wxEVT_TREELIST_COLUMN_SORTED event indicating that the control contents has just been "
+                    "resorted using the specified column. The event doesn't carry the sort direction, use "
+                    "GetSortColumn() method if you need to know it."));
 
     m_namePattern = "m_treeListCtrl";
     SetName(GenerateName());

--- a/wxcrafter/web_view_wrapper.cpp
+++ b/wxcrafter/web_view_wrapper.cpp
@@ -7,33 +7,33 @@ WebViewWrapper::WebViewWrapper()
     : wxcWidget(ID_WXWEBVIEW)
 {
     RegisterEvent("wxEVT_COMMAND_WEBVIEW_NAVIGATING", "wxWebViewEvent",
-                  "Process a wxEVT_COMMAND_WEBVIEW_NAVIGATING event, generated before trying to get a resource. This "
-                  "event may be vetoed to prevent navigating to this resource. Note that if the displayed HTML "
-                  "document has several frames, one such event will be generated per frame");
+                  _("Process a wxEVT_COMMAND_WEBVIEW_NAVIGATING event, generated before trying to get a resource. This "
+                    "event may be vetoed to prevent navigating to this resource. Note that if the displayed HTML "
+                    "document has several frames, one such event will be generated per frame"));
     RegisterEvent("wxEVT_COMMAND_WEBVIEW_NAVIGATED", "wxWebViewEvent",
-                  "Process a wxEVT_COMMAND_WEBVIEW_NAVIGATED event generated after it was confirmed that a resource "
-                  "would be requested. This event may not be vetoed. Note that if the displayed HTML document has "
-                  "several frames, one such event will be generated per frame.");
+                  _("Process a wxEVT_COMMAND_WEBVIEW_NAVIGATED event generated after it was confirmed that a resource "
+                    "would be requested. This event may not be vetoed. Note that if the displayed HTML document has "
+                    "several frames, one such event will be generated per frame."));
     RegisterEvent("wxEVT_COMMAND_WEBVIEW_LOADED", "wxWebViewEvent",
-                  "Process a wxEVT_COMMAND_WEBVIEW_LOADED event generated when the document is fully loaded and "
-                  "displayed. Note that if the displayed HTML document has several frames, one such event will be "
-                  "generated per frame.");
+                  _("Process a wxEVT_COMMAND_WEBVIEW_LOADED event generated when the document is fully loaded and "
+                    "displayed. Note that if the displayed HTML document has several frames, one such event will be "
+                    "generated per frame."));
     RegisterEvent("wxEVT_COMMAND_WEBVIEW_ERROR", "wxWebViewEvent",
-                  "Process a wxEVT_COMMAND_WEBVIEW_ERROR event generated when a navigation error occurs. The integer "
-                  "associated with this event will be a wxWebNavigationError item. The string associated with this "
-                  "event may contain a backend-specific more precise error message/code");
+                  _("Process a wxEVT_COMMAND_WEBVIEW_ERROR event generated when a navigation error occurs. The integer "
+                    "associated with this event will be a wxWebNavigationError item. The string associated with this "
+                    "event may contain a backend-specific more precise error message/code"));
     RegisterEvent("wxEVT_COMMAND_WEBVIEW_NEWWINDOW", "wxWebViewEvent",
-                  "Process a wxEVT_COMMAND_WEBVIEW_NEWWINDOW event, generated when a new window is created. You must "
-                  "handle this event if you want anything to happen, for example to load the page in a new window or "
-                  "tab.");
+                  _("Process a wxEVT_COMMAND_WEBVIEW_NEWWINDOW event, generated when a new window is created. You must "
+                    "handle this event if you want anything to happen, for example to load the page in a new window or "
+                    "tab."));
     RegisterEvent("wxEVT_COMMAND_WEBVIEW_TITLE_CHANGED", "wxWebViewEvent",
-                  "Process a wxEVT_COMMAND_WEBVIEW_TITLE_CHANGED event, generated when the page title changes. Use "
-                  "GetString to get the title.");
+                  _("Process a wxEVT_COMMAND_WEBVIEW_TITLE_CHANGED event, generated when the page title changes. Use "
+                    "GetString to get the title."));
 
     SetPropertyString(_("Common Settings"), "wxWebView");
     AddProperty(new StringProperty(PROP_URL, _("about:blank"),
                                    _("URL to load by default in the web view.\nNote that the designer will display "
-                                     "about:blank.The preview and generated code will use the actual URL")));
+                                     "about:blank. The preview and generated code will use the actual URL")));
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);

--- a/wxcrafter/wizard_wrapper.cpp
+++ b/wxcrafter/wizard_wrapper.cpp
@@ -13,7 +13,7 @@ WizardWrapper::WizardWrapper()
     : TopLevelWinWrapper(ID_WXWIZARD)
 {
     SetPropertyString(_("Common Settings"), "wxWizard");
-    DoSetPropertyStringValue(PROP_TITLE, wxT("My Wizard"));
+    DoSetPropertyStringValue(PROP_TITLE, _("My Wizard"));
     AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""),
                                          _("The default bitmap used in the left side of the wizard.")));
 

--- a/wxcrafter/wxcTreeView.cpp
+++ b/wxcrafter/wxcTreeView.cpp
@@ -26,7 +26,7 @@ wxcTreeView::wxcTreeView(wxWindow* parent, wxCrafterPlugin* plugin)
 {
     m_treeControls->SetImageList(Allocator::Instance()->GetImageList());
     m_treeControls->SetSortFunction(nullptr);
-    m_treeControls->AddRoot(wxT("wxCrafter Project"), 0, 0);
+    m_treeControls->AddRoot(_("wxCrafter Project"), 0, 0);
     m_eventsPane = new EventsEditorPane(m_splitterPageEvents, NULL, plugin);
     m_splitterPageEvents->GetSizer()->Add(m_eventsPane, 1, wxEXPAND | wxALL, 2);
 

--- a/wxcrafter/wxcrafter_gui.cpp
+++ b/wxcrafter/wxcrafter_gui.cpp
@@ -1514,7 +1514,7 @@ NewFormWizardBaseClass::NewFormWizardBaseClass(wxWindow* parent, wxWindowID id, 
 
     flexGridSizer198->Add(m_textCtrlInheritedClassName, 0, wxALL | wxEXPAND, WXC_FROM_DIP(5));
 
-    m_staticText187 = new wxStaticText(m_wizardPageGeneratedCode, wxID_ANY, _("Sublcass file:"), wxDefaultPosition,
+    m_staticText187 = new wxStaticText(m_wizardPageGeneratedCode, wxID_ANY, _("Subclass file:"), wxDefaultPosition,
                                        wxDLG_UNIT(m_wizardPageGeneratedCode, wxSize(-1, -1)), 0);
 
     flexGridSizer198->Add(m_staticText187, 0, wxALL | wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, WXC_FROM_DIP(5));

--- a/wxcrafter/wxcrafter_gui.wxcp
+++ b/wxcrafter/wxcrafter_gui.wxcp
@@ -14410,7 +14410,7 @@
 												}, {
 													"type":	"multi-string",
 													"m_label":	"Label:",
-													"m_value":	"Sublcass file:"
+													"m_value":	"Subclass file:"
 												}, {
 													"type":	"string",
 													"m_label":	"Wrap:",

--- a/wxcrafter/wxguicraft_main_view.cpp
+++ b/wxcrafter/wxguicraft_main_view.cpp
@@ -415,7 +415,7 @@ void GUICraftMainPanel::Clear()
     m_styles.Clear(m_pgMgrStyles->GetGrid());
 
     m_treeControls->DeleteAllItems();
-    m_treeControls->AddRoot(wxT("wxCrafter Project"), 0, 0);
+    m_treeControls->AddRoot(_("wxCrafter Project"), 0, 0);
     wxcProjectMetadata::Get().Reset();
 
     // Notify all controls to perform cleanup
@@ -589,17 +589,17 @@ void GUICraftMainPanel::DoUpdateSizerFlags(wxcWidget* data)
 
     if(!data) {
         DoShowPropertiesPage(m_panelAuiPaneInfo, "wxAuiPaneInfo", false);
-        DoShowPropertiesPage(m_panelSizerFlags, "Sizer Flags", false);
+        DoShowPropertiesPage(m_panelSizerFlags, _("Sizer Flags"), false);
 
     } else {
         int cursel = m_notebook2->GetSelection();
         if(data->IsAuiPane()) {
             DoShowPropertiesPage(m_panelAuiPaneInfo, "wxAuiPaneInfo", true);
-            DoShowPropertiesPage(m_panelSizerFlags, "Sizer Flags", false);
+            DoShowPropertiesPage(m_panelSizerFlags, _("Sizer Flags"), false);
 
         } else {
             DoShowPropertiesPage(m_panelAuiPaneInfo, "wxAuiPaneInfo", false);
-            DoShowPropertiesPage(m_panelSizerFlags, "Sizer Flags", true);
+            DoShowPropertiesPage(m_panelSizerFlags, _("Sizer Flags"), true);
         }
 #ifndef __WXGTK__
         m_notebook2->SetSelection(cursel);
@@ -1153,7 +1153,7 @@ void GUICraftMainPanel::LoadProject(const wxFileName& fn, const wxString& fileCo
 #endif
     if(deleteAllItems) {
         m_treeControls->DeleteAllItems();
-        m_treeControls->AddRoot(wxT("wxCrafter Project"), 0, 0);
+        m_treeControls->AddRoot(_("wxCrafter Project"), 0, 0);
         project_file = wxcProjectMetadata::Get().GetProjectFile();
         wxcProjectMetadata::Get().FromJSON(
             json.toElement().namedObject(wxT("metadata"))); // Needed for Redo() to work correctly
@@ -1174,7 +1174,7 @@ void GUICraftMainPanel::LoadProject(const wxFileName& fn, const wxString& fileCo
     }
     NotifyPreviewChanged(wxEVT_WXGUI_PROJECT_LOADED);
 
-    wxString rootText = project_file.IsOk() ? project_file.GetFullPath() : wxT("wxCrafter Project");
+    wxString rootText = project_file.IsOk() ? project_file.GetFullPath() : _("wxCrafter Project");
 
     m_treeControls->SetItemText(m_treeControls->GetRootItem(), rootText);
     wxcWidget::SetObjCounter(wxcProjectMetadata::Get().GetObjCounter());
@@ -2584,7 +2584,7 @@ wxcWidget* GUICraftMainPanel::GetActiveTopLevelWin() const
 void GUICraftMainPanel::OnGenerateCodeMenu(wxAuiToolBarEvent& e)
 {
     if(e.IsDropDownClicked()) {
-        wxMenu menu(wxT("Code Generation"));
+        wxMenu menu(_("Code Generation"));
         wxMenuItem* item = menu.AppendCheckItem(XRCID("GenerateCPP"), _("Generate C++ code"));
         item->Check(wxcProjectMetadata::Get().GetGenerateCPPCode());
         item = menu.AppendCheckItem(XRCID("GenerateXRC"), _("Generate XRC"));

--- a/wxformbuilder/wxformbuilder.cpp
+++ b/wxformbuilder/wxformbuilder.cpp
@@ -101,7 +101,7 @@ void wxFormBuilder::CreatePluginMenu(wxMenu* pluginsMenu)
     item = new wxMenuItem(menu, XRCID("wxfb_settings"), _("Settings..."), _("Settings..."), wxITEM_NORMAL);
     menu->Append(item);
 
-    pluginsMenu->Append(wxID_ANY, wxT("wxFormBuilder"), menu);
+    pluginsMenu->Append(wxID_ANY, _("wxFormBuilder"), menu);
 
     m_topWin->Connect(XRCID("wxfb_settings"), wxEVT_COMMAND_MENU_SELECTED,
                       wxCommandEventHandler(wxFormBuilder::OnSettings), NULL, this);


### PR DESCRIPTION
This PR fixes the following:
- Typographical errors (e.g. Sublcass)
- Missing closed parentheses (e.g. "foo (bar")
- Missing translations (for frequently-seen texts only)
- Empty translations (i.e. _(""))
- Double calls for wxGetTranslation() function (e.g. passing a string that already wrapped by _())