### PR TITLE
Project changes

### DIFF
--- a/LiteEditor/CodeLiteIDE.project
+++ b/LiteEditor/CodeLiteIDE.project
@@ -2170,6 +2170,7 @@ resources.cpp: resources.xrc
         <Preprocessor Value="HAS_LIBCLANG=1"/>
         <Preprocessor Value="HAS_LIBCLANG_BRIEFCOMMENTS=1"/>
         <Preprocessor Value="CL_DEBUG_BUILD=1"/>
+        <Preprocessor Value="_HITLOGGING_DEFINED=0"/>
       </Compiler>
       <Linker Options="-g;$(shell wx-config  --libs std,stc,propgrid --unicode=yes);-Wl,--subsystem,windows -mwindows;" Required="yes">
         <LibraryPath Value="."/>
@@ -2290,6 +2291,7 @@ resources.cpp: resources.xrc
         <IncludePath Value="../sdk/clang/include"/>
         <Preprocessor Value="PHP_BUILD=1"/>
         <Preprocessor Value="HAS_LIBCLANG=0"/>
+        <Preprocessor Value="_HITLOGGING_DEFINED=0"/>
       </Compiler>
       <Linker Options=";$(shell wx-config --debug=no --unicode=yes --libs std,stc,propgrid);-Wl,--subsystem,windows -mwindows;-O2;" Required="yes">
         <LibraryPath Value="."/>


### PR DESCRIPTION
These are changes I found were needed during my work to convert the projects to build under MSys2 MinGW CodeLite git package. They are prerequisite to my conversion patches. And, are needed when not building under MSys2. 

Tim S.