### PR TITLE
cmake: fix sqlite3 not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ include(UtilsHelper)
 if(NOT SQLITE3_FOUND)
     set(SQLITE3_INCLUDE_DIR ${CL_SRC_ROOT}/sqlite3)
     set(SQLITE3_LIBRARY "-lsqlite3lib")
+    set(CL_BUILT_SQLITE3 1)
+else()
+    set(CL_BUILT_SQLITE3 0)
 endif()
 
 set( IS_FREEBSD 0 )
@@ -480,20 +483,20 @@ message("-- ARCH_NAME ${ARCH_NAME}")
 if ( MAKE_DEB )
     get_distro_name(distro)
     message("-- Distro name: ${distro}")
-    
+
     set(DEB_DEPS "")
     if ( ${distro} STREQUAL "debian_10" )
         set(DEB_DEPS "clang-tools-7, clang-format-10")
     endif()
-    
+
     if ( ${distro} STREQUAL "ubuntu_1804" )
         set(DEB_DEPS "clangd-10, clang-format-10")
     endif()
-    
+
     if ( ${distro} STREQUAL "ubuntu_2004" )
         set(DEB_DEPS "clangd-10, clang-format-10")
     endif()
-    
+
     message("-- Generating deb target")
     if( ${ARCH} EQUAL 32 )
         message("-- CPACK_DEBIAN_PACKAGE_ARCHITECTURE i386")
@@ -502,7 +505,7 @@ if ( MAKE_DEB )
         message("-- CPACK_DEBIAN_PACKAGE_ARCHITECTURE amd64")
         set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
     endif ()
-    
+
     if (GTK_VERSION EQUAL 3)
         set(LIBGTK "libgtk-3-dev")
         set(GTKNAME "gtk3")
@@ -617,7 +620,7 @@ if ( APPLE )
     add_definitions( -mmacosx-version-min=10.8 )
 endif()
 
-if(APPLE)
+if(NOT SQLITE3_FOUND)
     # On Linux, we use the distro's libsqlite3
     add_subdirectory(sqlite3)
 endif()
@@ -715,6 +718,9 @@ if(APPLE)
     if ( USE_PCH )
         add_dependencies(sqlite3lib ${CL_PCH_TARGET})
     endif ( USE_PCH )
+endif()
+
+if(NOT SQLITE3_FOUND)
     add_dependencies(wxsqlite3 sqlite3lib)
 endif()
 

--- a/sdk/databaselayer/CMakeLists.txt
+++ b/sdk/databaselayer/CMakeLists.txt
@@ -1,8 +1,8 @@
 # define minimum cmake version
 cmake_minimum_required(VERSION 3.0)
- 
+
 # Our project is called 'databaselayersqlite' this is how it will be called in
-# visual studio, and in our makefiles. 
+# visual studio, and in our makefiles.
 project(databaselayersqlite)
 
 # It was noticed that when using MinGW gcc it is essential that 'core' is mentioned before 'base'.
@@ -12,7 +12,7 @@ project(databaselayersqlite)
 include( "${wxWidgets_USE_FILE}" )
 
 # Include paths
-include_directories(./include/wx/dblayer/include src/sqlite3)
+include_directories(./include/wx/dblayer/include ${SQLITE3_INCLUDE_DIR})
 
 if ( USE_PCH )
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include ${CL_PCH_FILE} -Winvalid-pch ")
@@ -32,26 +32,22 @@ if ( APPLE )
     add_definitions(-fPIC)
 endif()
 
-if(APPLE)
-    FILE(GLOB SRCS "src/dblayer/Sqlite*.cpp" "src/dblayer/Database*.cpp" "src/dblayer/Prepared*.cpp" "src/sqlite3/*.c")
-else()
-    FILE(GLOB SRCS "src/dblayer/Sqlite*.cpp" "src/dblayer/Database*.cpp" "src/dblayer/Prepared*.cpp")
-endif()
+FILE(GLOB SRCS "src/dblayer/Sqlite*.cpp" "src/dblayer/Database*.cpp" "src/dblayer/Prepared*.cpp")
 
 if ( WITH_MYSQL )
     find_library(LIBMYSQLCLIENT NAMES mysql mysqlclient mariadb mariadbclient)
     find_path(MYSQLCLIENT_INCLUDE NAMES mysql.h PATH_SUFFIXES mysql mariadb)
-    
-    if (  ${LIBMYSQLCLIENT} STREQUAL "LIBMYSQLCLIENT-NOTFOUND") 
+
+    if (  ${LIBMYSQLCLIENT} STREQUAL "LIBMYSQLCLIENT-NOTFOUND")
         message( FATAL_ERROR "-- Could not locate libmysqlclient.so" )
     else ( ${LIBMYSQLCLIENT} STREQUAL "LIBMYSQLCLIENT-NOTFOUND" )
         message( "-- LIBMYSQLCLIENT is set to ${LIBMYSQLCLIENT}" )
     endif ( ${LIBMYSQLCLIENT} STREQUAL "LIBMYSQLCLIENT-NOTFOUND" )
-    
+
     if ( ${MYSQLCLIENT_INCLUDE} STREQUAL "MYSQLCLIENT_INCLUDE-NOTFOUND" )
         message( FATAL_ERROR "-- Could not locate mysql.h" )
     endif ( ${MYSQLCLIENT_INCLUDE} STREQUAL "MYSQLCLIENT_INCLUDE-NOTFOUND" )
-    
+
     add_definitions( -DDBL_USE_MYSQL=1 )
     include_directories(${MYSQLCLIENT_INCLUDE})
     message("-- Adding MySQL include path: ${MYSQLCLIENT_INCLUDE} ")
@@ -72,7 +68,11 @@ endif ( WITH_MYSQL )
 
 # Define the output
 add_library(databaselayersqlite SHARED ${SRCS} ${MYSQL_SRCS})
-target_link_libraries(databaselayersqlite ${LINKER_OPTIONS} ${wxWidgets_LIBRARIES})
+if( CL_BUILT_SQLITE3 )
+target_link_libraries(databaselayersqlite ${LINKER_OPTIONS} ${wxWidgets_LIBRARIES} -L"${CL_LIBPATH}" ${SQLITE3_LIBRARY})
+else( CL_BUILT_SQLITE3 )
+target_link_libraries(databaselayersqlite ${LINKER_OPTIONS} ${wxWidgets_LIBRARIES} ${SQLITE3_LIBRARY})
+endif( CL_BUILT_SQLITE3 )
 
 if(APPLE)
     install(TARGETS databaselayersqlite DESTINATION ${CMAKE_BINARY_DIR}/codelite.app/Contents/MacOS/)


### PR DESCRIPTION
This patch adds CL_BUILT_SQLITE3 to indicate that SQLite3 is being built by
CodeLite. And, uses "NOT SQLITE3_FOUND" in place of testing for "APPLE".
This patch also removes trailing whitespace.