### PR TITLE
Plugin: wxWidgets changes for MS Windows

### DIFF
--- a/Plugin/clCaptionBar.cpp
+++ b/Plugin/clCaptionBar.cpp
@@ -1,6 +1,10 @@
 #include "clCaptionBar.hpp"
 #include "clMenuBar.hpp"
 #include "drawingutils.h"
+#include "wx/defs.h"
+#ifdef __WINDOWS__          // __WINDOWS__ defined by wx/defs.h
+#include "wx/msw/wrapwin.h" // includes windows.h
+#endif
 #include <wx/dcbuffer.h>
 #include <wx/dcgraph.h>
 #include <wx/frame.h>

--- a/codelite_terminal/wxTerminalColourHandler.cpp
+++ b/codelite_terminal/wxTerminalColourHandler.cpp
@@ -3,8 +3,7 @@
 #include "wxTerminalCtrl.h"
 
 #ifdef __WXMSW__
-#include <Winuser.h>
-#include <windows.h>
+#include "wx/msw/wrapwin.h" // includes windows.h
 #endif
 #include <fileutils.h>
 #include <wx/tokenzr.h>


### PR DESCRIPTION
Helps to prevent "error: 'ShowWindowAsync' was not declared" when building using cmake/make under MSys2

Added 2nd change to replace the included of "Winuser.h" because it caused build errors that suggested this header should not be included directly.