### PR TITLE
codelite_indexer/ctags: Several fixes for C++11/C++17 keywords

### DIFF
--- a/sdk/codelite_indexer/libctags/c.c
+++ b/sdk/codelite_indexer/libctags/c.c
@@ -59,7 +59,7 @@ typedef enum eException {
  */
 typedef enum eKeywordId {
     KEYWORD_NONE = -1,
-    KEYWORD_ATTRIBUTE, KEYWORD_ABSTRACT,
+    KEYWORD_ALIGNAS, KEYWORD_ATTRIBUTE, KEYWORD_ABSTRACT,
     KEYWORD_BOOLEAN, KEYWORD_BYTE, KEYWORD_BAD_STATE, KEYWORD_BAD_TRANS,
     KEYWORD_BIND, KEYWORD_BIND_VAR, KEYWORD_BIT,
     KEYWORD_CASE, KEYWORD_CATCH, KEYWORD_CHAR, KEYWORD_CLASS, KEYWORD_CONST,
@@ -375,6 +375,7 @@ static const keywordDesc KeywordTable [] = {
     /*                                       ANSI C  |  C# Java    */
     /*                                            |  |  |  |  Vera */
     /* keyword          keyword ID                |  |  |  |  |    */
+    { "alignas",        KEYWORD_ALIGNAS,        { 0, 1, 0, 0, 0 } },
     { "__attribute__",  KEYWORD_ATTRIBUTE,      { 1, 1, 1, 0, 0 } },
     { "abstract",       KEYWORD_ABSTRACT,       { 0, 0, 1, 1, 0 } },
     { "bad_state",      KEYWORD_BAD_STATE,      { 0, 0, 0, 0, 1 } },
@@ -1936,6 +1937,10 @@ static void processToken (tokenInfo *const token, statementInfo *const st)
         break;
     case KEYWORD_ABSTRACT:
         st->implementation = IMP_ABSTRACT;
+        break;
+    case KEYWORD_ALIGNAS:
+        skipParens ();
+        initToken (token);
         break;
     case KEYWORD_ATTRIBUTE:
         skipParens ();

--- a/sdk/codelite_indexer/libctags/c.c
+++ b/sdk/codelite_indexer/libctags/c.c
@@ -149,9 +149,9 @@ typedef enum eDeclaration {
     DECL_STRUCT,
     DECL_TASK,           /* Vera task */
     DECL_UNION,
-    DECL_COUNT,
     DECL_STRONG_ENUM,
     DECL_USING,
+    DECL_COUNT,
 } declType;
 
 typedef enum eVisibilityType {
@@ -615,7 +615,7 @@ static const char *declString (const declType declaration)
     static const char *const names [] = {
         "?", "base", "class", "enum", "event", "function", "ignore",
         "interface", "namespace", "no mangle", "package", "program",
-        "struct", "task", "union",
+        "struct", "task", "union", "enum class", "using"
     };
     Assert (sizeof (names) / sizeof (names [0]) == DECL_COUNT);
     Assert ((int) declaration < DECL_COUNT);

--- a/sdk/codelite_indexer/libctags/c.c
+++ b/sdk/codelite_indexer/libctags/c.c
@@ -2103,6 +2103,20 @@ static void processToken (tokenInfo *const token, statementInfo *const st)
         }
         break;
 
+    case KEYWORD_FINAL:
+    case KEYWORD_OVERRIDE:
+        /* C++11 final and override is a context-dependent keyword.
+         * It will be treated as a keyword only if it makes sense.
+         * For final/override member functions, see skipPostArgumentStuff (). */
+        if ( st->declaration == DECL_CLASS || st->declaration == DECL_STRUCT ) {
+            initToken (token);
+        } else {
+            token->type = TOKEN_NAME;
+            token->keyword = KEYWORD_NONE;
+            processName (st);
+        }
+        break;
+
     case KEYWORD_FOR:
     case KEYWORD_FOREACH:
     case KEYWORD_IF:

--- a/sdk/codelite_indexer/libctags/c.c
+++ b/sdk/codelite_indexer/libctags/c.c
@@ -77,7 +77,7 @@ typedef enum eKeywordId {
     KEYWORD_LOCAL, KEYWORD_LONG,
     KEYWORD_M_BAD_STATE, KEYWORD_M_BAD_TRANS, KEYWORD_M_STATE, KEYWORD_M_TRANS,
     KEYWORD_MUTABLE,
-    KEYWORD_NAMESPACE, KEYWORD_NEW, KEYWORD_NEWCOV, KEYWORD_NATIVE,
+    KEYWORD_NAMESPACE, KEYWORD_NEW, KEYWORD_NEWCOV, KEYWORD_NATIVE, KEYWORD_NOEXCEPT,
     KEYWORD_OPERATOR, KEYWORD_OUTPUT, KEYWORD_OVERLOAD, KEYWORD_OVERRIDE,
     KEYWORD_PACKED, KEYWORD_PORT, KEYWORD_PACKAGE, KEYWORD_PRIVATE,
     KEYWORD_PROGRAM, KEYWORD_PROTECTED, KEYWORD_PUBLIC,
@@ -432,6 +432,7 @@ static const keywordDesc KeywordTable [] = {
     { "native",         KEYWORD_NATIVE,         { 0, 0, 0, 1, 0 } },
     { "new",            KEYWORD_NEW,            { 0, 1, 1, 1, 0 } },
     { "newcov",         KEYWORD_NEWCOV,         { 0, 0, 0, 0, 1 } },
+    { "noexcept",       KEYWORD_NOEXCEPT,       { 0, 1, 0, 0, 0 } },
     { "operator",       KEYWORD_OPERATOR,       { 0, 1, 1, 0, 0 } },
     { "output",         KEYWORD_OUTPUT,         { 0, 0, 0, 0, 1 } },
     { "overload",       KEYWORD_OVERLOAD,       { 0, 1, 0, 0, 0 } },
@@ -2271,12 +2272,15 @@ static boolean skipPostArgumentStuff (
 
                 case KEYWORD_CONST:
                 case KEYWORD_VOLATILE:
+                case KEYWORD_NOEXCEPT:
                 case KEYWORD_OVERRIDE:
                 case KEYWORD_FINAL:
                     if (vStringLength (Signature) > 0) {
                         vStringPut (Signature, ' ');
                         vStringCat (Signature, token->name);
                     }
+                    if (token->keyword == KEYWORD_NOEXCEPT)
+                        skipParens (); // noexcept(...)
                     break;
 
                 case KEYWORD_CATCH:

--- a/sdk/codelite_indexer/libctags/main.c
+++ b/sdk/codelite_indexer/libctags/main.c
@@ -682,6 +682,11 @@ extern void ctags_free(char* ptr)
 
 extern void ctags_batch_parse(const char* filelist, const char* outputfile)
 {
+    /* ctags command line to use */
+    const char* ctags_cmd = getenv("CTAGS_BATCH_CMD");
+    if(!ctags_cmd)
+        ctags_cmd = "--excmd=pattern --sort=no --fields=aKmSsnit --c-kinds=+p --C++-kinds=+p ";
+
     /* Open the filelist and load list of files */
     char* line = (char*)0;
     FILE* fp = NULL;
@@ -714,8 +719,7 @@ extern void ctags_batch_parse(const char* filelist, const char* outputfile)
     int count = l->size;
     while(n) {
         counter++;
-        char* tags =
-            ctags_make_tags("--excmd=pattern --sort=no --fields=aKmSsnit --c-kinds=+p --C++-kinds=+p ", (char*)n->data);
+        char* tags = ctags_make_tags(ctags_cmd, (char*)n->data);
         free(n->data);
         if(tags) {
             size_t tags_size = strlen(tags);


### PR DESCRIPTION
1. Accept C++11 'type alias' syntax (`using Int64 = long long;`)
2. Accept C++11 'final' class specifier (`class Foo final { ... };`)
3. Accept C++11 'alignas' specifier (`struct alignas(32) Baz { ... };`)
4. Accept C++11 'noexcept' specifier (`void Bar() noexcept;`)
5. Accept C++17 nested namespace notation (`namespace A::B::C { ... }`)
6. Properly collect using aliases (`using std::shared_ptr;`)
7. Pass ignore token list when invoking the codelite_indexer in a batch mode

This is the C++ code that I've used for testing:
```c++
#include <memory>

using Int64 = long long; // (1) Accept C++11 'type alias' syntax

class Foo final // (2) Accept C++11 'final' class specifier
{
    void Bar() noexcept; // (4) Accept C++11 'noexcept' specifier
};

struct alignas(32) Baz {}; // (3) Accept C++11 'alignas' specifier

namespace A::B::C // (5) Accept C++17 nested namespace notation
{
    using std::shared_ptr; // (6) Properly collect using aliases (e.g. using std::shared_ptr;)
}

/*
    Int64       src.cpp  /^using Int64 = long long; \/\/ (1) Accept C++11 'type alias' syntax $/;"                               typedef    line:3
    Foo         src.cpp  /^class Foo final \/\/ (2) Accept C++11 'final' class specifier$/;"                                     class      line:5
    Bar         src.cpp  /^    void Bar() noexcept; \/\/ (4) Accept C++11 'noexcept' specifier$/;"                               prototype  line:7   class:Foo          access:private  signature:() noexcept  returns:void
    Baz         src.cpp  /^struct alignas(32) Baz {}; \/\/ (3) Accept C++11 'alignas' specifier$/;"                              struct     line:10
    A           src.cpp  /^namespace A::B::C \/\/ (5) Accept C++17 nested namespace notation$/;"                                 namespace  line:12
    B           src.cpp  /^namespace A::B::C \/\/ (5) Accept C++17 nested namespace notation$/;"                                 namespace  line:12  namespace:A
    C           src.cpp  /^namespace A::B::C \/\/ (5) Accept C++17 nested namespace notation$/;"                                 namespace  line:12  namespace:A::B
    shared_ptr  src.cpp  /^    using std::shared_ptr; \/\/ (6) Properly collect using aliases (e.g. using std::shared_ptr;)$/;"  class      line:14  namespace:A::B::C  typeref:class:std::shared_ptr
*/
```