### PR TITLE
Update to wxCrafter that allows the underlying wxVariant type to be set for a wxDataViewListCtrl text column

### DIFF
--- a/wxcrafter/data_view_list_ctrl_column.cpp
+++ b/wxcrafter/data_view_list_ctrl_column.cpp
@@ -21,7 +21,20 @@ DataViewListCtrlColumn::DataViewListCtrlColumn()
     coltype.Add("icontext");
     coltype.Add("progress");
     coltype.Add("choice");
-
+    
+    wxArrayString texttype;
+    texttype.Add("bool");
+    texttype.Add("char");
+    texttype.Add("datetime");
+    texttype.Add("double");
+    texttype.Add("list");
+    texttype.Add("long");
+    texttype.Add("longlong");
+    texttype.Add("string");
+    texttype.Add("ulonglong");
+    texttype.Add("arrstring");
+    texttype.Add("void*");
+    
     wxArrayString alignment;
     alignment.Add("wxALIGN_LEFT");
     alignment.Add("wxALIGN_RIGHT");
@@ -38,6 +51,9 @@ DataViewListCtrlColumn::DataViewListCtrlColumn()
                                    _("Column Width (in pixels)\n-1 - special value for column width meaning "
                                      "unspecified/default\n-2 - size the column automatically to fit all values")));
     AddProperty(new ChoiceProperty(PROP_DV_LISTCTRL_COL_TYPES, coltype, 2, _("Column Type")));
+    AddProperty(new ChoiceProperty(PROP_DV_LISTCTRL_TEXT_TYPES, texttype, 7, 
+                                        _("The type of object held in the variant that will be displayed as text\n"
+                                          "Relevant only for column of type 'text'")));
     AddProperty(new MultiStringsProperty(PROP_OPTIONS, _("Choices strings\nRelevant only for column of type 'choice'"),
                                          ";", "Enter choices"));
     AddProperty(new ChoiceProperty(PROP_DV_LISTCTRL_COL_ALIGN, alignment, 0, _("Cell Alignment")));
@@ -59,6 +75,7 @@ wxString DataViewListCtrlColumn::CppCtorCode() const
     wxString alignstring = PropertyString(PROP_DV_LISTCTRL_COL_ALIGN);
     wxString label = wxCrafter::UNDERSCORE(GetName());
     wxString coltype = PropertyString(PROP_DV_LISTCTRL_COL_TYPES);
+    wxString texttype = PropertyString(PROP_DV_LISTCTRL_TEXT_TYPES);    
 
     bool childOfDataViewListCtrl = GetParent()->GetType() == ID_WXDATAVIEWLISTCTRL;
     wxString cellMode = PropertyString(PROP_DV_CELLMODE);
@@ -75,9 +92,10 @@ wxString DataViewListCtrlColumn::CppCtorCode() const
         cppCode << cellMode << ", " << columnWidth << ", " << alignstring << ", " << colFlag << ");";
 
     } else if(coltype == "text") {
-        cppCode << parentName << "->AppendTextColumn(" << label << ", ";
-        if(!childOfDataViewListCtrl) cppCode << parentName << "->GetColumnCount(), ";
-        cppCode << cellMode << ", " << columnWidth << ", " << alignstring << ", " << colFlag << ");";
+        cppCode << parentName << "->AppendColumn(new wxDataViewColumn(" << label << ", "
+                << "new wxDataViewTextRenderer(\"" << texttype << "\", " << cellMode << ", " << alignstring << "), "
+                << parentName << "->GetColumnCount(), "
+                << columnWidth << ", " << alignstring << ", " << colFlag << "), \"" << texttype << "\");";
 
     } else if(coltype == "icontext") {
         cppCode << parentName << "->AppendIconTextColumn(" << label << ", ";

--- a/wxcrafter/wxgui_defs.h
+++ b/wxcrafter/wxgui_defs.h
@@ -219,6 +219,7 @@ class wxcWidget;
 #define PROP_STC_EOL_MODE wxTRANSLATE("EOL Mode")
 #define PROP_CLASS_DECORATOR wxTRANSLATE("Class Decorator")
 #define PROP_DV_LISTCTRL_COL_TYPES wxTRANSLATE("Column Type")
+#define PROP_DV_LISTCTRL_TEXT_TYPES wxTRANSLATE("Text Column Variant Type")
 #define PROP_DV_LISTCTRL_COL_ALIGN wxTRANSLATE("Alignment")
 #define PROP_DV_MODEL_CLASS_NAME wxTRANSLATE("Generated Model Class Name")
 #define PROP_DV_CELLMODE wxTRANSLATE("Cell Mode")


### PR DESCRIPTION
wxVariant has an underlying type (e.g., "bool", "datetime", "long", "string", etc.). 

The purpose of this PR is to allow wxCrafter users to select different underlying types for different columns in a wxDataViewListCtrl. This replaces the current behaviour where all columns are hard coded to "string" type.

wxVariant provides a default string conversion for each of the underlying types and this is used to display the value in the corresponding column of the wxDataViewListCtrl.

This patch can be tested by creating a simple wxFrame with a wxDataViewListCtrl in it. Text columns can be added as follows: Long, String, Date, Bool, Double, ArrayString.

The following stub can be used to test the resulting wxCrafter generated code:


```
wxArrayString strings;
	strings.Add("One");
	strings.Add("Two");
	strings.Add("Three");
	strings.Add("Four");
	for (int i = 0; i < 5; i++) 	

{
		wxVector<wxVariant> row;
		row.push_back((long)1234567890L);
		row.push_back("Hello, this is a test.");
		row.push_back(wxDateTime::Now());
		row.push_back(true);
		row.push_back((double)123.4567890);
		row.push_back(strings);
		m_pDataList->AppendItem(row);
		// wxSleep(1);
}
```

