### PR TITLE
QuickFindBar: Fix 'found N results' message

### DIFF
--- a/LiteEditor/quickfindbar.cpp
+++ b/LiteEditor/quickfindbar.cpp
@@ -638,8 +638,7 @@ void QuickFindBar::DoHighlightMatches(bool checked)
         }
 
         wxString message;
-        message << "Found"
-                << " " << (matches.size() > 1 ? _("results") : _("result"));
+        message << _("Found ") << matches.size() << wxPLURAL(" result", " results", matches.size());
         m_matchesFound->SetLabel(message);
 
     } else {


### PR DESCRIPTION
Currently, the message just says `Found result(s)`, but I think the intended one was `Found N result(s)`.