### PR TITLE
Several wxCrafter fixes

### DIFF
--- a/wxcrafter/RearrangeListWrapper.cpp
+++ b/wxcrafter/RearrangeListWrapper.cpp
@@ -34,7 +34,7 @@ wxString RearrangeListWrapper::CppCtorCode() const
     code << wxT("wxArrayInt ") << orderArr << wxT(";\n");
     code << wxT("wxArrayString ") << optionsArr << wxT(";\n");
     for(size_t i = 0; i < options.GetCount(); i++) {
-        code << optionsArr << ".Add(" << wxCrafter::WXT(options.Item(i)) << ");\n";
+        code << optionsArr << ".Add(" << wxCrafter::UNDERSCORE(options.Item(i)) << ");\n";
         code << orderArr << ".Add(" << i << ");\n";
     }
 

--- a/wxcrafter/SimpleHtmlListBoxWrapper.cpp
+++ b/wxcrafter/SimpleHtmlListBoxWrapper.cpp
@@ -46,7 +46,7 @@ wxString SimpleHtmlListBoxWrapper::CppCtorCode() const
     code << wxT("wxArrayString ") << optionsArr << wxT(";\n");
     for(size_t i = 0; i < options.GetCount(); i++) {
 
-        code << optionsArr << wxT(".Add(_(\"") << wxCrafter::ESCAPE(options.Item(i)) << wxT("\"));\n");
+        code << optionsArr << wxT(".Add(") << wxCrafter::UNDERSCORE(options.Item(i)) << wxT(");\n");
     }
 
     code << GetName() << wxT(" = new ") << GetRealClassName() << "(" << GetWindowParent() << wxT(", ") << WindowID()

--- a/wxcrafter/check_list_box_wrapper.cpp
+++ b/wxcrafter/check_list_box_wrapper.cpp
@@ -48,7 +48,7 @@ wxString CheckListBoxWrapper::CppCtorCode() const
 
     code << wxT("wxArrayString ") << optionsArr << wxT(";\n");
     for(size_t i = 0; i < options.GetCount(); i++) {
-        code << optionsArr << wxT(".Add(_(\"") << options.Item(i) << wxT("\"));\n");
+        code << optionsArr << wxT(".Add(") << wxCrafter::UNDERSCORE(options.Item(i)) << wxT(");\n");
     }
 
     code << GetName() << wxT(" = new ") << GetRealClassName() << "(" << GetWindowParent() << wxT(", ") << WindowID()

--- a/wxcrafter/choice_wrapper.cpp
+++ b/wxcrafter/choice_wrapper.cpp
@@ -33,7 +33,7 @@ wxString ChoiceWrapper::CppCtorCode() const
 
     code << wxT("wxArrayString ") << GetName() << wxT("Arr;\n");
     for(size_t i = 0; i < options.GetCount(); i++) {
-        code << GetName() << wxT("Arr.Add(wxT(\"") << options.Item(i) << wxT("\"));\n");
+        code << GetName() << wxT("Arr.Add(") << wxCrafter::UNDERSCORE(options.Item(i)) << wxT(");\n");
     }
 
     code << GetName() << wxT(" = new ") << GetRealClassName() << "(" << GetWindowParent() << wxT(", ") << WindowID()

--- a/wxcrafter/combox_wrapper.cpp
+++ b/wxcrafter/combox_wrapper.cpp
@@ -55,7 +55,7 @@ wxString ComboxWrapper::CppCtorCode() const
 
     code << wxT("wxArrayString ") << GetName() << wxT("Arr;\n");
     for(size_t i = 0; i < options.GetCount(); i++) {
-        code << GetName() << wxT("Arr.Add(wxT(\"") << options.Item(i) << wxT("\"));\n");
+        code << GetName() << wxT("Arr.Add(") << wxCrafter::UNDERSCORE(options.Item(i)) << wxT(");\n");
     }
 
     code << GetName() << wxT(" = new ") << GetRealClassName() << "(" << GetWindowParent() << wxT(", ") << WindowID()

--- a/wxcrafter/html_window_wrapper.cpp
+++ b/wxcrafter/html_window_wrapper.cpp
@@ -2,6 +2,7 @@
 #include "allocator_mgr.h"
 #include "string_property.h"
 #include "wxgui_defs.h"
+#include "wxgui_helpers.h"
 #include "xmlutils.h"
 #include <wx/html/htmlwin.h>
 
@@ -37,13 +38,12 @@ wxString HtmlWindowWrapper::CppCtorCode() const
 
     wxString htmlCode = PropertyString(PROP_HTMLCODE);
     htmlCode.Trim().Trim(false);
-    htmlCode.Prepend(wxT("wxT(\"")).Append(wxT("\")"));
-
-    if(htmlCode.IsEmpty() == false) { code << GetName() << wxT("->SetPage(") << htmlCode << wxT(");\n"); }
+    if(htmlCode.IsEmpty() == false) { code << GetName() << wxT("->SetPage(") << wxCrafter::WXT(htmlCode) << wxT(");\n"); }
 
     wxString url = PropertyFile(PROP_URL);
     url.Trim().Trim(false);
-    if(url.IsEmpty() == false) { code << GetName() << wxT("->LoadPage(") << url << wxT(");\n"); }
+    if(url.IsEmpty() == false) { code << GetName() << wxT("->LoadPage(") << wxCrafter::WXT(url) << wxT(");\n"); }
+
     code << CPPCommonAttributes();
     return code;
 }

--- a/wxcrafter/list_box_wrapper.cpp
+++ b/wxcrafter/list_box_wrapper.cpp
@@ -48,7 +48,7 @@ wxString ListBoxWrapper::CppCtorCode() const
 
     code << wxT("wxArrayString ") << optionsArr << wxT(";\n");
     for(size_t i = 0; i < options.GetCount(); i++) {
-        code << optionsArr << wxT(".Add(_(\"") << options.Item(i) << wxT("\"));\n");
+        code << optionsArr << wxT(".Add(") << wxCrafter::UNDERSCORE(options.Item(i)) << wxT(");\n");
     }
 
     code << GetName() << wxT(" = new ") << GetRealClassName() << "(" << GetWindowParent() << wxT(", ") << WindowID()

--- a/wxcrafter/property_grid_wrapper.cpp
+++ b/wxcrafter/property_grid_wrapper.cpp
@@ -41,7 +41,7 @@ PropertyGridWrapper::PropertyGridWrapper()
     AddProperty(new CategoryProperty("wxPGProperty"));
     AddProperty(new StringProperty(PROP_NAME, "", _("The property name")));
     AddProperty(new StringProperty(PROP_LABEL, wxString("My Label") << ++labelCount, _("The property label")));
-    AddProperty(new MultiStringsProperty(PROP_TOOLTIP, "The property help string"));
+    AddProperty(new MultiStringsProperty(PROP_TOOLTIP, _("The property help string")));
     AddProperty(new ColorProperty(PROP_BG, "<Default>", _("Property background colour")));
     AddProperty(new ChoiceProperty(PROP_CUSTOM_EDITOR, customEditors, 0, _("Set custom editor control to a property")));
 

--- a/wxcrafter/radio_box_wrapper.cpp
+++ b/wxcrafter/radio_box_wrapper.cpp
@@ -42,7 +42,7 @@ wxString RadioBoxWrapper::CppCtorCode() const
     code << wxT("wxArrayString ") << arrname << wxT(";\n");
 
     for(size_t i = 0; i < options.GetCount(); i++) {
-        code << arrname << wxT(".Add(_(\"") << options.Item(i) << wxT("\"));\n");
+        code << arrname << wxT(".Add(") << wxCrafter::UNDERSCORE(options.Item(i)) << wxT(");\n");
     }
 
     // wxRadioBox(wxWindow* parent, wxWindowID id, const wxString& label, const wxPoint& point, const wxSize& size,

--- a/wxcrafter/static_text_wrapper.cpp
+++ b/wxcrafter/static_text_wrapper.cpp
@@ -13,7 +13,7 @@ StaticTextWrapper::StaticTextWrapper()
     PREPEND_STYLE(wxST_NO_AUTORESIZE, false);
 
     SetPropertyString(_("Common Settings"), "wxStaticText");
-    AddProperty(new MultiStringsProperty(PROP_LABEL, wxT("Static Text Label"), wxT("\\n"), _("Label:")));
+    AddProperty(new MultiStringsProperty(PROP_LABEL, _("Static Text Label"), wxT("\\n"), _("Label:")));
     m_properties.Item(PROP_LABEL)->SetValue(_("Static Text Label"));
 
     AddProperty(


### PR DESCRIPTION
This PR fixes the following:

1. 'Choices' option doesn't respect the 'Generate Translatable Strings' setting.
Sometimes they were wrapped by `_()`, and sometimes by `wxT()`, regardless of the setting.

2. Auto-generated wxHtmlWindow code contains some errors, such as:
```c++
m_htmlWin->SetPage(wxT("")); // unnecessary call
m_htmlWin->SetPage(wxT("<img src="foo.jpg"/>")); // improperly escaped
m_htmlWin->LoadPage(http://www.example.com); // not a string literal
```

3. Add a few missing translations.