### PR TITLE
Fix Output View multi-byte text handling

### DIFF
--- a/CodeLite/StringUtils.cpp
+++ b/CodeLite/StringUtils.cpp
@@ -3,11 +3,7 @@
 
 std::string StringUtils::ToStdString(const wxString& str)
 {
-    wxCharBuffer cb = str.ToAscii();
-    const char* data = cb.data();
-    if(!data) {
-        data = str.mb_str(wxConvUTF8).data();
-    }
+    const char* data = str.mb_str(wxConvUTF8).data();
     if(!data) {
         data = str.To8BitData();
     }


### PR DESCRIPTION
1. Don't perform ToAscii() conversion
This will destroy all multi-byte character occurrences, but it's normal to see those texts in this Output Pane.
(e.g. source code comments, localized system messages etc.)
For this reason I've simply omitted the conversion.

2. Fix UTF-8 character width detection in the styling function