### PR TITLE
Workspace: Locally remember the selected build configuration

### DIFF
--- a/LiteEditor/configuration_manager_dlg.cpp
+++ b/LiteEditor/configuration_manager_dlg.cpp
@@ -119,7 +119,7 @@ void ConfigurationManagerDlg::PopulateConfigurations()
     } else if(m_choiceConfigurations->GetCount() > 2) {
         m_choiceConfigurations->SetSelection(2);
     } else {
-        m_choiceConfigurations->Append(_("Debug"));
+        m_choiceConfigurations->Append("Debug");
         m_choiceConfigurations->SetSelection(2);
     }
 

--- a/Plugin/configuration_mapping.h
+++ b/Plugin/configuration_mapping.h
@@ -61,19 +61,16 @@ public:
 private:
     wxString m_name;
     ConfigMappingList m_mappingList;
-    bool m_isSelected;
     wxString m_environmentVariables;
 
 public:
     void RenameProject(const wxString& oldname, const wxString& newname);
     WorkspaceConfiguration();
     WorkspaceConfiguration(wxXmlNode* node);
-    WorkspaceConfiguration(const wxString& name, bool selected);
+    WorkspaceConfiguration(const wxString& name);
     virtual ~WorkspaceConfiguration();
     wxXmlNode* ToXml() const;
 
-    void SetSelected(bool selected) { m_isSelected = selected; }
-    bool IsSelected() const { return m_isSelected; }
     const wxString& GetName() const { return m_name; }
     const ConfigMappingList& GetMapping() const { return m_mappingList; }
     void SetConfigMappingList(const ConfigMappingList& mapList) { m_mappingList = mapList; }
@@ -90,21 +87,23 @@ typedef SmartPtr<WorkspaceConfiguration> WorkspaceConfigurationPtr;
 class WXDLLIMPEXP_SDK BuildMatrix
 {
     std::list<WorkspaceConfigurationPtr> m_configurationList;
+    wxString m_selectedConfiguration;
 
 protected:
     WorkspaceConfigurationPtr FindConfiguration(const wxString& name) const;
+    void SelectFirstConfiguration();
 
 public:
     void RenameProject(const wxString& oldname, const wxString& newname);
 
-    BuildMatrix(wxXmlNode* node);
+    BuildMatrix(wxXmlNode* node, const wxString& selectedConfiguration);
     virtual ~BuildMatrix();
     wxXmlNode* ToXml() const;
-    const std::list<WorkspaceConfigurationPtr>& GetConfigurations() const { return m_configurationList; };
+    const std::list<WorkspaceConfigurationPtr>& GetConfigurations() const { return m_configurationList; }
     void RemoveConfiguration(const wxString& configName);
     void SetConfiguration(WorkspaceConfigurationPtr conf);
     wxString GetProjectSelectedConf(const wxString& configName, const wxString& project) const;
-    wxString GetSelectedConfigurationName() const;
+    wxString GetSelectedConfigurationName() const { return m_selectedConfiguration; }
     void SetSelectedConfigurationName(const wxString& name);
     WorkspaceConfigurationPtr GetConfigurationByName(const wxString& name) const;
 };

--- a/Plugin/localworkspace.cpp
+++ b/Plugin/localworkspace.cpp
@@ -446,6 +446,36 @@ void LocalWorkspace::SetParserFlags(size_t flags)
     SaveXmlFile();
 }
 
+wxString LocalWorkspace::GetSelectedBuildConfiguration()
+{
+    if(!SanityCheck())
+        return wxT("");
+
+    wxXmlNode* node = XmlUtils::FindFirstByTagName(m_doc.GetRoot(), wxT("BuildMatrix"));
+    wxString confName;
+    if(node) {
+        confName = node->GetPropVal(wxT("SelectedConfiguration"), wxT(""));
+    }
+    return confName;
+}
+
+void LocalWorkspace::SetSelectedBuildConfiguration(const wxString& confName)
+{
+    if(!SanityCheck())
+        return;
+
+    wxXmlNode* node = XmlUtils::FindFirstByTagName(m_doc.GetRoot(), wxT("BuildMatrix"));
+    if(node) {
+        m_doc.GetRoot()->RemoveChild(node);
+        delete node;
+    }
+    node = new wxXmlNode(m_doc.GetRoot(), wxXML_ELEMENT_NODE, wxT("BuildMatrix"));
+    if(!confName.empty()) {
+        node->AddProperty(wxT("SelectedConfiguration"), confName);
+    }
+    SaveXmlFile();
+}
+
 wxString LocalWorkspace::GetActiveEnvironmentSet()
 {
     if(!SanityCheck())

--- a/Plugin/localworkspace.h
+++ b/Plugin/localworkspace.h
@@ -333,6 +333,12 @@ public:
     wxString GetCustomData(const wxString& name);
 
     /**
+     * @brief set and get the currently selected build configuration name
+     */
+    void SetSelectedBuildConfiguration(const wxString& confName);
+    wxString GetSelectedBuildConfiguration();
+
+    /**
      * @brief set and get the active environment variables set name
      */
     void SetActiveEnvironmentSet(const wxString& setName);

--- a/Plugin/workspace.cpp
+++ b/Plugin/workspace.cpp
@@ -167,6 +167,8 @@ void clCxxWorkspace::SetBuildMatrix(BuildMatrixPtr mapping)
     parent->AddChild(mapping->ToXml());
     SaveXmlFile();
 
+    GetLocalWorkspace()->SetSelectedBuildConfiguration(mapping->GetSelectedConfigurationName());
+
     // force regeneration of makefiles for all projects
     for(ProjectMap_t::iterator iter = m_projects.begin(); iter != m_projects.end(); iter++) {
         iter->second->SetModified(true);
@@ -1182,7 +1184,8 @@ void clCxxWorkspace::ReplaceCompilers(wxStringMap_t& compilers)
 
 void clCxxWorkspace::DoUpdateBuildMatrix()
 {
-    m_buildMatrix.Reset(new BuildMatrix(XmlUtils::FindFirstByTagName(m_doc.GetRoot(), "BuildMatrix")));
+    m_buildMatrix.Reset(new BuildMatrix(XmlUtils::FindFirstByTagName(m_doc.GetRoot(), "BuildMatrix"),
+                                        GetLocalWorkspace()->GetSelectedBuildConfiguration()));
 }
 
 void clCxxWorkspace::RenameProject(const wxString& oldname, const wxString& newname)


### PR DESCRIPTION
Currently selected workspace build configuration (such as `Debug`/`Release`) is now stored into the local workspace file (the same way as filesystem workspace).
Re-selecting the build configuration won't modify the root workspace file anymore, so it won't appear unstaged in Git (as long as `.codelite` is .gitignore'd) everytime you pick a different build configuration.