### PR TITLE
Make "Hidden Tabs" menu always accessible

### DIFF
--- a/LiteEditor/output_pane.cpp
+++ b/LiteEditor/output_pane.cpp
@@ -289,7 +289,7 @@ void OutputPane::OnOutputBookFileListMenu(clContextMenuEvent& event)
             continue;
         }
 
-        if(hiddenTabsMenu->GetMenuItemCount() == 0) {
+        if(menu->GetMenuItemCount() > 0 && hiddenTabsMenu->GetMenuItemCount() == 0) {
             // we are adding the first menu item
             menu->AppendSeparator();
         }

--- a/LiteEditor/workspace_pane.cpp
+++ b/LiteEditor/workspace_pane.cpp
@@ -481,7 +481,7 @@ void WorkspacePane::OnWorkspaceBookFileListMenu(clContextMenuEvent& event)
             continue;
         }
 
-        if(hiddenTabsMenu->GetMenuItemCount() == 0) {
+        if(menu->GetMenuItemCount() > 0 && hiddenTabsMenu->GetMenuItemCount() == 0) {
             // we are adding the first menu item
             menu->AppendSeparator();
         }

--- a/Plugin/GTKNotebook.cpp
+++ b/Plugin/GTKNotebook.cpp
@@ -674,20 +674,15 @@ void clGTKNotebook::GTKActionButtonMenuClicked(GtkToolItem* button)
     clTabInfo::Vec_t tabs;
     GetAllTabs(tabs);
 
-    // Do we have pages opened?
-    if(GetPageCount() == 0) {
-        return;
-    }
-
     const int curselection = GetSelection();
     wxMenu menu;
     const int firstTabPageID = 13457;
     int pageMenuID = firstTabPageID;
 
-    // Optionally make a sorted view of tabs.
-    std::vector<size_t> sortedIndexes;
+    // Do we have pages opened?
     if(GetPageCount()) {
-        sortedIndexes.resize(GetPageCount());
+        // Optionally make a sorted view of tabs.
+        std::vector<size_t> sortedIndexes(GetPageCount());
         {
             // std is C++11 at the moment, so no generalized capture.
             size_t index = 0;
@@ -723,6 +718,10 @@ void clGTKNotebook::GTKActionButtonMenuClicked(GtkToolItem* button)
     menuEvent.SetMenu(&menu);
     menuEvent.SetEventObject(this); // The clGTKNotebook
     GetEventHandler()->ProcessEvent(menuEvent);
+
+    if(menu.GetMenuItemCount() == 0) {
+        return;
+    }
 
     wxPoint pt(wxNOT_FOUND, wxNOT_FOUND);
     int width, height;


### PR DESCRIPTION
When no workspace pane tabs or output pane tabs are open (i.e. all closed), the dropdown menu will be disabled.
However, this menu is also needed to restore hidden tabs.
So if you once close all tabs, there will be no ways to restore those tabs from the user interface.

Related issue: #2658 (the tabs are gone because the `VisibleXXXTabs` in codelite.conf holds localized tab name; this PR provides a way to restore them manually)