### PR TITLE
Project Settings: Improve dirty settings detection

### DIFF
--- a/LiteEditor/project_settings.wxcp
+++ b/LiteEditor/project_settings.wxcp
@@ -4441,7 +4441,14 @@
 															"m_label":	"Auto Complete Files:",
 															"m_value":	false
 														}],
-													"m_events":	[],
+													"m_events":	[{
+															"m_eventName":	"wxEVT_COMMAND_TEXT_UPDATED",
+															"m_eventClass":	"wxCommandEvent",
+															"m_eventHandler":	"wxCommandEventHandler",
+															"m_functionNameAndSignature":	"OnCmdEvtVModified(wxCommandEvent& event)",
+															"m_description":	"Respond to a wxEVT_COMMAND_TEXT_UPDATED event, generated when the text changes.\nNotice that this event will be sent when the text controls contents changes\n - whether this is due to user input or comes from the program itself\n(for example, if SetValue() is called); see ChangeValue() for a function which does not send this event.",
+															"m_noBody":	false
+														}],
 													"m_children":	[]
 												}, {
 													"m_type":	4400,
@@ -5358,7 +5365,14 @@
 																			"m_label":	"Keywords Set 5",
 																			"m_value":	""
 																		}],
-																	"m_events":	[],
+																	"m_events":	[{
+																			"m_eventName":	"wxEVT_STC_MODIFIED",
+																			"m_eventClass":	"wxStyledTextEvent",
+																			"m_eventHandler":	"wxStyledTextEventHandler",
+																			"m_functionNameAndSignature":	"OnStcEvtVModified(wxStyledTextEvent& event)",
+																			"m_description":	"Document modified",
+																			"m_noBody":	false
+																		}],
 																	"m_children":	[]
 																}]
 														}]
@@ -5663,7 +5677,14 @@
 																			"m_label":	"Keywords Set 5",
 																			"m_value":	""
 																		}],
-																	"m_events":	[],
+																	"m_events":	[{
+																			"m_eventName":	"wxEVT_STC_MODIFIED",
+																			"m_eventClass":	"wxStyledTextEvent",
+																			"m_eventHandler":	"wxStyledTextEventHandler",
+																			"m_functionNameAndSignature":	"OnStcEvtVModified(wxStyledTextEvent& event)",
+																			"m_description":	"Document modified",
+																			"m_noBody":	false
+																		}],
 																	"m_children":	[]
 																}]
 														}]
@@ -7569,7 +7590,14 @@
 													"m_label":	"Keywords Set 5",
 													"m_value":	""
 												}],
-											"m_events":	[],
+											"m_events":	[{
+													"m_eventName":	"wxEVT_STC_MODIFIED",
+													"m_eventClass":	"wxStyledTextEvent",
+													"m_eventHandler":	"wxStyledTextEventHandler",
+													"m_functionNameAndSignature":	"OnStcEvtVModified(wxStyledTextEvent& event)",
+													"m_description":	"Document modified",
+													"m_noBody":	false
+												}],
 											"m_children":	[]
 										}]
 								}]
@@ -8009,11 +8037,11 @@
 															"m_value":	""
 														}],
 													"m_events":	[{
-															"m_eventName":	"wxEVT_STC_CHARADDED",
+															"m_eventName":	"wxEVT_STC_MODIFIED",
 															"m_eventClass":	"wxStyledTextEvent",
 															"m_eventHandler":	"wxStyledTextEventHandler",
-															"m_functionNameAndSignature":	"OnBuildEventCharAdded(wxStyledTextEvent& event)",
-															"m_description":	"A char was added",
+															"m_functionNameAndSignature":	"OnStcEvtVModified(wxStyledTextEvent& event)",
+															"m_description":	"Document modified",
 															"m_noBody":	false
 														}],
 													"m_children":	[]
@@ -10796,7 +10824,14 @@
 															"m_label":	"Keywords Set 5",
 															"m_value":	""
 														}],
-													"m_events":	[],
+													"m_events":	[{
+															"m_eventName":	"wxEVT_STC_MODIFIED",
+															"m_eventClass":	"wxStyledTextEvent",
+															"m_eventHandler":	"wxStyledTextEventHandler",
+															"m_functionNameAndSignature":	"OnStcEvtVModified(wxStyledTextEvent& event)",
+															"m_description":	"Document modified",
+															"m_noBody":	false
+														}],
 													"m_children":	[]
 												}]
 										}, {
@@ -11406,7 +11441,14 @@
 															"m_label":	"Keywords Set 5",
 															"m_value":	""
 														}],
-													"m_events":	[],
+													"m_events":	[{
+															"m_eventName":	"wxEVT_STC_MODIFIED",
+															"m_eventClass":	"wxStyledTextEvent",
+															"m_eventHandler":	"wxStyledTextEventHandler",
+															"m_functionNameAndSignature":	"OnStcEvtVModified(wxStyledTextEvent& event)",
+															"m_description":	"Document modified",
+															"m_noBody":	false
+														}],
 													"m_children":	[]
 												}]
 										}]
@@ -11695,7 +11737,14 @@
 															"m_label":	"Keywords Set 5",
 															"m_value":	""
 														}],
-													"m_events":	[],
+													"m_events":	[{
+															"m_eventName":	"wxEVT_STC_MODIFIED",
+															"m_eventClass":	"wxStyledTextEvent",
+															"m_eventHandler":	"wxStyledTextEventHandler",
+															"m_functionNameAndSignature":	"OnStcEvtVModified(wxStyledTextEvent& event)",
+															"m_description":	"Document modified",
+															"m_noBody":	false
+														}],
 													"m_children":	[]
 												}, {
 													"m_type":	4401,

--- a/LiteEditor/project_settings_base_dlg.cpp
+++ b/LiteEditor/project_settings_base_dlg.cpp
@@ -753,6 +753,8 @@ PSDebuggerPageBase::PSDebuggerPageBase(wxWindow* parent, wxWindowID id, const wx
     }
     // Connect events
     this->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSDebuggerPageBase::OnProjectEnabledUI), NULL, this);
+    m_textCtrlDebuggerPath->Connect(wxEVT_COMMAND_TEXT_UPDATED,
+                                    wxCommandEventHandler(PSDebuggerPageBase::OnCmdEvtVModified), NULL, this);
     m_button39->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                         wxCommandEventHandler(PSDebuggerPageBase::OnBrowseForDebuggerPath), NULL, this);
     m_dvListCtrlDebuggerSearchPaths->Connect(wxEVT_COMMAND_DATAVIEW_ITEM_ACTIVATED,
@@ -763,6 +765,10 @@ PSDebuggerPageBase::PSDebuggerPageBase(wxWindow* parent, wxWindowID id, const wx
                         wxCommandEventHandler(PSDebuggerPageBase::OnDeleteDebuggerSearchPath), NULL, this);
     m_button90->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSDebuggerPageBase::OnDeleteDebuggerSearchPathUI), NULL,
                         this);
+    m_textCtrlDbgCmds->Connect(wxEVT_STC_MODIFIED, wxStyledTextEventHandler(PSDebuggerPageBase::OnStcEvtVModified),
+                               NULL, this);
+    m_textCtrlDbgPostConnectCmds->Connect(wxEVT_STC_MODIFIED,
+                                          wxStyledTextEventHandler(PSDebuggerPageBase::OnStcEvtVModified), NULL, this);
     m_checkBoxDbgRemote->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                                  wxCommandEventHandler(PSDebuggerPageBase::OnCmdEvtVModified), NULL, this);
     m_staticText31->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSDebuggerPageBase::OnRemoteDebugUI), NULL, this);
@@ -784,6 +790,8 @@ PSDebuggerPageBase::PSDebuggerPageBase(wxWindow* parent, wxWindowID id, const wx
 PSDebuggerPageBase::~PSDebuggerPageBase()
 {
     this->Disconnect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSDebuggerPageBase::OnProjectEnabledUI), NULL, this);
+    m_textCtrlDebuggerPath->Disconnect(wxEVT_COMMAND_TEXT_UPDATED,
+                                       wxCommandEventHandler(PSDebuggerPageBase::OnCmdEvtVModified), NULL, this);
     m_button39->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
                            wxCommandEventHandler(PSDebuggerPageBase::OnBrowseForDebuggerPath), NULL, this);
     m_dvListCtrlDebuggerSearchPaths->Disconnect(
@@ -794,6 +802,10 @@ PSDebuggerPageBase::~PSDebuggerPageBase()
                            wxCommandEventHandler(PSDebuggerPageBase::OnDeleteDebuggerSearchPath), NULL, this);
     m_button90->Disconnect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSDebuggerPageBase::OnDeleteDebuggerSearchPathUI),
                            NULL, this);
+    m_textCtrlDbgCmds->Disconnect(wxEVT_STC_MODIFIED, wxStyledTextEventHandler(PSDebuggerPageBase::OnStcEvtVModified),
+                                  NULL, this);
+    m_textCtrlDbgPostConnectCmds->Disconnect(
+        wxEVT_STC_MODIFIED, wxStyledTextEventHandler(PSDebuggerPageBase::OnStcEvtVModified), NULL, this);
     m_checkBoxDbgRemote->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                                     wxCommandEventHandler(PSDebuggerPageBase::OnCmdEvtVModified), NULL, this);
     m_staticText31->Disconnect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSDebuggerPageBase::OnRemoteDebugUI), NULL,
@@ -991,6 +1003,8 @@ PSEnvironmentBasePage::PSEnvironmentBasePage(wxWindow* parent, wxWindowID id, co
                          NULL, this);
     m_choiceDbgEnv->Connect(wxEVT_COMMAND_CHOICE_SELECTED,
                             wxCommandEventHandler(PSEnvironmentBasePage::OnCmdEvtVModified), NULL, this);
+    m_textCtrlEnvvars->Connect(wxEVT_STC_MODIFIED, wxStyledTextEventHandler(PSEnvironmentBasePage::OnStcEvtVModified),
+                               NULL, this);
 }
 
 PSEnvironmentBasePage::~PSEnvironmentBasePage()
@@ -1000,6 +1014,8 @@ PSEnvironmentBasePage::~PSEnvironmentBasePage()
                             wxCommandEventHandler(PSEnvironmentBasePage::OnCmdEvtVModified), NULL, this);
     m_choiceDbgEnv->Disconnect(wxEVT_COMMAND_CHOICE_SELECTED,
                                wxCommandEventHandler(PSEnvironmentBasePage::OnCmdEvtVModified), NULL, this);
+    m_textCtrlEnvvars->Disconnect(wxEVT_STC_MODIFIED,
+                                  wxStyledTextEventHandler(PSEnvironmentBasePage::OnStcEvtVModified), NULL, this);
 }
 
 PSBuildEventsBasePage::PSBuildEventsBasePage(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size,
@@ -1078,15 +1094,15 @@ PSBuildEventsBasePage::PSBuildEventsBasePage(wxWindow* parent, wxWindowID id, co
     }
     // Connect events
     this->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSBuildEventsBasePage::OnProjectEnabledUI), NULL, this);
-    m_textCtrlBuildEvents->Connect(wxEVT_STC_CHARADDED,
-                                   wxStyledTextEventHandler(PSBuildEventsBasePage::OnBuildEventCharAdded), NULL, this);
+    m_textCtrlBuildEvents->Connect(wxEVT_STC_MODIFIED,
+                                   wxStyledTextEventHandler(PSBuildEventsBasePage::OnStcEvtVModified), NULL, this);
 }
 
 PSBuildEventsBasePage::~PSBuildEventsBasePage()
 {
     this->Disconnect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSBuildEventsBasePage::OnProjectEnabledUI), NULL, this);
-    m_textCtrlBuildEvents->Disconnect(
-        wxEVT_STC_CHARADDED, wxStyledTextEventHandler(PSBuildEventsBasePage::OnBuildEventCharAdded), NULL, this);
+    m_textCtrlBuildEvents->Disconnect(wxEVT_STC_MODIFIED,
+                                      wxStyledTextEventHandler(PSBuildEventsBasePage::OnStcEvtVModified), NULL, this);
 }
 
 PSCustomBuildBasePage::PSCustomBuildBasePage(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size,
@@ -1472,6 +1488,8 @@ PSCustomMakefileBasePage::PSCustomMakefileBasePage(wxWindow* parent, wxWindowID 
                         this);
     m_staticText26->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSCustomMakefileBasePage::OnProjectCustumBuildUI),
                             NULL, this);
+    m_textPreBuildRule->Connect(wxEVT_STC_MODIFIED,
+                                wxStyledTextEventHandler(PSCustomMakefileBasePage::OnStcEvtVModified), NULL, this);
     m_staticText24->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSCustomMakefileBasePage::OnProjectCustumBuildUI),
                             NULL, this);
 }
@@ -1487,6 +1505,8 @@ PSCustomMakefileBasePage::~PSCustomMakefileBasePage()
                            NULL, this);
     m_staticText26->Disconnect(wxEVT_UPDATE_UI,
                                wxUpdateUIEventHandler(PSCustomMakefileBasePage::OnProjectCustumBuildUI), NULL, this);
+    m_textPreBuildRule->Disconnect(wxEVT_STC_MODIFIED,
+                                   wxStyledTextEventHandler(PSCustomMakefileBasePage::OnStcEvtVModified), NULL, this);
     m_staticText24->Disconnect(wxEVT_UPDATE_UI,
                                wxUpdateUIEventHandler(PSCustomMakefileBasePage::OnProjectCustumBuildUI), NULL, this);
 }
@@ -1623,11 +1643,19 @@ PSCompletionBase::PSCompletionBase(wxWindow* parent, wxWindowID id, const wxPoin
     }
     // Connect events
     this->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSCompletionBase::OnProjectEnabledUI), NULL, this);
+    m_textCtrlSearchPaths->Connect(wxEVT_STC_MODIFIED, wxStyledTextEventHandler(PSCompletionBase::OnStcEvtVModified),
+                                   NULL, this);
+    m_textCtrlMacros->Connect(wxEVT_STC_MODIFIED, wxStyledTextEventHandler(PSCompletionBase::OnStcEvtVModified), NULL,
+                              this);
 }
 
 PSCompletionBase::~PSCompletionBase()
 {
     this->Disconnect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSCompletionBase::OnProjectEnabledUI), NULL, this);
+    m_textCtrlSearchPaths->Disconnect(wxEVT_STC_MODIFIED, wxStyledTextEventHandler(PSCompletionBase::OnStcEvtVModified),
+                                      NULL, this);
+    m_textCtrlMacros->Disconnect(wxEVT_STC_MODIFIED, wxStyledTextEventHandler(PSCompletionBase::OnStcEvtVModified),
+                                 NULL, this);
 }
 
 ProjectCustomBuildTragetDlgBase::ProjectCustomBuildTragetDlgBase(wxWindow* parent, wxWindowID id, const wxString& title,

--- a/LiteEditor/project_settings_base_dlg.h
+++ b/LiteEditor/project_settings_base_dlg.h
@@ -214,12 +214,13 @@ protected:
 
 protected:
     virtual void OnProjectEnabledUI(wxUpdateUIEvent& event) { event.Skip(); }
+    virtual void OnCmdEvtVModified(wxCommandEvent& event) { event.Skip(); }
     virtual void OnBrowseForDebuggerPath(wxCommandEvent& event) { event.Skip(); }
     virtual void OnItemActivated(wxDataViewEvent& event) { event.Skip(); }
     virtual void OnAddDebuggerSearchPath(wxCommandEvent& event) { event.Skip(); }
     virtual void OnDeleteDebuggerSearchPath(wxCommandEvent& event) { event.Skip(); }
     virtual void OnDeleteDebuggerSearchPathUI(wxUpdateUIEvent& event) { event.Skip(); }
-    virtual void OnCmdEvtVModified(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnStcEvtVModified(wxStyledTextEvent& event) { event.Skip(); }
     virtual void OnRemoteDebugUI(wxUpdateUIEvent& event) { event.Skip(); }
 
 public:
@@ -286,6 +287,7 @@ protected:
 protected:
     virtual void OnProjectEnabledUI(wxUpdateUIEvent& event) { event.Skip(); }
     virtual void OnCmdEvtVModified(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnStcEvtVModified(wxStyledTextEvent& event) { event.Skip(); }
 
 public:
     wxStaticText* GetStaticText44() { return m_staticText44; }
@@ -310,7 +312,7 @@ protected:
 
 protected:
     virtual void OnProjectEnabledUI(wxUpdateUIEvent& event) { event.Skip(); }
-    virtual void OnBuildEventCharAdded(wxStyledTextEvent& event) { event.Skip(); }
+    virtual void OnStcEvtVModified(wxStyledTextEvent& event) { event.Skip(); }
 
 public:
     wxStaticText* GetStaticText11() { return m_staticText11; }
@@ -406,6 +408,7 @@ protected:
     virtual void OnProjectEnabledUI(wxUpdateUIEvent& event) { event.Skip(); }
     virtual void OnProjectCustumBuildUI(wxUpdateUIEvent& event) { event.Skip(); }
     virtual void OnCmdEvtVModified(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnStcEvtVModified(wxStyledTextEvent& event) { event.Skip(); }
 
 public:
     wxStaticText* GetStaticText25() { return m_staticText25; }
@@ -432,6 +435,7 @@ protected:
 
 protected:
     virtual void OnProjectEnabledUI(wxUpdateUIEvent& event) { event.Skip(); }
+    virtual void OnStcEvtVModified(wxStyledTextEvent& event) { event.Skip(); }
 
 public:
     wxStaticText* GetStaticText47() { return m_staticText47; }

--- a/LiteEditor/ps_build_events_page.cpp
+++ b/LiteEditor/ps_build_events_page.cpp
@@ -36,9 +36,9 @@ PSBuildEventsPage::PSBuildEventsPage(wxWindow* parent, bool preEvents, ProjectSe
 {
 }
 
-void PSBuildEventsPage::OnCmdEvtVModified(wxCommandEvent& event)
+void PSBuildEventsPage::OnStcEvtVModified(wxStyledTextEvent& event)
 {
-    wxUnusedVar(event);
+    event.Skip();
     m_dlg->SetIsDirty(true);
 }
 
@@ -67,9 +67,6 @@ void PSBuildEventsPage::Load(BuildConfigPtr buildConf)
         cmdText.Append(wxT("\n"));
         m_textCtrlBuildEvents->AppendText(cmdText);
     }
-
-    m_textCtrlBuildEvents->Connect(wxEVT_COMMAND_TEXT_UPDATED,
-                                   wxCommandEventHandler(PSBuildEventsPage::OnCmdEvtVModified), NULL, this);
 }
 
 void PSBuildEventsPage::Save(BuildConfigPtr buildConf, ProjectSettingsPtr projSettingsPtr)
@@ -93,8 +90,3 @@ void PSBuildEventsPage::Save(BuildConfigPtr buildConf, ProjectSettingsPtr projSe
 
 void PSBuildEventsPage::Clear() { m_textCtrlBuildEvents->Clear(); }
 void PSBuildEventsPage::OnProjectEnabledUI(wxUpdateUIEvent& event) { event.Enable(m_dlg->IsProjectEnabled()); }
-void PSBuildEventsPage::OnBuildEventCharAdded(wxStyledTextEvent& event)
-{
-    event.Skip();
-    m_dlg->SetIsDirty(true);
-}

--- a/LiteEditor/ps_build_events_page.h
+++ b/LiteEditor/ps_build_events_page.h
@@ -43,10 +43,9 @@ class PSBuildEventsPage : public PSBuildEventsBasePage, public IProjectSettingsP
     ProjectSettingsDlg* m_dlg;
 
 protected:
-    virtual void OnBuildEventCharAdded(wxStyledTextEvent& event);
     virtual void OnProjectEnabledUI(wxUpdateUIEvent& event);
     // Handlers for PSBuildEventsBasePage events.
-    void OnCmdEvtVModified(wxCommandEvent& event);
+    void OnStcEvtVModified(wxStyledTextEvent& event);
 
 public:
     /** Constructor */

--- a/LiteEditor/ps_completion_page.cpp
+++ b/LiteEditor/ps_completion_page.cpp
@@ -29,15 +29,13 @@
 PSCompletionPage::PSCompletionPage(wxWindow* parent, ProjectSettingsDlg* dlg)
     : PSCompletionBase(parent)
     , m_dlg(dlg)
-    , m_ccSettingsModified(false)
 {
 }
 
-void PSCompletionPage::OnCmdEvtVModified(wxCommandEvent& event)
+void PSCompletionPage::OnStcEvtVModified(wxStyledTextEvent& event)
 {
-    wxUnusedVar(event);
+    event.Skip();
     m_dlg->SetIsDirty(true);
-    m_ccSettingsModified = true;
 }
 
 void PSCompletionPage::Clear()
@@ -45,7 +43,6 @@ void PSCompletionPage::Clear()
     m_textCtrlSearchPaths->Clear();
     m_textCtrlMacros->Clear();
     m_textCtrlSearchPaths->Clear();
-    m_ccSettingsModified = false;
 }
 
 void PSCompletionPage::Load(BuildConfigPtr buildConf)
@@ -58,10 +55,6 @@ void PSCompletionPage::Save(BuildConfigPtr buildConf, ProjectSettingsPtr projSet
 {
     buildConf->SetClangPPFlags(m_textCtrlMacros->GetValue());
     buildConf->SetCcSearchPaths(m_textCtrlSearchPaths->GetValue());
-    // Save was requested
-    if(m_ccSettingsModified) {
-        m_ccSettingsModified = false;
-    }
 }
 
 void PSCompletionPage::OnBrowsePCH(wxCommandEvent& event) {}

--- a/LiteEditor/ps_completion_page.h
+++ b/LiteEditor/ps_completion_page.h
@@ -44,11 +44,10 @@ class PSCompletionPage : public PSCompletionBase, public IProjectSettingsPage
 protected:
     virtual void OnProjectEnabledUI(wxUpdateUIEvent& event);
     ProjectSettingsDlg* m_dlg;
-    bool m_ccSettingsModified;
 
 protected:
     // Handlers for PSCompletionBase events.
-    void OnCmdEvtVModified(wxCommandEvent& event);
+    void OnStcEvtVModified(wxStyledTextEvent& event);
     void OnBrowsePCH(wxCommandEvent& event);
 
 public:

--- a/LiteEditor/ps_custom_makefile_rules_page.cpp
+++ b/LiteEditor/ps_custom_makefile_rules_page.cpp
@@ -44,6 +44,12 @@ void PSCustomMakefileRulesPage::OnCmdEvtVModified( wxCommandEvent& event )
     m_dlg->SetIsDirty(true);
 }
 
+void PSCustomMakefileRulesPage::OnStcEvtVModified( wxStyledTextEvent& event )
+{
+    event.Skip();
+    m_dlg->SetIsDirty(true);
+}
+
 void PSCustomMakefileRulesPage::Load(BuildConfigPtr buildConf)
 {
     //set the custom pre-prebuild step

--- a/LiteEditor/ps_custom_makefile_rules_page.h
+++ b/LiteEditor/ps_custom_makefile_rules_page.h
@@ -45,6 +45,7 @@ protected:
     // Handlers for PSCustomMakefileBasePage events.
     void OnProjectCustumBuildUI( wxUpdateUIEvent& event );
     void OnCmdEvtVModified( wxCommandEvent& event );
+    void OnStcEvtVModified( wxStyledTextEvent& event );
 public:
     /** Constructor */
     PSCustomMakefileRulesPage( wxWindow* parent, ProjectSettingsDlg *dlg );

--- a/LiteEditor/ps_debugger_page.cpp
+++ b/LiteEditor/ps_debugger_page.cpp
@@ -44,6 +44,12 @@ void PSDebuggerPage::OnCmdEvtVModified( wxCommandEvent& event )
     m_dlg->SetIsDirty(true);
 }
 
+void PSDebuggerPage::OnStcEvtVModified( wxStyledTextEvent& event )
+{
+    event.Skip();
+    m_dlg->SetIsDirty(true);
+}
+
 void PSDebuggerPage::OnRemoteDebugUI( wxUpdateUIEvent& event )
 {
     event.Enable(m_checkBoxDbgRemote->IsChecked());

--- a/LiteEditor/ps_debugger_page.h
+++ b/LiteEditor/ps_debugger_page.h
@@ -51,6 +51,7 @@ protected:
 
     // Handlers for PSDebuggerPageBase events.
     void OnCmdEvtVModified( wxCommandEvent& event );
+    void OnStcEvtVModified( wxStyledTextEvent& event );
     void OnRemoteDebugUI( wxUpdateUIEvent& event );
     void DoAddPath(wxStringClientData* path);
 

--- a/LiteEditor/ps_environment_page.cpp
+++ b/LiteEditor/ps_environment_page.cpp
@@ -40,6 +40,12 @@ void PSEnvironmentPage::OnCmdEvtVModified(wxCommandEvent& event)
     m_dlg->SetIsDirty(true);
 }
 
+void PSEnvironmentPage::OnStcEvtVModified(wxStyledTextEvent& event)
+{
+    event.Skip();
+    m_dlg->SetIsDirty(true);
+}
+
 void PSEnvironmentPage::Load(BuildConfigPtr buildConf)
 {
     ///////////////////////////////////////////////////////////////////////////

--- a/LiteEditor/ps_environment_page.h
+++ b/LiteEditor/ps_environment_page.h
@@ -45,6 +45,7 @@ protected:
     virtual void OnProjectEnabledUI(wxUpdateUIEvent& event);
     // Handlers for PSEnvironmentBasePage events.
     void OnCmdEvtVModified( wxCommandEvent& event );
+    void OnStcEvtVModified( wxStyledTextEvent& event );
 
 public:
     /** Constructor */


### PR DESCRIPTION
These fields are now marked as dirty when modified:
`Environment` > `Additional environment variables`
`Debugger` > `Debugger Path`, `Startup Commands` and `Remote Attach Commands`
`Pre / Post Build Commands` > `Pre Build` and `Post Build` (wxEVT_STC_CHARADDED doesn't detect Backspace changes)
`Customize` > `Custom Makefile Rules`
`Code Completion` > `Search paths` and `Macros`

This PR also cleans up some unused event handlers and variables.