### PR TITLE
cmake: Rewrite FindSqlite3.cmake and logic using it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,12 @@ else()
     set( CL_SRC_ROOT ${CMAKE_CURRENT_SOURCE_DIR}) # which seems to be the same, at least in this situation
 endif()
 
-include(FindSqlite3)
+if( UNIX AND NOT APPLE)
+    include(FindSqlite3)
+    set(SQLITE3_FOUND ${SQLITE3_FOUND})
+else()
+    set(SQLITE3_FOUND FALSE)
+endif()
 include(UtilsHelper)
 
 if(NOT SQLITE3_FOUND)

--- a/cmake/Modules/FindSqlite3.cmake
+++ b/cmake/Modules/FindSqlite3.cmake
@@ -1,4 +1,11 @@
-if(UNIX AND NOT APPLE)
+#  Try to find Sqlite3
+#  Once done this will define values if library is found
+#    SQLITE3_FOUND - system has Sqlite3
+#    SQLITE3_INCLUDE_DIR - the Sqlite3 include directory
+#    SQLITE3_LIBRARY - Link these to use Sqlite3
+#
+
+if(NOT DEFINED SQLITE3_FOUND)
     find_library(SQLITE3_LIBRARY
                  NAMES libsqlite3.so
                  HINTS
@@ -17,11 +24,11 @@ if(UNIX AND NOT APPLE)
     if (SQLITE3_INCLUDE_DIR AND SQLITE3_LIBRARY)
        set(SQLITE3_FOUND TRUE)
     endif()
-    
-    if(NOT SQLITE3_FOUND)
-        message(FATAL_ERROR " **** Could not find Sqlite3. Please install libsqlite3-dev package **** ")
+
+    if(SQLITE3_FOUND)
+      message("-- SQLITE3_INCLUDE_DIR: " ${SQLITE3_INCLUDE_DIR})
+      message("-- SQLITE3_LIBRARY: " ${SQLITE3_LIBRARY})
     else()
-        message("-- SQLITE3_INCLUDE_DIR: " ${SQLITE3_INCLUDE_DIR})
-        message("-- SQLITE3_LIBRARY: " ${SQLITE3_LIBRARY})
+      message(-- "Could not find system Sqlite3. Using bundled sqlite3")
     endif()
 endif()


### PR DESCRIPTION
I took your FindSqlite3.cmake and a tiny bit from the MSys2 and decided the logic and using the FindSqlite3 needed changed. I moved the part that prevents Apple from using the system Sqlite3 to the CMakeLists.txt file instead of in FindSqlite3.cmake.

Tim S.