### PR TITLE
wxCrafter: Fix BoolProperty arguments

### DIFF
--- a/wxcrafter/bitmaptogglebuttonwrapper.cpp
+++ b/wxcrafter/bitmaptogglebuttonwrapper.cpp
@@ -8,7 +8,7 @@ BitmapToggleButtonWrapper::BitmapToggleButtonWrapper()
 {
     SetPropertyString(_("Common Settings"), "wxBitmapToggleButton");
     AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", _("The bitmap")));
-    AddProperty(new BoolProperty(PROP_CHECKED, wxT("Initial state"), _("The button initial state")));
+    AddProperty(new BoolProperty(PROP_CHECKED, false, _("The button initial state")));
 
     PREPEND_STYLE(wxBU_BOTTOM, false);
     PREPEND_STYLE(wxBU_EXACTFIT, false);

--- a/wxcrafter/ribbon_page_wrapper.cpp
+++ b/wxcrafter/ribbon_page_wrapper.cpp
@@ -14,7 +14,7 @@ RibbonPageWrapper::RibbonPageWrapper()
     SetPropertyString(_("Common Settings"), "wxRibbonPage");
     AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), _("Page Icon")));
     AddProperty(new StringProperty(PROP_LABEL, "Page", _("Page Label")));
-    AddProperty(new BoolProperty(PROP_SELECTED, "Selected", _("Selected")));
+    AddProperty(new BoolProperty(PROP_SELECTED, false, _("Selected")));
     m_namePattern = "m_ribbonPage";
     SetName(GenerateName());
 }

--- a/wxcrafter/toggle_button_wrapper.cpp
+++ b/wxcrafter/toggle_button_wrapper.cpp
@@ -11,7 +11,7 @@ ToggleButtonWrapper::ToggleButtonWrapper()
 {
     SetPropertyString(_("Common Settings"), "wxToggleButton");
     AddProperty(new StringProperty(PROP_LABEL, _("My Button"), _("The button label")));
-    AddProperty(new BoolProperty(PROP_CHECKED, wxT("Initial state"), _("The button initial state")));
+    AddProperty(new BoolProperty(PROP_CHECKED, false, _("The button initial state")));
 
     PREPEND_STYLE(wxBU_BOTTOM, false);
     PREPEND_STYLE(wxBU_EXACTFIT, false);


### PR DESCRIPTION
The 2nd parameter takes a bool, not a string.