### PR TITLE
Improve compiler detection

### DIFF
--- a/Plugin/CompilerLocatorCLANG.cpp
+++ b/Plugin/CompilerLocatorCLANG.cpp
@@ -31,7 +31,6 @@
 #include "fileutils.h"
 #include "GCCMetadata.hpp"
 #include "procutils.h"
-#include <array>
 #include <globals.h>
 #include <wx/regex.h>
 
@@ -283,24 +282,31 @@ bool CompilerLocatorCLANG::ReadMSWInstallLocation(const wxString& regkey, wxStri
 #endif
 }
 
+std::vector<CompilerLocatorCLANG::MSYS2Env> CompilerLocatorCLANG::GetMSYS2Envs() const
+{
+    std::vector<MSYS2Env> msys2Envs;
+    msys2Envs.push_back({ 32, "clang32" });
+    msys2Envs.push_back({ 64, "clang64" });
+    msys2Envs.push_back({ 64, "clangarm64" });
+    msys2Envs.push_back({ 32, "mingw32" });
+    msys2Envs.push_back({ 64, "mingw64" });
+    msys2Envs.push_back({ 64, "ucrt64" });
+
+    return msys2Envs;
+}
+
 void CompilerLocatorCLANG::CheckUninstRegKey(const wxString& displayName, const wxString& installFolder)
 {
     if(displayName.StartsWith("MSYS2")) {
-        // 32bit or 64bit, directory prefix
-        static const std::array<std::pair<int, wxString>, 6> msys2Envs{ { { 32, "clang32" },
-                                                                          { 64, "clang64" },
-                                                                          { 64, "clangarm64" },
-                                                                          { 32, "mingw32" },
-                                                                          { 64, "mingw64" },
-                                                                          { 64, "ucrt64" } } };
+        static const auto msys2Envs = GetMSYS2Envs();
         for(const auto& env : msys2Envs) {
             wxFileName fnBinFolder(installFolder, "");
-            fnBinFolder.AppendDir(env.second);
+            fnBinFolder.AppendDir(env.prefix);
             fnBinFolder.AppendDir("bin");
             fnBinFolder.SetFullName("clang++.exe");
             if(fnBinFolder.FileExists()) {
-                AddCompiler(fnBinFolder.GetPath(), wxString() << "CLANG " << env.first << "bit ( " << displayName
-                                                              << ", " << env.second << " )");
+                AddCompiler(fnBinFolder.GetPath(), wxString() << "CLANG " << env.cpuBits << "bit ( " << displayName
+                                                              << ", " << env.prefix << " )");
             }
         }
     }

--- a/Plugin/CompilerLocatorCLANG.h
+++ b/Plugin/CompilerLocatorCLANG.h
@@ -41,15 +41,16 @@ protected:
     wxString GetClangVersion(const wxString& clangBinary);
     wxString GetCompilerFullName(const wxString& clangBinary);
     bool ReadMSWInstallLocation(const wxString& regkey, wxString& installPath, wxString& llvmVersion);
-    CompilerPtr AddCompiler(const wxString& clangFolder, const wxString& suffix);
+    virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder);
+    CompilerPtr AddCompiler(const wxString& clangFolder, const wxString& name = "", const wxString& suffix = "");
 
 public:
     CompilerLocatorCLANG();
     virtual ~CompilerLocatorCLANG();
 
 public:
-    bool Locate();
-    CompilerPtr Locate(const wxString& folder);
+    virtual bool Locate();
+    virtual CompilerPtr Locate(const wxString& folder);
 };
 
 #endif // COMPILERLOCATORCLANG_H

--- a/Plugin/CompilerLocatorCLANG.h
+++ b/Plugin/CompilerLocatorCLANG.h
@@ -33,6 +33,11 @@
 
 class WXDLLIMPEXP_SDK CompilerLocatorCLANG : public ICompilerLocator
 {
+    struct MSYS2Env {
+        int cpuBits;     // 32bit or 64bit
+        wxString prefix; // directory prefix
+    };
+
 protected:
     void MSWLocate();
     void AddTools(CompilerPtr compiler, const wxString& installFolder, const wxString& suffix = "");
@@ -41,6 +46,7 @@ protected:
     wxString GetClangVersion(const wxString& clangBinary);
     wxString GetCompilerFullName(const wxString& clangBinary);
     bool ReadMSWInstallLocation(const wxString& regkey, wxString& installPath, wxString& llvmVersion);
+    std::vector<MSYS2Env> GetMSYS2Envs() const;
     virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder);
     CompilerPtr AddCompiler(const wxString& clangFolder, const wxString& name = "", const wxString& suffix = "");
 

--- a/Plugin/CompilerLocatorCrossGCC.cpp
+++ b/Plugin/CompilerLocatorCrossGCC.cpp
@@ -74,9 +74,7 @@ CompilerPtr CompilerLocatorCrossGCC::Locate(const wxString& folder, bool clear)
         }
 #endif
         wxFileName filename(matches.Item(i));
-        if(filename.GetName() == "mingw32-gcc" || filename.GetName() == "x86_64-w64-mingw32-gcc") {
-            // Don't include standard mingw32-gcc (32 and 64 bit) binaries
-            // they will be picked up later by the MinGW locator
+        if(!IsCrossGCC(filename.GetName())) {
             continue;
         }
 
@@ -97,6 +95,23 @@ CompilerPtr CompilerLocatorCrossGCC::Locate(const wxString& folder, bool clear)
     } else {
         return *m_compilers.begin();
     }
+}
+
+bool CompilerLocatorCrossGCC::IsCrossGCC(const wxString& name) const
+{
+#ifdef __WXMSW__
+    if(name == "mingw32-gcc" || name == "i686-w64-mingw32-gcc" || name == "x86_64-w64-mingw32-gcc") {
+        // Don't include standard mingw32-gcc (32 and 64 bit) binaries
+        // they will be picked up later by the MinGW locator
+        return false;
+    }
+#elif defined(__WXGTK__)
+    if(name == "i686-linux-gnu-gcc" || name == "x86_64-linux-gnu-gcc") {
+        // Standard gcc will be picked up later by the GCC locator
+        return false;
+    }
+#endif
+    return true;
 }
 
 bool CompilerLocatorCrossGCC::Locate()

--- a/Plugin/CompilerLocatorCrossGCC.h
+++ b/Plugin/CompilerLocatorCrossGCC.h
@@ -39,6 +39,7 @@ protected:
     void AddTool(CompilerPtr compiler, const wxString &toolname,
                  const wxString &toolpath, const wxString &extraArgs = "");
     CompilerPtr Locate(const wxString& folder, bool clear);
+    bool IsCrossGCC(const wxString& name) const;
 
 public:
     CompilerLocatorCrossGCC();

--- a/Plugin/CompilerLocatorMinGW.cpp
+++ b/Plugin/CompilerLocatorMinGW.cpp
@@ -148,44 +148,7 @@ bool CompilerLocatorMinGW::Locate()
     }
 
     // check uninstall keys
-    std::vector<wxString> unInstKey;
-    unInstKey.push_back("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall");
-    unInstKey.push_back("SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall");
-
-    std::vector<wxRegKey::StdKey> regBase;
-    regBase.push_back(wxRegKey::HKCU);
-    regBase.push_back(wxRegKey::HKLM);
-
-    for(size_t i = 0; i < regBase.size(); ++i) {
-        for(size_t j = 0; j < unInstKey.size(); ++j) {
-            wxRegKey regKey(regBase[i], unInstKey[j]);
-            if(!regKey.Exists() || !regKey.Open(wxRegKey::Read))
-                continue;
-
-            size_t subkeys = 0;
-            regKey.GetKeyInfo(&subkeys, NULL, NULL, NULL);
-            wxString keyName;
-            long keyIndex = 0;
-            regKey.GetFirstKey(keyName, keyIndex);
-
-            for(size_t k = 0; k < subkeys; ++k) {
-                wxRegKey subKey(regKey, keyName);
-                if(!subKey.Exists() || !subKey.Open(wxRegKey::Read))
-                    continue;
-
-                wxString displayName, installFolder;
-                if(subKey.HasValue("DisplayName") && subKey.HasValue("InstallLocation") &&
-                   subKey.QueryValue("DisplayName", displayName) &&
-                   subKey.QueryValue("InstallLocation", installFolder)) {
-                    CheckRegKey(displayName, installFolder);
-                }
-
-                subKey.Close();
-                regKey.GetNextKey(keyName, keyIndex);
-            }
-            regKey.Close();
-        }
-    }
+    ScanUninstRegKeys();
 
     // Last: many people install MinGW by simply extracting it into the
     // root folder:
@@ -244,7 +207,7 @@ bool CompilerLocatorMinGW::Locate()
     return !m_compilers.empty();
 }
 
-void CompilerLocatorMinGW::CheckRegKey(const wxString& displayName, const wxString& installFolder)
+void CompilerLocatorMinGW::CheckUninstRegKey(const wxString& displayName, const wxString& installFolder)
 {
     if(displayName.StartsWith("TDM-GCC")) {
         wxFileName fnTDMBinFolder(installFolder, "");

--- a/Plugin/CompilerLocatorMinGW.h
+++ b/Plugin/CompilerLocatorMinGW.h
@@ -38,7 +38,7 @@ protected:
     void AddTool(CompilerPtr compiler, const wxString &toolname, const wxString &toolpath, const wxString &extraArgs = "");
     wxString FindBinFolder(const wxString &parentPath);
     wxString GetGCCVersion(const wxString &gccBinary);
-    void CheckRegKey(const wxString& displayName, const wxString& installFolder);
+    virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder);
 
 public:
     CompilerLocatorMinGW();

--- a/Plugin/CompilersDetectorManager.h
+++ b/Plugin/CompilersDetectorManager.h
@@ -62,6 +62,9 @@ public:
 
     void MSWFixClangToolChain(CompilerPtr compiler,
                               const ICompilerLocator::CompilerVec_t& allCompilers = ICompilerLocator::CompilerVec_t());
+
+    wxString GetRealCXXPath(const CompilerPtr compiler) const;
+    wxString ResolveLink(const wxString& path) const;
 };
 
 #endif // COMPILERSDETECTORMANAGER_H

--- a/Plugin/ICompilerLocator.cpp
+++ b/Plugin/ICompilerLocator.cpp
@@ -54,11 +54,11 @@ wxArrayString ICompilerLocator::GetPaths() const
 void ICompilerLocator::ScanUninstRegKeys()
 {
 #ifdef __WXMSW__
-    static const std::array<wxString, 2> unInstKey{
+    static const std::array<wxString, 2> unInstKey = {
         "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
         "SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
     };
-    static const std::array<wxRegKey::StdKey, 2> regBase{ wxRegKey::HKCU, wxRegKey::HKLM };
+    static const std::array<wxRegKey::StdKey, 2> regBase = { wxRegKey::HKCU, wxRegKey::HKLM };
 
     for(size_t i = 0; i < regBase.size(); ++i) {
         for(size_t j = 0; j < unInstKey.size(); ++j) {

--- a/Plugin/ICompilerLocator.h
+++ b/Plugin/ICompilerLocator.h
@@ -58,6 +58,12 @@ protected:
     ICompilerLocator::CompilerVec_t m_compilers;
     wxArrayString GetPaths() const;
 
+    /**
+     * @brief windows only: scan registry for uninstall information
+     */
+    void ScanUninstRegKeys();
+    virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder) {}
+
 public:
     ICompilerLocator();
     virtual ~ICompilerLocator();

--- a/Plugin/compiler.cpp
+++ b/Plugin/compiler.cpp
@@ -637,6 +637,7 @@ void Compiler::AddDefaultGnuComplierOptions()
     AddCompilerOption("-std=c++11", "Enable C++11 features");
     AddCompilerOption("-std=c++14", "Enable C++14 features");
     AddCompilerOption("-std=c++17", "Enable C++17 features");
+    AddCompilerOption("-std=c++20", "Enable C++20 features");
 }
 
 void Compiler::AddDefaultGnuLinkerOptions()


### PR DESCRIPTION
1. Improve duplicated compiler detection
Previously, a dummy C++ compiler name `cxx` was used for the detection. Therefore, all of the `/usr/bin/g++`, `/usr/bin/clang++` or any other compilers are considered identical (i.e. `/usr/bin/cxx`).
To fix this, follow the symlink recursively to check the compiler is really the identical one; wxWidgets 3.1.5 has [new portable API](https://docs.wxwidgets.org/3.1.5/classwx_file_name.html#a9c4d1743f75827d99951d033b00719ba) to achieve this.

2. Improve cross MinGW detection
The MinGW toolchain for Linux (known as [mingw-w64 package](https://packages.ubuntu.com/hirsute/mingw-w64) in Debian and Ubuntu) will be detected as Cross GCC.

3. Add MSYS2 Clang detection
MSYS2 provides its own [LLVM/Clang toolchain package](https://packages.msys2.org/base/mingw-w64-clang) in addition to the GNU GCC toolchain.

4. Add `Enable C++20 features` option by default

This is how the detection works on my environment:
![linux-compilers](https://user-images.githubusercontent.com/32811754/132097293-f2990ae2-59b1-4d27-b5bd-2d794342c128.png)
![windows-compilers](https://user-images.githubusercontent.com/32811754/132117511-477fcb3f-2037-42e2-80f4-1c2a73da7aa9.png)