### PR TITLE
Fix std::length_error exception in FileUtils::ReadFileContentRaw()

### DIFF
--- a/CodeLite/fileutils.cpp
+++ b/CodeLite/fileutils.cpp
@@ -117,6 +117,11 @@ bool FileUtils::ReadFileContent(const wxFileName& fn, wxString& data, const wxMB
 
 bool FileUtils::ReadFileContentRaw(const wxFileName& fn, std::string& data)
 {
+    // fopen() may return non NULL for directories too, so we have to test it ourselves
+    if(!fn.FileExists()) {
+        return false;
+    }
+
     wxString filename = fn.GetFullPath();
     data.clear();
     const char* cfile = filename.mb_str(wxConvUTF8).data();


### PR DESCRIPTION
The easiest way to reproduce this issue is:
![Screenshot 2021-09-28 23-55-29](https://user-images.githubusercontent.com/32811754/135112833-a7259513-2b91-4cc8-916c-b13733fa2d1c.png)