### PR TITLE
Change QuickFindBar behaviour to the best of both worlds (#2806)

### DIFF
--- a/LiteEditor/frame.cpp
+++ b/LiteEditor/frame.cpp
@@ -5863,7 +5863,6 @@ void clMainFrame::OnFindSelection(wxCommandEvent& event)
     wxString selection =
         editor->GetSelection().IsEmpty() ? GetMainBook()->GetFindBar()->GetFindWhat() : editor->GetSelection();
     find_bar->SetFindWhat(selection);
-    GetMainBook()->ShowQuickBar(true);
     find_bar->FindNext();
 }
 
@@ -5878,7 +5877,6 @@ void clMainFrame::OnFindSelectionPrev(wxCommandEvent& event)
     wxString selection =
         editor->GetSelection().IsEmpty() ? GetMainBook()->GetFindBar()->GetFindWhat() : editor->GetSelection();
     find_bar->SetFindWhat(selection);
-    GetMainBook()->ShowQuickBar(true);
     find_bar->FindPrevious();
 }
 


### PR DESCRIPTION
This minor tweak changes the QuickFindBar behaviour to the best of both worlds in respect to issue #2806

With this change quickfindbar will show and get focus upon Find...
The change is that pressing Find Next/Prev will not affect focus.
This means that if focus already is at the quickfindbar it will stay there.
But if focus is at the editor - Find Next/Prev will not change focus from the editor and back to the quickfindbar.
This has the advantage that you can instantly find and edit - without having to press ESC to get focus back to the editor.

Question: would you prefer a setting to control this behaviour ? or ?