### PR TITLE
SnipWiz fixes

### DIFF
--- a/SnipWiz/snipwiz.cpp
+++ b/SnipWiz/snipwiz.cpp
@@ -113,18 +113,15 @@ SnipWiz::SnipWiz(IManager* manager)
     m_shortName = plugName;
     m_topWin = m_mgr->GetTheApp();
 
-    // get plugin path
-    m_pluginPath = m_mgr->GetStartupDirectory();
-    m_pluginPath += wxFILE_SEP_PATH;
-    m_pluginPath += wxT("templates");
-    m_pluginPath += wxFILE_SEP_PATH;
-    if(!wxFileName::DirExists(m_pluginPath)) {
-        wxFileName::Mkdir(m_pluginPath);
-    }
+    // get config path
+    m_configPath = clStandardPaths::Get().GetUserDataDir();
+    m_configPath += wxFILE_SEP_PATH;
+    m_configPath += wxT("config");
+    m_configPath += wxFILE_SEP_PATH;
 
     m_StringDb.SetCompress(true);
 
-    m_StringDb.Load(m_pluginPath + defaultTmplFile);
+    m_StringDb.Load(m_configPath + defaultTmplFile);
 
     m_StringDb.GetAllSnippetKeys(m_snippets);
     if(!m_snippets.GetCount()) {
@@ -142,7 +139,7 @@ SnipWiz::SnipWiz(IManager* manager)
 SnipWiz::~SnipWiz()
 {
     if(m_modified)
-        m_StringDb.Save(m_pluginPath + defaultTmplFile);
+        m_StringDb.Save(m_configPath + defaultTmplFile);
 }
 //------------------------------------------------------------
 
@@ -470,7 +467,7 @@ void SnipWiz::OnClassWizard(wxCommandEvent& e)
     TemplateClassDlg dlg(m_mgr->GetTheApp()->GetTopWindow(), this, m_mgr);
 
     dlg.SetCurEol(GetEOLByOS());
-    dlg.SetPluginPath(m_pluginPath);
+    dlg.SetConfigPath(m_configPath);
     dlg.ShowModal();
     if(dlg.GetModified()) {
         m_modified = true;
@@ -500,7 +497,7 @@ void SnipWiz::OnFolderContextMenu(clContextMenuEvent& event)
             wxUnusedVar(e);
             TemplateClassDlg dlg(m_mgr->GetTheApp()->GetTopWindow(), this, m_mgr);
             dlg.SetCurEol(GetEOLByOS());
-            dlg.SetPluginPath(m_pluginPath);
+            dlg.SetConfigPath(m_configPath);
             dlg.SetProjectPath(path);
             dlg.ShowModal();
         },

--- a/SnipWiz/snipwiz.cpp
+++ b/SnipWiz/snipwiz.cpp
@@ -119,9 +119,20 @@ SnipWiz::SnipWiz(IManager* manager)
     m_configPath += wxT("config");
     m_configPath += wxFILE_SEP_PATH;
 
+    m_modified = false;
     m_StringDb.SetCompress(true);
 
-    m_StringDb.Load(m_configPath + defaultTmplFile);
+    if(!m_StringDb.Load(m_configPath + defaultTmplFile)) {
+        // For compatibility with CodeLite < 15.0.4:
+        // we don't use this directory for storing templates anymore.
+        wxString pluginPath = m_mgr->GetStartupDirectory();
+        pluginPath += wxFILE_SEP_PATH;
+        pluginPath += wxT("templates");
+        pluginPath += wxFILE_SEP_PATH;
+        if(m_StringDb.Load(pluginPath + defaultTmplFile)) {
+            m_modified = true;
+        }
+    }
 
     m_StringDb.GetAllSnippetKeys(m_snippets);
     if(!m_snippets.GetCount()) {
@@ -129,7 +140,6 @@ SnipWiz::SnipWiz(IManager* manager)
         m_StringDb.GetAllSnippetKeys(m_snippets);
     }
     m_snippets.Sort();
-    m_modified = false;
     m_clipboard.Empty();
     EventNotifier::Get()->Bind(wxEVT_CONTEXT_MENU_EDITOR, &SnipWiz::OnEditorContextMenu, this);
     EventNotifier::Get()->Bind(wxEVT_CONTEXT_MENU_FOLDER, &SnipWiz::OnFolderContextMenu, this);

--- a/SnipWiz/snipwiz.cpp
+++ b/SnipWiz/snipwiz.cpp
@@ -410,6 +410,7 @@ void SnipWiz::IntSnippets()
     m_StringDb.SetSnippetString(wxT("for($"), wxT("for( $ = 0; $  < @; $++ )"));
     m_StringDb.SetSnippetString(wxT("for(Ii"), wxT("for( int i = 0; i  < $; i++ )@"));
     m_StringDb.SetSnippetString(wxT("for(Ui"), wxT("for( unsigned int i = 0; i  < $; i++ )@"));
+    m_StringDb.SetSnippetString(wxT("R\"("), wxT("R\"$(@)$\""));
 }
 
 //------------------------------------------------------------

--- a/SnipWiz/snipwiz.h
+++ b/SnipWiz/snipwiz.h
@@ -99,7 +99,7 @@ protected:
     /// if stringDB is not found, init snippets with some defaults
     void IntSnippets();
 
-    wxString m_pluginPath;    // plugins path
+    wxString m_configPath;    // configs path
     wxArrayString m_snippets; // keys for StringDB
     bool m_modified;          // modified flag
     swStringDb m_StringDb;    // string database with snippets and templates

--- a/SnipWiz/templateclassdlg.cpp
+++ b/SnipWiz/templateclassdlg.cpp
@@ -61,7 +61,7 @@ void TemplateClassDlg::Initialize()
         cppLexer->Apply(m_textCtrlImpl, true);
     }
 
-    GetStringDb()->Load(m_pluginPath + defaultTmplFile);
+    GetStringDb()->Load(m_configPath + defaultTmplFile);
 
     wxArrayString templates;
     GetStringDb()->GetAllSets(templates);
@@ -221,7 +221,7 @@ void TemplateClassDlg::OnGenerateUI(wxUpdateUIEvent& event)
 void TemplateClassDlg::OnQuit(wxCommandEvent& event)
 {
     wxUnusedVar(event);
-    GetStringDb()->Save(m_pluginPath + defaultTmplFile);
+    GetStringDb()->Save(m_configPath + defaultTmplFile);
     EndModal(wxID_CANCEL);
 }
 
@@ -398,7 +398,7 @@ void TemplateClassDlg::OnStcImplFileContentChnaged(wxStyledTextEvent& event) { e
 
 void TemplateClassDlg::OnVirtualDirUI(wxUpdateUIEvent& event) { event.Enable(clCxxWorkspaceST::Get()->IsOpen()); }
 
-void TemplateClassDlg::SetPluginPath(const wxString& pluginPath) { this->m_pluginPath = pluginPath; }
+void TemplateClassDlg::SetConfigPath(const wxString& configPath) { this->m_configPath = configPath; }
 
 void TemplateClassDlg::SetProjectPath(const wxString& projectPath)
 {

--- a/SnipWiz/templateclassdlg.h
+++ b/SnipWiz/templateclassdlg.h
@@ -36,7 +36,7 @@ class TemplateClassDlg : public TemplateClassBaseDlg
 {
     SnipWiz* m_plugin;
     bool m_modified;
-    wxString m_pluginPath;
+    wxString m_configPath;
     int m_curEol;
     wxString m_virtualFolder; // name of current project
     wxString m_projectPath;   // path to current project
@@ -80,11 +80,11 @@ public:
     SnipWiz* GetPlugin() { return m_plugin; }
 
     void SetCurEol(const int& curEol) { this->m_curEol = curEol; }
-    void SetPluginPath(const wxString& pluginPath);
+    void SetConfigPath(const wxString& configPath);
     void SetProjectPath(const wxString& projectPath);
     void SetVirtualFolder(const wxString& virtualFolder) { this->m_virtualFolder = virtualFolder; }
     const int& GetCurEol() const { return m_curEol; }
-    const wxString& GetPluginPath() const { return m_pluginPath; }
+    const wxString& GetConfigPath() const { return m_configPath; }
     const wxString& GetProjectPath() const { return m_projectPath; }
     const wxString& GetVirtualFolder() const { return m_virtualFolder; }
 };


### PR DESCRIPTION
1. Add C++11 "Raw String Literal" as a predefined snippet for convenience

2. Change config file location for guaranteed write-access (especially on Windows)
On Windows: `%ProgramFiles%\CodeLite\templates\SnipWiz.tmpl` -> `%AppData%\Roaming\codelite\config\SnipWiz.tmpl`
On Linux: `~/.codelite/templates/SnipWiz.tmpl` -> `~/.codelite/config/SnipWiz.tmpl`
The relevant variables and functions are renamed to `configPath` for better clarification.