### PR TITLE
wxCrafter: Fix string literal issue in XRC preview

### DIFF
--- a/wxcrafter/RearrangeListWrapper.cpp
+++ b/wxcrafter/RearrangeListWrapper.cpp
@@ -4,7 +4,7 @@
 
 RearrangeListWrapper::RearrangeListWrapper()
 {
-    SetPropertyString("wxCheckListBox", "wxRearrangeList");
+    SetPropertyString(_("Common Settings"), "wxRearrangeList");
     SetType(ID_WXREARRANGELIST);
     m_namePattern = "m_rearrangelist";
     SetName(GenerateName());

--- a/wxcrafter/check_list_box_wrapper.cpp
+++ b/wxcrafter/check_list_box_wrapper.cpp
@@ -71,7 +71,7 @@ void CheckListBoxWrapper::ToXRC(wxString& text, XRC_TYPE type) const
     text << wxT("<content>");
 
     for(size_t i = 0; i < options.GetCount(); i++) {
-        text << wxT("<item checked=\"0\">") << options.Item(i) << wxT("</item>");
+        text << wxT("<item checked=\"0\">") << wxCrafter::XMLEncode(options.Item(i)) << wxT("</item>");
     }
     text << wxT("</content>");
 

--- a/wxcrafter/data_view_list_ctrl_column.cpp
+++ b/wxcrafter/data_view_list_ctrl_column.cpp
@@ -136,7 +136,7 @@ void DataViewListCtrlColumn::ToXRC(wxString& text, XRC_TYPE type) const
              << PropertyString(PROP_DV_LISTCTRL_COL_TYPES) << wxT("</coltype>") << wxT("<width>")
              << PropertyString(PROP_WIDTH) << wxT("</width>") << wxT("<label>") << wxCrafter::CDATA(GetName())
              << wxT("</label>") << wxT("<align>") << PropertyString(PROP_DV_LISTCTRL_COL_ALIGN) << wxT("</align>")
-             << wxT("<cellmode>") << PropertyString(PROP_DV_CELLMODE) << wxT("</cellmode>") << "<choices>"
-             << PropertyString(PROP_OPTIONS) << "</choices>" << wxT("</object>");
+             << wxT("<cellmode>") << PropertyString(PROP_DV_CELLMODE) << wxT("</cellmode>") << wxT("<choices>")
+             << wxCrafter::XMLEncode(PropertyString(PROP_OPTIONS)) << wxT("</choices>") << wxT("</object>");
     }
 }

--- a/wxcrafter/dialog_wrapper.cpp
+++ b/wxcrafter/dialog_wrapper.cpp
@@ -111,7 +111,7 @@ void DialogWrapper::ToXRC(wxString& text, XRC_TYPE type) const
                                                  // wxBOTH/wxVERTICAL/wxHORIZONTAL
     }
 
-    text << XRCPrefix() << wxT("<title>") << PropertyString(PROP_TITLE) << wxT("</title>") << centred
+    text << XRCPrefix() << wxT("<title>") << wxCrafter::CDATA(PropertyString(PROP_TITLE)) << wxT("</title>") << centred
          << XRCStyle(type != wxcWidget::XRC_LIVE) // The parameter is to add the wxSTAY_ON_TOP, but not if we're 'live'
          << XRCCommonAttributes() << XRCSize();
 

--- a/wxcrafter/frame_wrapper.cpp
+++ b/wxcrafter/frame_wrapper.cpp
@@ -74,7 +74,8 @@ void FrameWrapper::ToXRC(wxString& text, XRC_TYPE type) const
         xrcPrefix = "wxMiniFrame";
     }
     
-    text << XRCPrefix("wxFrame") << wxT("<title>") << PropertyString(PROP_TITLE) << wxT("</title>") << centred
+    text << XRCPrefix("wxFrame") << wxT("<title>") << wxCrafter::CDATA(PropertyString(PROP_TITLE)) << wxT("</title>")
+         << centred
          << XRCStyle(type != wxcWidget::XRC_LIVE) // The parameter is to add the wxSTAY_ON_TOP, but not if we're 'live'
          << XRCSize() << XRCCommonAttributes();
 

--- a/wxcrafter/list_ctrl_column_wrapper.cpp
+++ b/wxcrafter/list_ctrl_column_wrapper.cpp
@@ -41,8 +41,8 @@ wxString ListCtrlColumnWrapper::GetWxClassName() const { return wxT(""); }
 
 void ListCtrlColumnWrapper::ToXRC(wxString& text, XRC_TYPE type) const
 {
-    text << wxT("<object class=\"listcol\">") << wxT("<text>") << GetName() << wxT("</text>") << wxT("<width>")
-         << PropertyString(PROP_WIDTH) << wxT("</width>") << wxT("</object>");
+    text << wxT("<object class=\"listcol\">") << wxT("<text>") << wxCrafter::CDATA(GetName()) << wxT("</text>")
+         << wxT("<width>") << PropertyString(PROP_WIDTH) << wxT("</width>") << wxT("</object>");
 }
 
 void ListCtrlColumnWrapper::LoadPropertiesFromXRC(const wxXmlNode* node)

--- a/wxcrafter/wizard_wrapper.cpp
+++ b/wxcrafter/wizard_wrapper.cpp
@@ -107,7 +107,8 @@ void WizardWrapper::ToXRC(wxString& text, XRC_TYPE type) const
                                                  // wxBOTH/wxVERTICAL/wxHORIZONTAL
     }
 
-    text << XRCPrefix() << wxT("<title>") << PropertyString(PROP_TITLE) << wxT("</title>") << centred << XRCBitmap()
+    text << XRCPrefix() << wxT("<title>") << wxCrafter::CDATA(PropertyString(PROP_TITLE)) << wxT("</title>") << centred
+         << XRCBitmap()
          << XRCStyle(type != wxcWidget::XRC_LIVE) // The parameter is to add the wxSTAY_ON_TOP, but not if we're 'live'
          << XRCCommonAttributes();
 


### PR DESCRIPTION
1. Add some missing string escapes for XRC preview code
This will break whole XRC preview because of the syntax error.

2. Fix wxRearrangeList property label