### PR TITLE
Compiler: Tweak some default compiler options

### DIFF
--- a/Plugin/CompilersDetectorManager.cpp
+++ b/Plugin/CompilersDetectorManager.cpp
@@ -84,24 +84,12 @@ bool CompilersDetectorManager::Locate()
     for(auto locator : m_detectors) {
         if(locator->Locate()) {
             for(auto compiler : locator->GetCompilers()) {
-                // We'll detect the duplicated compilers by:
-                // [1] Recursively resolving the symbolic links, e.g.
-                //       /usr/bin/g++ (GCC)
-                //         -> /usr/bin/g++-9 (GCC-9)
-                //           -> /usr/bin/x86_64-linux-gnu-g++-9
-                // [2] Checking whether an identical compiler has already been found
-                //     (some executables are same, but not symlinked; i.e. a distinct copy or hard-linked),
-                //     e.g.
-                //       /bin/clang++-12 (CLANG-12)
-                //         -> /lib/llvm-12/bin/clang++
-                //           -> /lib/llvm-12/bin/clang
-                //     and
-                //       /usr/bin/clang++-12 (CLANG-12)
-                //         -> /usr/lib/llvm-12/bin/clang++
-                //           -> /usr/lib/llvm-12/bin/clang
+                // Resolve the symlinks and detect compiler duplication, e.g.:
+                //   /usr/bin/g++ (GCC)
+                //     -> /usr/bin/g++-9 (GCC-9)
+                //       -> /usr/bin/x86_64-linux-gnu-g++-9
                 wxString cxxPath = GetRealCXXPath(compiler);
-                if(S.count(compiler->GetName()) == 0 && !cxxPath.IsEmpty() && S.count(cxxPath) == 0) {
-                    S.insert(compiler->GetName());
+                if(!cxxPath.IsEmpty() && S.count(cxxPath) == 0) {
                     S.insert(cxxPath);
                     m_compilersFound.push_back(compiler);
                 }
@@ -217,40 +205,5 @@ wxString CompilersDetectorManager::GetRealCXXPath(const CompilerPtr compiler) co
         // rustc is a dummy compiler, do not touch it
         return compiler->GetTool("CXX");
     }
-    return ResolveLink(compiler->GetTool("CXX"));
-}
-
-wxString CompilersDetectorManager::ResolveLink(const wxString& path) const
-{
-    return FileUtils::RealPath(path);
-#if 0
-#if !wxCHECK_VERSION(3, 1, 5)
-    // Try old 'directory-only' comparison
-    return wxFileName(path).GetPath();
-#elif defined(__WXMSW__)
-    // There is no symlink support in Windows
-    return path;
-#else
-    wxString actualPath, symlinkPath = path;
-    wxStringSet_t pathStack;
-    while(true) {
-        actualPath = wxFileName(symlinkPath).ResolveLink().GetFullPath();
-        if(actualPath.IsEmpty()) {
-            // The link is no longer alive
-            return wxEmptyString;
-        }
-        if(actualPath == symlinkPath) {
-            // This is the real file we're looking for
-            break;
-        }
-        if(pathStack.count(actualPath) > 0) {
-            // Infinite-recursion link detected
-            return wxEmptyString;
-        }
-        symlinkPath = actualPath;
-        pathStack.insert(actualPath);
-    }
-    return actualPath;
-#endif
-#endif
+    return FileUtils::RealPath(compiler->GetTool("CXX"));
 }

--- a/Plugin/CompilersDetectorManager.h
+++ b/Plugin/CompilersDetectorManager.h
@@ -64,7 +64,6 @@ public:
                               const ICompilerLocator::CompilerVec_t& allCompilers = ICompilerLocator::CompilerVec_t());
 
     wxString GetRealCXXPath(const CompilerPtr compiler) const;
-    wxString ResolveLink(const wxString& path) const;
 };
 
 #endif // COMPILERSDETECTORMANAGER_H

--- a/Plugin/compiler.cpp
+++ b/Plugin/compiler.cpp
@@ -613,19 +613,18 @@ bool Compiler::IsGnuCompatibleCompiler() const
 void Compiler::AddDefaultGnuComplierOptions()
 {
     // Add GCC / CLANG default compiler options
-    AddCompilerOption("-O", "Optimize generated code. (for speed)");
-    AddCompilerOption("-O1", "Optimize more (for speed)");
-    AddCompilerOption("-O2", "Optimize even more (for speed)");
-    AddCompilerOption("-O3", "Optimize fully (for speed)");
-    AddCompilerOption("-Os", "Optimize generated code (for size)");
+    AddCompilerOption("-O", "Optimize generated code for speed");
+    AddCompilerOption("-O1", "Optimize more for speed");
+    AddCompilerOption("-O2", "Optimize even more for speed");
+    AddCompilerOption("-O3", "Optimize fully for speed");
+    AddCompilerOption("-Os", "Optimize generated code for size");
     AddCompilerOption("-O0", "Optimize for debugging");
     AddCompilerOption("-W", "Enable standard compiler warnings");
     AddCompilerOption("-Wall", "Enable all compiler warnings");
     AddCompilerOption("-Wfatal-errors", "Stop compiling after first error");
     AddCompilerOption("-Wmain", "Warn if main() is not conformant");
-    AddCompilerOption(
-        "-ansi",
-        "In C mode, support all ISO C90 programs. In C++ mode, remove GNU extensions that conflict with ISO C++");
+    AddCompilerOption("-ansi",
+                      "In C mode, this is equivalent to -std=c90. In C++ mode, it is equivalent to -std=c++98");
     AddCompilerOption("-fexpensive-optimizations", "Expensive optimizations");
     AddCompilerOption("-fopenmp", "Enable OpenMP (compilation)");
     AddCompilerOption("-g", "Produce debugging information");
@@ -633,7 +632,8 @@ void Compiler::AddDefaultGnuComplierOptions()
     AddCompilerOption("-pedantic-errors", "Treat as errors the warnings demanded by strict ISO C and ISO C++");
     AddCompilerOption("-pg", "Profile code when executed");
     AddCompilerOption("-w", "Inhibit all warning messages");
-    AddCompilerOption("-std=c99", "Enable ANSI C99 features");
+    AddCompilerOption("-std=c99", "Enable C99 features");
+    AddCompilerOption("-std=c11", "Enable C11 features");
     AddCompilerOption("-std=c++11", "Enable C++11 features");
     AddCompilerOption("-std=c++14", "Enable C++14 features");
     AddCompilerOption("-std=c++17", "Enable C++17 features");

--- a/Plugin/configuration_mapping.cpp
+++ b/Plugin/configuration_mapping.cpp
@@ -46,7 +46,7 @@ BuildMatrix::BuildMatrix(wxXmlNode* node, const wxString& selectedConfiguration)
     }
 
     // verify the selected configuration
-    if(m_selectedConfiguration.empty() || !FindConfiguration(m_selectedConfiguration)) {
+    if(m_selectedConfiguration.IsEmpty() || !FindConfiguration(m_selectedConfiguration)) {
         SelectFirstConfiguration();
     }
 }

--- a/Plugin/localworkspace.cpp
+++ b/Plugin/localworkspace.cpp
@@ -470,7 +470,7 @@ void LocalWorkspace::SetSelectedBuildConfiguration(const wxString& confName)
         delete node;
     }
     node = new wxXmlNode(m_doc.GetRoot(), wxXML_ELEMENT_NODE, wxT("BuildMatrix"));
-    if(!confName.empty()) {
+    if(!confName.IsEmpty()) {
         node->AddProperty(wxT("SelectedConfiguration"), confName);
     }
     SaveXmlFile();


### PR DESCRIPTION
1. Make `-O*` descriptions consistent.
2. Update `-ansi` description according to the [current GCC manual](https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html#index-ANSI-support).
3. Add `Enable C11 features` option which can be used to disable GNU C extensions.

This PR also contains a minor code refactoring for my earlier PRs.