### PR TITLE
project: Fix PCH file path

### DIFF
--- a/codelitephp/php-plugin/PHPPlugin.project
+++ b/codelitephp/php-plugin/PHPPlugin.project
@@ -412,7 +412,7 @@ PATH=$(WXWIN)\lib\gcc_dll;$(PATH)]]>
       </Completion>
     </Configuration>
     <Configuration Name="Win_x64_Release" CompilerType="GCC (x86_64)" DebuggerType="GNU gdb debugger" Type="Dynamic Library" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="-O2;;-Wall;$(shell wx-config --cxxflags);-Winvalid-pch" C_Options="-O2" Assembler="" Required="yes" PreCompiledHeader="../PCH/precompiled_header_release.h" PCHInCommandLine="yes" PCHFlags="" PCHFlagsPolicy="2">
+      <Compiler Options="-O2;;-Wall;$(shell wx-config --cxxflags);-Winvalid-pch" C_Options="-O2" Assembler="" Required="yes" PreCompiledHeader="../../PCH/precompiled_header_release.h" PCHInCommandLine="yes" PCHFlags="" PCHFlagsPolicy="2">
         <IncludePath Value="."/>
         <IncludePath Value="../../Interfaces"/>
         <IncludePath Value="../../CodeLite"/>


### PR DESCRIPTION
This is likely a fix for [Building CodeLite - Last Hope](https://codelite.org/forum/viewtopic.php?f=3&t=4800&p=19541#p19541)

I duplicated the problem in versions 15.0.3 and 15.0.4.
It made it passed this issue with this fix in 15.0.4.
I myself can no longer build CodeLite Git master using the CodeLite IDE.
Looks like the last version I built was 15.0.2 from the git repo; likely before it was released.

Edit: I have now built an 15.0.6 with this patch using CodeLite IDE version 15.0.2.
I am starting to think my CodeLite IDE setting might have been wrong somewhere that was the cause of my earlier error before the original poster error that I fixed.

Tim S.