### PR TITLE
cmake: Simplify libcodelite link libraries

### DIFF
--- a/CodeLite/CMakeLists.txt
+++ b/CodeLite/CMakeLists.txt
@@ -1,8 +1,8 @@
 # define minimum cmake version
 cmake_minimum_required(VERSION 3.0)
- 
+
 # Our project is called 'codelite' this is how it will be called in
-# visual studio, and in our makefiles. 
+# visual studio, and in our makefiles.
 project(libcodelite)
 
 # It was noticed that when using MinGW gcc it is essential that 'core' is mentioned before 'base'.
@@ -23,16 +23,16 @@ if (UNIX AND NOT APPLE)
     if(WITH_FLEX)
         message("-- Adding flex support")
         find_package(FLEX REQUIRED)
-        
+
         set(CxxFlexOutput ${CMAKE_SOURCE_DIR}/CodeLite/CxxLexer.cpp)
         set(CxxFlexInput ${CMAKE_SOURCE_DIR}/CodeLite/CxxScanner.l)
-        
+
         set(PhpFlexOutput ${CMAKE_SOURCE_DIR}/CodeLite/PhpLexer.cpp)
         set(PhpFlexInput ${CMAKE_SOURCE_DIR}/CodeLite/PhpLexer.l)
-        
+
         set(JSFlexOutput ${CMAKE_SOURCE_DIR}/CodeLite/JSLexer.cpp)
         set(JSFlexInput ${CMAKE_SOURCE_DIR}/CodeLite/JSLexer.l)
-        
+
         if(FLEX_FOUND)
             add_custom_command(
                 OUTPUT ${CxxFlexOutput}
@@ -56,10 +56,10 @@ if (UNIX AND NOT APPLE)
 endif()
 
 # Include paths
-include_directories("${CL_SRC_ROOT}/sdk/wxsqlite3/include" 
-                    "${CL_SRC_ROOT}/sdk/codelite_indexer/network" 
-                    "${CL_SRC_ROOT}/sdk/websocketpp" 
-                    "${CL_SRC_ROOT}/sdk/asio-1.12.1" 
+include_directories("${CL_SRC_ROOT}/sdk/wxsqlite3/include"
+                    "${CL_SRC_ROOT}/sdk/codelite_indexer/network"
+                    "${CL_SRC_ROOT}/sdk/websocketpp"
+                    "${CL_SRC_ROOT}/sdk/asio-1.12.1"
                     "${CL_SRC_ROOT}/CodeLite"
                     "${CL_SRC_ROOT}/PCH"
                     "${CL_SRC_ROOT}/Interfaces")
@@ -74,7 +74,7 @@ if (UNIX)
     elseif ( UNIX AND NOT APPLE )
         set(ADDITIONAL_LIBRARIES "-ldl -lutil")
     else ( )
-        set(ADDITIONAL_LIBRARIES "-ldl")
+        set(ADDITIONAL_LIBRARIES "-ldl -lz")
     endif ( )
 else (UNIX)
     set(ADDITIONAL_LIBRARIES "-lws2_32")
@@ -104,7 +104,7 @@ add_definitions(-DWXUSINGDLL_WXSQLITE3)
 
 # Add RPATH
 if (NOT MINGW AND WXC_APP)
-    string( REPLACE "codelite" "wxcrafter" WXC_LIBS_DIR ${PLUGINS_DIR}) 
+    string( REPLACE "codelite" "wxcrafter" WXC_LIBS_DIR ${PLUGINS_DIR})
     set (LINKER_OPTIONS -Wl,-rpath,"${WXC_LIBS_DIR}")
     message( "-- libcodelite.so is using RPATH set to ${WXC_LIBS_DIR}")
 endif ()
@@ -112,28 +112,16 @@ FILE(GLOB SRCS "*.cpp" "../sdk/codelite_indexer/network/*.cpp" "SocketAPI/*.cpp"
 
 # Define the output
 add_library(libcodelite SHARED ${SRCS})
-if (UNIX AND NOT APPLE )
-    target_link_libraries(libcodelite 
-                         ${LINKER_OPTIONS} 
-                         ${wxWidgets_LIBRARIES} 
-                         -L"${CL_LIBPATH}" 
-                         ${SQLITE3_LIBRARY}
-                         wxsqlite3 
-                         ${LIBSSH_LIB} 
-                         ${ADDITIONAL_LIBRARIES}
-                         ${LIBUCHARDET_LIB})
-else (UNIX AND NOT APPLE)
-    target_link_libraries(libcodelite 
-                          ${LINKER_OPTIONS} 
-                          ${wxWidgets_LIBRARIES} 
-                          -L"${CL_LIBPATH}" 
-                          sqlite3lib 
-                          wxsqlite3 
-                          ${LIBSSH_LIB} 
-                          ${ADDITIONAL_LIBRARIES} 
-                          ${LIBUCHARDET_LIB}
-                          -lz)
-endif ( UNIX AND NOT APPLE )
+
+target_link_libraries(libcodelite
+                      ${LINKER_OPTIONS}
+                      ${wxWidgets_LIBRARIES}
+                      -L"${CL_LIBPATH}"
+                      ${SQLITE3_LIBRARY}
+                      wxsqlite3
+                      ${LIBSSH_LIB}
+                      ${ADDITIONAL_LIBRARIES}
+                      ${LIBUCHARDET_LIB})
 
 if(MINGW)
     set_target_properties(libcodelite


### PR DESCRIPTION
Remove the if/else logic to set target_link_libraries for libcodelite.
And, stripped the trailing spaces in the file.
