### PR TITLE
Adjust initial dialog size

### DIFF
--- a/LiteEditor/SelectProjectsDlg.cpp
+++ b/LiteEditor/SelectProjectsDlg.cpp
@@ -42,6 +42,7 @@ SelectProjectsDlg::SelectProjectsDlg(wxWindow* parent)
     
     SetName("SelectProjectsDlg");
     WindowAttrManager::Load(this);
+    ::clSetSmallDialogBestSizeAndPosition(this);
 }
 
 SelectProjectsDlg::~SelectProjectsDlg()

--- a/LiteEditor/implement_parent_virtual_functions.cpp
+++ b/LiteEditor/implement_parent_virtual_functions.cpp
@@ -51,6 +51,7 @@ ImplementParentVirtualFunctionsDialog::ImplementParentVirtualFunctionsDialog(wxW
     EditorConfigST::Get()->ReadObject(wxT("ImplParentVirtualFunctionsData"), &data);
     m_checkBoxFormat->SetValue(data.GetFlags() & ImplParentVirtualFunctionsData::FormatText);
     DoInitialize(false);
+    ::clSetDialogBestSizeAndPosition(this);
 }
 
 ImplementParentVirtualFunctionsDialog::~ImplementParentVirtualFunctionsDialog()


### PR DESCRIPTION
Initial size of the `Rename Symbol` (a project selector) and `Implement virtual Functions` dialog was too small.
So add a call to the clSet(Small)DialogBestSizeAndPosition() just like any other dialogs.