### PR TITLE
CodeLiteDiff fixes

### DIFF
--- a/CodeLiteDiff/NewFileComparison.cpp
+++ b/CodeLiteDiff/NewFileComparison.cpp
@@ -12,7 +12,9 @@ NewFileComparison::NewFileComparison(wxWindow* parent, const wxFileName& leftFil
     clGetManager()->GetAllEditors(editors);
     m_textCtrlLeftFile->ChangeValue(leftFile.GetFullPath());
     std::for_each(editors.begin(), editors.end(), [&](IEditor* editor) {
-        m_listBox16->Append(editor->GetFileName().GetFullPath());
+        if(editor->GetFileName() != leftFile) {
+            m_listBox16->Append(editor->GetFileName().GetFullPath());
+        }
     });
 }
 
@@ -35,7 +37,7 @@ void NewFileComparison::OnBrowse(wxCommandEvent& event)
 void NewFileComparison::OnOKUI(wxUpdateUIEvent& event)
 {
     wxFileName fn(m_textCtrlFileName->GetValue());
-    event.Enable(fn.Exists() || m_textCtrlFileName->GetValue().StartsWith("Untitled"));
+    event.Enable(fn.Exists() || m_textCtrlFileName->GetValue().StartsWith(_("Untitled")));
 }
 
 void NewFileComparison::OnFileSelected(wxCommandEvent& event)

--- a/CodeLiteDiff/codelitediff.cpp
+++ b/CodeLiteDiff/codelitediff.cpp
@@ -122,7 +122,7 @@ void CodeLiteDiff::OnDiff(wxCommandEvent& event)
     bool tempfile(false);
     NewFileComparison dlg(EventNotifier::Get()->TopFrame(), m_leftFile);
     if(dlg.ShowModal() == wxID_OK) {
-        if(m_leftFile.GetName().StartsWith("Untitled")) {
+        if(m_leftFile.GetName().StartsWith(_("Untitled"))) {
             tempfile = true;
             m_leftFile = SaveEditorToTmpfile(m_mgr->GetActiveEditor());
             if(!m_leftFile.IsOk()) {
@@ -131,7 +131,7 @@ void CodeLiteDiff::OnDiff(wxCommandEvent& event)
             }
         }
         wxString secondFile = dlg.GetTextCtrlFileName()->GetValue();
-        if(secondFile.StartsWith("Untitled")) {
+        if(secondFile.StartsWith(_("Untitled"))) {
             tempfile = true;
             IEditor* editor = m_mgr->FindEditor(secondFile);
             if(!editor) {


### PR DESCRIPTION
* Left file (i.e. its own file) should not be listed in comparison targets.
* Fix 'Untitled' editor comparison for localized languages.