### PR TITLE
Gizmos: Update 'New Class' wizard to use C++11 features

### DIFF
--- a/Gizmos/new_class_dlg_data.h
+++ b/Gizmos/new_class_dlg_data.h
@@ -44,6 +44,8 @@ public:
         HppHeader = (1 << 7),
         UsePragma = (1 << 8),
         UseLowerCase = (1 << 9),
+        NonMovable = (1 << 10),
+        NonInheritable = (1 << 11),
     };
 
 public:

--- a/Gizmos/newclassbasedlg.cpp
+++ b/Gizmos/newclassbasedlg.cpp
@@ -222,35 +222,17 @@ NewClassBaseDlg::NewClassBaseDlg(wxWindow* parent, wxWindowID id, const wxString
 
     boxSizer59->Add(fgSizer2, 0, wxALL | wxEXPAND, WXC_FROM_DIP(5));
 
-    m_checkBoxVirtualDtor = new wxCheckBox(m_panel55, wxID_ANY, _("Virtual destructor"), wxDefaultPosition,
-                                           wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
-    m_checkBoxVirtualDtor->SetValue(false);
-
-    fgSizer2->Add(m_checkBoxVirtualDtor, 0, wxALL, WXC_FROM_DIP(5));
-
-    m_checkBoxCopyable = new wxCheckBox(m_panel55, wxID_ANY, _("Declare this class non-copyable"), wxDefaultPosition,
-                                        wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
-    m_checkBoxCopyable->SetValue(false);
-
-    fgSizer2->Add(m_checkBoxCopyable, 0, wxALL, WXC_FROM_DIP(5));
-
-    m_checkBoxImplVirtual = new wxCheckBox(m_panel55, wxID_ANY, _("Implement all virtual functions"), wxDefaultPosition,
-                                           wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
-    m_checkBoxImplVirtual->SetValue(false);
-
-    fgSizer2->Add(m_checkBoxImplVirtual, 0, wxALL, WXC_FROM_DIP(5));
-
     m_checkBoxSingleton = new wxCheckBox(m_panel55, wxID_ANY, _("This is a singleton class"), wxDefaultPosition,
                                          wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
     m_checkBoxSingleton->SetValue(false);
 
     fgSizer2->Add(m_checkBoxSingleton, 0, wxALL, WXC_FROM_DIP(5));
 
-    m_checkBoxImplPureVirtual = new wxCheckBox(m_panel55, wxID_ANY, _("Implement all pure virtual functions"),
-                                               wxDefaultPosition, wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
-    m_checkBoxImplPureVirtual->SetValue(false);
+    m_checkBoxVirtualDtor = new wxCheckBox(m_panel55, wxID_ANY, _("Virtual destructor"), wxDefaultPosition,
+                                           wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
+    m_checkBoxVirtualDtor->SetValue(false);
 
-    fgSizer2->Add(m_checkBoxImplPureVirtual, 0, wxALL, WXC_FROM_DIP(5));
+    fgSizer2->Add(m_checkBoxVirtualDtor, 0, wxALL, WXC_FROM_DIP(5));
 
     m_checkBoxInline = new wxCheckBox(m_panel55, wxID_ANY, _("Inline class"), wxDefaultPosition,
                                       wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
@@ -258,6 +240,36 @@ NewClassBaseDlg::NewClassBaseDlg(wxWindow* parent, wxWindowID id, const wxString
     m_checkBoxInline->SetToolTip(_("Put both the declaration and the implementation in the header file"));
 
     fgSizer2->Add(m_checkBoxInline, 0, wxALL, WXC_FROM_DIP(5));
+
+    m_checkBoxNonInheritable = new wxCheckBox(m_panel55, wxID_ANY, _("Prohibit further inheritance"), wxDefaultPosition,
+                                              wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
+    m_checkBoxNonInheritable->SetValue(false);
+
+    fgSizer2->Add(m_checkBoxNonInheritable, 0, wxALL, WXC_FROM_DIP(5));
+
+    m_checkBoxNonCopyable = new wxCheckBox(m_panel55, wxID_ANY, _("Declare this class non-copyable"), wxDefaultPosition,
+                                           wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
+    m_checkBoxNonCopyable->SetValue(false);
+
+    fgSizer2->Add(m_checkBoxNonCopyable, 0, wxALL, WXC_FROM_DIP(5));
+
+    m_checkBoxNonMovable = new wxCheckBox(m_panel55, wxID_ANY, _("Declare this class non-movable"), wxDefaultPosition,
+                                          wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
+    m_checkBoxNonMovable->SetValue(false);
+
+    fgSizer2->Add(m_checkBoxNonMovable, 0, wxALL, WXC_FROM_DIP(5));
+
+    m_checkBoxImplVirtual = new wxCheckBox(m_panel55, wxID_ANY, _("Implement all virtual functions"), wxDefaultPosition,
+                                           wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
+    m_checkBoxImplVirtual->SetValue(false);
+
+    fgSizer2->Add(m_checkBoxImplVirtual, 0, wxALL, WXC_FROM_DIP(5));
+
+    m_checkBoxImplPureVirtual = new wxCheckBox(m_panel55, wxID_ANY, _("Implement all pure virtual functions"),
+                                               wxDefaultPosition, wxDLG_UNIT(m_panel55, wxSize(-1, -1)), 0);
+    m_checkBoxImplPureVirtual->SetValue(false);
+
+    fgSizer2->Add(m_checkBoxImplPureVirtual, 0, wxALL, WXC_FROM_DIP(5));
 
     m_stdBtnSizer30 = new wxStdDialogButtonSizer();
 
@@ -281,7 +293,9 @@ NewClassBaseDlg::NewClassBaseDlg(wxWindow* parent, wxWindowID id, const wxString
 
     SetName(wxT("NewClassBaseDlg"));
     SetSize(wxDLG_UNIT(this, wxSize(-1, -1)));
-    if(GetSizer()) { GetSizer()->Fit(this); }
+    if(GetSizer()) {
+        GetSizer()->Fit(this);
+    }
     if(GetParent()) {
         CentreOnParent(wxBOTH);
     } else {
@@ -309,10 +323,10 @@ NewClassBaseDlg::NewClassBaseDlg(wxWindow* parent, wxWindowID id, const wxString
                                   NULL, this);
     m_checkBoxLowercaseFileName->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                                          wxCommandEventHandler(NewClassBaseDlg::OnUseLowerCaseFileName), NULL, this);
+    m_checkBoxSingleton->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
+                                 wxCommandEventHandler(NewClassBaseDlg::OnCheckSingleton), NULL, this);
     m_checkBoxImplVirtual->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                                    wxCommandEventHandler(NewClassBaseDlg::OnCheckImpleAllVirtualFunctions), NULL, this);
-    m_checkBoxInline->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(NewClassBaseDlg::OnCheckInline),
-                              NULL, this);
     m_button34->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(NewClassBaseDlg::OnButtonOK), NULL, this);
 }
 
@@ -333,11 +347,11 @@ NewClassBaseDlg::~NewClassBaseDlg()
                                      wxCommandEventHandler(NewClassBaseDlg::OnBrowseFolder), NULL, this);
     m_checkBoxLowercaseFileName->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                                             wxCommandEventHandler(NewClassBaseDlg::OnUseLowerCaseFileName), NULL, this);
+    m_checkBoxSingleton->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
+                                    wxCommandEventHandler(NewClassBaseDlg::OnCheckSingleton), NULL, this);
     m_checkBoxImplVirtual->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                                       wxCommandEventHandler(NewClassBaseDlg::OnCheckImpleAllVirtualFunctions), NULL,
                                       this);
-    m_checkBoxInline->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(NewClassBaseDlg::OnCheckInline),
-                                 NULL, this);
     m_button34->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(NewClassBaseDlg::OnButtonOK), NULL,
                            this);
 }

--- a/Gizmos/newclassbasedlg.h
+++ b/Gizmos/newclassbasedlg.h
@@ -68,12 +68,14 @@ protected:
     wxCheckBox* m_checkBoxLowercaseFileName;
     wxCheckBox* m_checkBoxPragmaOnce;
     wxPanel* m_panel55;
-    wxCheckBox* m_checkBoxVirtualDtor;
-    wxCheckBox* m_checkBoxCopyable;
-    wxCheckBox* m_checkBoxImplVirtual;
     wxCheckBox* m_checkBoxSingleton;
-    wxCheckBox* m_checkBoxImplPureVirtual;
+    wxCheckBox* m_checkBoxVirtualDtor;
     wxCheckBox* m_checkBoxInline;
+    wxCheckBox* m_checkBoxNonInheritable;
+    wxCheckBox* m_checkBoxNonCopyable;
+    wxCheckBox* m_checkBoxNonMovable;
+    wxCheckBox* m_checkBoxImplVirtual;
+    wxCheckBox* m_checkBoxImplPureVirtual;
     wxStdDialogButtonSizer* m_stdBtnSizer30;
     wxButton* m_button32;
     wxButton* m_button34;
@@ -86,8 +88,8 @@ protected:
     virtual void OnBrowseVD(wxCommandEvent& event) { event.Skip(); }
     virtual void OnBrowseFolder(wxCommandEvent& event) { event.Skip(); }
     virtual void OnUseLowerCaseFileName(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnCheckSingleton(wxCommandEvent& event) { event.Skip(); }
     virtual void OnCheckImpleAllVirtualFunctions(wxCommandEvent& event) { event.Skip(); }
-    virtual void OnCheckInline(wxCommandEvent& event) { event.Skip(); }
     virtual void OnButtonOK(wxCommandEvent& event) { event.Skip(); }
 
 public:
@@ -114,12 +116,14 @@ public:
     wxCheckBox* GetCheckBoxLowercaseFileName() { return m_checkBoxLowercaseFileName; }
     wxCheckBox* GetCheckBoxPragmaOnce() { return m_checkBoxPragmaOnce; }
     wxPanel* GetPanel57() { return m_panel57; }
-    wxCheckBox* GetCheckBoxVirtualDtor() { return m_checkBoxVirtualDtor; }
-    wxCheckBox* GetCheckBoxCopyable() { return m_checkBoxCopyable; }
-    wxCheckBox* GetCheckBoxImplVirtual() { return m_checkBoxImplVirtual; }
     wxCheckBox* GetCheckBoxSingleton() { return m_checkBoxSingleton; }
-    wxCheckBox* GetCheckBoxImplPureVirtual() { return m_checkBoxImplPureVirtual; }
+    wxCheckBox* GetCheckBoxVirtualDtor() { return m_checkBoxVirtualDtor; }
     wxCheckBox* GetCheckBoxInline() { return m_checkBoxInline; }
+    wxCheckBox* GetCheckBoxNonInheritable() { return m_checkBoxNonInheritable; }
+    wxCheckBox* GetCheckBoxNonCopyable() { return m_checkBoxNonCopyable; }
+    wxCheckBox* GetCheckBoxNonMovable() { return m_checkBoxNonMovable; }
+    wxCheckBox* GetCheckBoxImplVirtual() { return m_checkBoxImplVirtual; }
+    wxCheckBox* GetCheckBoxImplPureVirtual() { return m_checkBoxImplPureVirtual; }
     wxPanel* GetPanel55() { return m_panel55; }
     wxNotebook* GetNotebook53() { return m_notebook53; }
     NewClassBaseDlg(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("New Class"),

--- a/Gizmos/newclassdlg.h
+++ b/Gizmos/newclassdlg.h
@@ -45,7 +45,9 @@ struct NewClassInfo {
     wxString fileName;
     wxString virtualDirectory;
     bool isSingleton;
-    bool isAssingable;
+    bool isAssignable;
+    bool isMovable;
+    bool isInheritable;
     bool isVirtualDtor;
     bool implAllPureVirtual;
     bool implAllVirtual;
@@ -56,7 +58,9 @@ struct NewClassInfo {
 
     NewClassInfo()
         : isSingleton(false)
-        , isAssingable(false)
+        , isAssignable(false)
+        , isMovable(false)
+        , isInheritable(false)
         , isVirtualDtor(false)
         , implAllPureVirtual(false)
         , implAllVirtual(false)
@@ -79,6 +83,8 @@ class NewClassDlg : public NewClassBaseDlg
     wxString m_parentClass;
 
 protected:
+    virtual void OnCheckSingleton(wxCommandEvent& event);
+    virtual void OnCheckImpleAllVirtualFunctions(wxCommandEvent& event);
     virtual void OnUseLowerCaseFileName(wxCommandEvent& event);
     virtual void OnBlockGuardUI(wxUpdateUIEvent& event);
     void OnBrowseParentClass(wxCommandEvent& event);
@@ -86,15 +92,14 @@ protected:
     void OnButtonOK(wxCommandEvent& e);
     bool ValidateInput();
     void OnTextEnter(wxCommandEvent& e);
-    void OnCheckImpleAllVirtualFunctions(wxCommandEvent& e);
     void OnBrowseFolder(wxCommandEvent& e);
     void OnBrowseVD(wxCommandEvent& e);
     void OnBrowseNamespace(wxCommandEvent& e);
-    void OnCheckInline(wxCommandEvent& e);
     void OnOkUpdateUI(wxUpdateUIEvent& event);
 
-    wxString doSpliteByCaptilization(const wxString& str);
+    wxString doSpliteByCaptilization(const wxString& str) const;
     void DoUpdateGeneratedPath();
+    void DoUpdateCheckBoxes();
     void DoSaveOptions();
     wxString CreateFileName() const;
 
@@ -103,17 +108,19 @@ public:
     NewClassDlg(wxWindow* parent, IManager* mgr);
     virtual ~NewClassDlg();
 
-    void GetNewClassInfo(NewClassInfo& info);
+    void GetNewClassInfo(NewClassInfo& info) const;
 
-    void GetInheritance(ClassParentInfo& inheritVec);
-    bool IsSingleton() { return m_checkBoxSingleton->GetValue(); }
-    wxString GetClassName() { return m_textClassName->GetValue(); }
+    void GetInheritance(ClassParentInfo& inheritVec) const;
+    bool IsSingleton() const { return m_checkBoxSingleton->GetValue(); }
+    wxString GetClassName() const { return m_textClassName->GetValue(); }
     wxString GetClassNamespace() const { return m_textCtrlNamespace->GetValue(); }
-    wxString GetClassPath();
-    wxString GetClassFile();
-    bool IsCopyableClass() { return !m_checkBoxCopyable->IsChecked(); }
-    wxString GetVirtualDirectoryPath() { return m_textCtrlVD->GetValue(); }
-    void GetNamespacesList(wxArrayString& namespacesArray);
+    wxString GetClassPath() const;
+    wxString GetClassFile() const;
+    bool IsCopyableClass() const { return !m_checkBoxNonCopyable->IsChecked(); }
+    bool IsMovableClass() const { return !m_checkBoxNonMovable->IsChecked(); }
+    bool IsInheritable() const { return !m_checkBoxNonInheritable->IsChecked(); }
+    wxString GetVirtualDirectoryPath() const { return m_textCtrlVD->GetValue(); }
+    void GetNamespacesList(wxArrayString& namespacesArray) const;
     bool IsInline() const { return m_checkBoxInline->GetValue(); }
     bool HppHeader() const { return m_checkBoxHpp->GetValue(); }
 };

--- a/Gizmos/newclasswizard.wxcp
+++ b/Gizmos/newclasswizard.wxcp
@@ -1,7 +1,7 @@
 {
 	"metadata":	{
 		"m_generatedFilesDir":	".",
-		"m_objCounter":	63,
+		"m_objCounter":	65,
 		"m_includeFiles":	[],
 		"m_bitmapFunction":	"wxC3999InitBitmapResources",
 		"m_bitmapsFile":	"newclasswizard_gizmos_bitmaps.cpp",
@@ -2480,6 +2480,88 @@
 																}, {
 																	"type":	"string",
 																	"m_label":	"Name:",
+																	"m_value":	"m_checkBoxSingleton"
+																}, {
+																	"type":	"multi-string",
+																	"m_label":	"Tooltip:",
+																	"m_value":	""
+																}, {
+																	"type":	"colour",
+																	"m_label":	"Bg Colour:",
+																	"colour":	"<Default>"
+																}, {
+																	"type":	"colour",
+																	"m_label":	"Fg Colour:",
+																	"colour":	"<Default>"
+																}, {
+																	"type":	"font",
+																	"m_label":	"Font:",
+																	"m_value":	""
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Hidden",
+																	"m_value":	false
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Disabled",
+																	"m_value":	false
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Focused",
+																	"m_value":	false
+																}, {
+																	"type":	"string",
+																	"m_label":	"Class Name:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Include File:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Style:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Label:",
+																	"m_value":	"This is a singleton class"
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Value:",
+																	"m_value":	false
+																}],
+															"m_events":	[{
+																	"m_eventName":	"wxEVT_COMMAND_CHECKBOX_CLICKED",
+																	"m_eventClass":	"wxCommandEvent",
+																	"m_eventHandler":	"wxCommandEventHandler",
+																	"m_functionNameAndSignature":	"OnCheckSingleton(wxCommandEvent& event)",
+																	"m_description":	"Process a wxEVT_COMMAND_CHECKBOX_CLICKED event, when the checkbox is clicked.",
+																	"m_noBody":	false
+																}],
+															"m_children":	[]
+														}, {
+															"m_type":	4415,
+															"proportion":	0,
+															"border":	5,
+															"gbSpan":	",",
+															"gbPosition":	",",
+															"m_styles":	[],
+															"m_sizerFlags":	["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
+															"m_properties":	[{
+																	"type":	"winid",
+																	"m_label":	"ID:",
+																	"m_winid":	"wxID_ANY"
+																}, {
+																	"type":	"string",
+																	"m_label":	"Size:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Minimum Size:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Name:",
 																	"m_value":	"m_checkBoxVirtualDtor"
 																}, {
 																	"type":	"multi-string",
@@ -2555,7 +2637,157 @@
 																}, {
 																	"type":	"string",
 																	"m_label":	"Name:",
-																	"m_value":	"m_checkBoxCopyable"
+																	"m_value":	"m_checkBoxInline"
+																}, {
+																	"type":	"multi-string",
+																	"m_label":	"Tooltip:",
+																	"m_value":	"Put both the declaration and the implementation in the header file"
+																}, {
+																	"type":	"colour",
+																	"m_label":	"Bg Colour:",
+																	"colour":	"<Default>"
+																}, {
+																	"type":	"colour",
+																	"m_label":	"Fg Colour:",
+																	"colour":	"<Default>"
+																}, {
+																	"type":	"font",
+																	"m_label":	"Font:",
+																	"m_value":	""
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Hidden",
+																	"m_value":	false
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Disabled",
+																	"m_value":	false
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Focused",
+																	"m_value":	false
+																}, {
+																	"type":	"string",
+																	"m_label":	"Class Name:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Include File:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Style:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Label:",
+																	"m_value":	"Inline class"
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Value:",
+																	"m_value":	false
+																}],
+															"m_events":	[],
+															"m_children":	[]
+														}, {
+															"m_type":	4415,
+															"proportion":	0,
+															"border":	5,
+															"gbSpan":	",",
+															"gbPosition":	",",
+															"m_styles":	[],
+															"m_sizerFlags":	["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
+															"m_properties":	[{
+																	"type":	"winid",
+																	"m_label":	"ID:",
+																	"m_winid":	"wxID_ANY"
+																}, {
+																	"type":	"string",
+																	"m_label":	"Size:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Minimum Size:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Name:",
+																	"m_value":	"m_checkBoxNonInheritable"
+																}, {
+																	"type":	"multi-string",
+																	"m_label":	"Tooltip:",
+																	"m_value":	""
+																}, {
+																	"type":	"colour",
+																	"m_label":	"Bg Colour:",
+																	"colour":	"<Default>"
+																}, {
+																	"type":	"colour",
+																	"m_label":	"Fg Colour:",
+																	"colour":	"<Default>"
+																}, {
+																	"type":	"font",
+																	"m_label":	"Font:",
+																	"m_value":	""
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Hidden",
+																	"m_value":	false
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Disabled",
+																	"m_value":	false
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Focused",
+																	"m_value":	false
+																}, {
+																	"type":	"string",
+																	"m_label":	"Class Name:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Include File:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Style:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Label:",
+																	"m_value":	"Prohibit further inheritance"
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Value:",
+																	"m_value":	false
+																}],
+															"m_events":	[],
+															"m_children":	[]
+														}, {
+															"m_type":	4415,
+															"proportion":	0,
+															"border":	5,
+															"gbSpan":	",",
+															"gbPosition":	",",
+															"m_styles":	[],
+															"m_sizerFlags":	["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
+															"m_properties":	[{
+																	"type":	"winid",
+																	"m_label":	"ID:",
+																	"m_winid":	"wxID_ANY"
+																}, {
+																	"type":	"string",
+																	"m_label":	"Size:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Minimum Size:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Name:",
+																	"m_value":	"m_checkBoxNonCopyable"
 																}, {
 																	"type":	"multi-string",
 																	"m_label":	"Tooltip:",
@@ -2600,6 +2832,81 @@
 																	"type":	"string",
 																	"m_label":	"Label:",
 																	"m_value":	"Declare this class non-copyable"
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Value:",
+																	"m_value":	false
+																}],
+															"m_events":	[],
+															"m_children":	[]
+														}, {
+															"m_type":	4415,
+															"proportion":	0,
+															"border":	5,
+															"gbSpan":	",",
+															"gbPosition":	",",
+															"m_styles":	[],
+															"m_sizerFlags":	["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
+															"m_properties":	[{
+																	"type":	"winid",
+																	"m_label":	"ID:",
+																	"m_winid":	"wxID_ANY"
+																}, {
+																	"type":	"string",
+																	"m_label":	"Size:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Minimum Size:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Name:",
+																	"m_value":	"m_checkBoxNonMovable"
+																}, {
+																	"type":	"multi-string",
+																	"m_label":	"Tooltip:",
+																	"m_value":	""
+																}, {
+																	"type":	"colour",
+																	"m_label":	"Bg Colour:",
+																	"colour":	"<Default>"
+																}, {
+																	"type":	"colour",
+																	"m_label":	"Fg Colour:",
+																	"colour":	"<Default>"
+																}, {
+																	"type":	"font",
+																	"m_label":	"Font:",
+																	"m_value":	""
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Hidden",
+																	"m_value":	false
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Disabled",
+																	"m_value":	false
+																}, {
+																	"type":	"bool",
+																	"m_label":	"Focused",
+																	"m_value":	false
+																}, {
+																	"type":	"string",
+																	"m_label":	"Class Name:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Include File:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Style:",
+																	"m_value":	""
+																}, {
+																	"type":	"string",
+																	"m_label":	"Label:",
+																	"m_value":	"Declare this class non-movable"
 																}, {
 																	"type":	"bool",
 																	"m_label":	"Value:",
@@ -2712,81 +3019,6 @@
 																}, {
 																	"type":	"string",
 																	"m_label":	"Name:",
-																	"m_value":	"m_checkBoxSingleton"
-																}, {
-																	"type":	"multi-string",
-																	"m_label":	"Tooltip:",
-																	"m_value":	""
-																}, {
-																	"type":	"colour",
-																	"m_label":	"Bg Colour:",
-																	"colour":	"<Default>"
-																}, {
-																	"type":	"colour",
-																	"m_label":	"Fg Colour:",
-																	"colour":	"<Default>"
-																}, {
-																	"type":	"font",
-																	"m_label":	"Font:",
-																	"m_value":	""
-																}, {
-																	"type":	"bool",
-																	"m_label":	"Hidden",
-																	"m_value":	false
-																}, {
-																	"type":	"bool",
-																	"m_label":	"Disabled",
-																	"m_value":	false
-																}, {
-																	"type":	"bool",
-																	"m_label":	"Focused",
-																	"m_value":	false
-																}, {
-																	"type":	"string",
-																	"m_label":	"Class Name:",
-																	"m_value":	""
-																}, {
-																	"type":	"string",
-																	"m_label":	"Include File:",
-																	"m_value":	""
-																}, {
-																	"type":	"string",
-																	"m_label":	"Style:",
-																	"m_value":	""
-																}, {
-																	"type":	"string",
-																	"m_label":	"Label:",
-																	"m_value":	"This is a singleton class"
-																}, {
-																	"type":	"bool",
-																	"m_label":	"Value:",
-																	"m_value":	false
-																}],
-															"m_events":	[],
-															"m_children":	[]
-														}, {
-															"m_type":	4415,
-															"proportion":	0,
-															"border":	5,
-															"gbSpan":	",",
-															"gbPosition":	",",
-															"m_styles":	[],
-															"m_sizerFlags":	["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
-															"m_properties":	[{
-																	"type":	"winid",
-																	"m_label":	"ID:",
-																	"m_winid":	"wxID_ANY"
-																}, {
-																	"type":	"string",
-																	"m_label":	"Size:",
-																	"m_value":	""
-																}, {
-																	"type":	"string",
-																	"m_label":	"Minimum Size:",
-																	"m_value":	""
-																}, {
-																	"type":	"string",
-																	"m_label":	"Name:",
 																	"m_value":	"m_checkBoxImplPureVirtual"
 																}, {
 																	"type":	"multi-string",
@@ -2838,88 +3070,6 @@
 																	"m_value":	false
 																}],
 															"m_events":	[],
-															"m_children":	[]
-														}, {
-															"m_type":	4415,
-															"proportion":	0,
-															"border":	5,
-															"gbSpan":	",",
-															"gbPosition":	",",
-															"m_styles":	[],
-															"m_sizerFlags":	["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
-															"m_properties":	[{
-																	"type":	"winid",
-																	"m_label":	"ID:",
-																	"m_winid":	"wxID_ANY"
-																}, {
-																	"type":	"string",
-																	"m_label":	"Size:",
-																	"m_value":	""
-																}, {
-																	"type":	"string",
-																	"m_label":	"Minimum Size:",
-																	"m_value":	""
-																}, {
-																	"type":	"string",
-																	"m_label":	"Name:",
-																	"m_value":	"m_checkBoxInline"
-																}, {
-																	"type":	"multi-string",
-																	"m_label":	"Tooltip:",
-																	"m_value":	"Put both the declaration and the implementation in the header file"
-																}, {
-																	"type":	"colour",
-																	"m_label":	"Bg Colour:",
-																	"colour":	"<Default>"
-																}, {
-																	"type":	"colour",
-																	"m_label":	"Fg Colour:",
-																	"colour":	"<Default>"
-																}, {
-																	"type":	"font",
-																	"m_label":	"Font:",
-																	"m_value":	""
-																}, {
-																	"type":	"bool",
-																	"m_label":	"Hidden",
-																	"m_value":	false
-																}, {
-																	"type":	"bool",
-																	"m_label":	"Disabled",
-																	"m_value":	false
-																}, {
-																	"type":	"bool",
-																	"m_label":	"Focused",
-																	"m_value":	false
-																}, {
-																	"type":	"string",
-																	"m_label":	"Class Name:",
-																	"m_value":	""
-																}, {
-																	"type":	"string",
-																	"m_label":	"Include File:",
-																	"m_value":	""
-																}, {
-																	"type":	"string",
-																	"m_label":	"Style:",
-																	"m_value":	""
-																}, {
-																	"type":	"string",
-																	"m_label":	"Label:",
-																	"m_value":	"Inline class"
-																}, {
-																	"type":	"bool",
-																	"m_label":	"Value:",
-																	"m_value":	false
-																}],
-															"m_events":	[{
-																	"m_eventName":	"wxEVT_COMMAND_CHECKBOX_CLICKED",
-																	"m_eventClass":	"wxCommandEvent",
-																	"m_eventHandler":	"wxCommandEventHandler",
-																	"m_functionNameAndSignature":	"OnCheckInline(wxCommandEvent& event)",
-																	"m_description":	"Process a wxEVT_COMMAND_CHECKBOX_CLICKED event, when the checkbox is clicked.",
-																	"m_noBody":	false
-																}],
 															"m_children":	[]
 														}]
 												}]

--- a/Runtime/templates/gizmos/liteeditor-plugin.project.wizard
+++ b/Runtime/templates/gizmos/liteeditor-plugin.project.wizard
@@ -51,7 +51,7 @@
             <General OutputFile="$(IntermediateDirectory)/$(ProjectName).dll" IntermediateDirectory="$(ConfigurationName)" 
                      Command="" CommandArguments="" WorkingDirectory="./ReleaseUnicode" 
                      PreCompiledHeader="../PCH/precompiled_header_release.h" PCHInCommandLine="yes" 
-                     PCHFlags="$(shell wx-config --cxxflags --debug=no) -O2" PCHFlagsPolicy="1"
+                     PCHFlags="" PCHFlagsPolicy="1"
             />
             <Compiler Required="yes" Options="$(shell wx-config --cxxflags --debug=no ); -O2">
                 <IncludePath Value="."/>


### PR DESCRIPTION
* Add `Declare this class non-movable` option.
* Add `Prohibit further inheritance` option (i.e. the `final` keyword).
* Mark constructor and assignment operator as `= delete` if non-copyable/movable option is enabled.
* Use nullptr instead of NULL (inclusion of `<cstdlib>` is no longer required).
* Reorder checkboxes and tweak its behavior (e.g. disable 'non-copyable/movable' checkbox in singleton mode).
* Refactor some variables and functions.

Here's a little snippet of the new generated code:
```C++
#pragma once

class Foo final
{
   static Foo* ms_instance;

private:
   Foo(const Foo&) = delete;
   Foo& operator=(const Foo&) = delete;
   Foo(Foo&&) = delete;
   Foo& operator=(Foo&&) = delete;

public:
   static Foo* Instance();
   static void Release();

private:
   Foo();
   ~Foo();

};
```
```C++
#include "Foo.hpp"

Foo* Foo::ms_instance{ nullptr };

Foo::Foo()
{
}

Foo::~Foo()
{
}

Foo* Foo::Instance()
{
   if (ms_instance == nullptr) {
      ms_instance = new Foo{};
   }
   return ms_instance;
}

void Foo::Release()
{
   delete ms_instance;
   ms_instance = nullptr;
}
```

This PR also contain a minor fix in the template file.