### PR TITLE
Visual Studio related fixes

### DIFF
--- a/LiteEditor/CompilerMainPage.cpp
+++ b/LiteEditor/CompilerMainPage.cpp
@@ -713,6 +713,7 @@ void CompilerMainPage::InitializeAdvancePage()
     m_textObjectExtension->ChangeValue("");
     m_textDependExtension->ChangeValue("");
     m_textPreprocessExtension->ChangeValue("");
+    m_checkBoxGenerateDependenciesFiles->Enable(false);
     m_checkBoxGenerateDependenciesFiles->SetValue(false);
     m_textCtrlGlobalIncludePath->ChangeValue("");
     m_textCtrlGlobalLibPath->ChangeValue("");
@@ -722,6 +723,7 @@ void CompilerMainPage::InitializeAdvancePage()
     m_textObjectExtension->ChangeValue(m_compiler->GetObjectSuffix());
     m_textDependExtension->ChangeValue(m_compiler->GetDependSuffix());
     m_textPreprocessExtension->ChangeValue(m_compiler->GetPreprocessSuffix());
+    m_checkBoxGenerateDependenciesFiles->Enable(m_compiler->IsGnuCompatibleCompiler());
     m_checkBoxGenerateDependenciesFiles->SetValue(m_compiler->GetGenerateDependeciesFile());
     m_textCtrlGlobalIncludePath->ChangeValue(m_compiler->GetGlobalIncludePath());
     m_textCtrlGlobalLibPath->ChangeValue(m_compiler->GetGlobalLibPath());

--- a/Plugin/CompilerLocatorCLANG.cpp
+++ b/Plugin/CompilerLocatorCLANG.cpp
@@ -63,7 +63,15 @@ bool OSXFindBrewClang(wxFileName& clang)
 }
 #endif
 
-CompilerLocatorCLANG::CompilerLocatorCLANG() {}
+CompilerLocatorCLANG::CompilerLocatorCLANG()
+{
+    m_msys2Envs.push_back({ 32, "clang32" });
+    m_msys2Envs.push_back({ 64, "clang64" });
+    m_msys2Envs.push_back({ 64, "clangarm64" });
+    m_msys2Envs.push_back({ 32, "mingw32" });
+    m_msys2Envs.push_back({ 64, "mingw64" });
+    m_msys2Envs.push_back({ 64, "ucrt64" });
+}
 
 CompilerLocatorCLANG::~CompilerLocatorCLANG() {}
 
@@ -282,24 +290,13 @@ bool CompilerLocatorCLANG::ReadMSWInstallLocation(const wxString& regkey, wxStri
 #endif
 }
 
-std::vector<CompilerLocatorCLANG::MSYS2Env> CompilerLocatorCLANG::GetMSYS2Envs() const
+void CompilerLocatorCLANG::CheckUninstRegKey(const wxString& displayName, const wxString& installFolder,
+                                             const wxString& displayVersion)
 {
-    std::vector<MSYS2Env> msys2Envs;
-    msys2Envs.push_back({ 32, "clang32" });
-    msys2Envs.push_back({ 64, "clang64" });
-    msys2Envs.push_back({ 64, "clangarm64" });
-    msys2Envs.push_back({ 32, "mingw32" });
-    msys2Envs.push_back({ 64, "mingw64" });
-    msys2Envs.push_back({ 64, "ucrt64" });
+    wxUnusedVar(displayVersion);
 
-    return msys2Envs;
-}
-
-void CompilerLocatorCLANG::CheckUninstRegKey(const wxString& displayName, const wxString& installFolder)
-{
     if(displayName.StartsWith("MSYS2")) {
-        static const auto msys2Envs = GetMSYS2Envs();
-        for(const auto& env : msys2Envs) {
+        for(const auto& env : m_msys2Envs) {
             wxFileName fnBinFolder(installFolder, "");
             fnBinFolder.AppendDir(env.prefix);
             fnBinFolder.AppendDir("bin");

--- a/Plugin/CompilerLocatorCLANG.h
+++ b/Plugin/CompilerLocatorCLANG.h
@@ -37,6 +37,7 @@ class WXDLLIMPEXP_SDK CompilerLocatorCLANG : public ICompilerLocator
         int cpuBits;     // 32bit or 64bit
         wxString prefix; // directory prefix
     };
+    std::vector<MSYS2Env> m_msys2Envs;
 
 protected:
     void MSWLocate();
@@ -46,8 +47,8 @@ protected:
     wxString GetClangVersion(const wxString& clangBinary);
     wxString GetCompilerFullName(const wxString& clangBinary);
     bool ReadMSWInstallLocation(const wxString& regkey, wxString& installPath, wxString& llvmVersion);
-    std::vector<MSYS2Env> GetMSYS2Envs() const;
-    virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder);
+    virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder,
+                                   const wxString& displayVersion);
     CompilerPtr AddCompiler(const wxString& clangFolder, const wxString& name = "", const wxString& suffix = "");
 
 public:

--- a/Plugin/CompilerLocatorMSVC.cpp
+++ b/Plugin/CompilerLocatorMSVC.cpp
@@ -27,7 +27,13 @@
 #include "compiler.h"
 #include <globals.h>
 
-CompilerLocatorMSVC::CompilerLocatorMSVC() {}
+CompilerLocatorMSVC::CompilerLocatorMSVC()
+{
+    // We only deal with x86/x64 Native Tools here for simplicity
+    // Other platforms (such as ARM64 Cross Tools) can be added manually by cloning the compiler
+    m_vcPlatforms.Add("x86");
+    m_vcPlatforms.Add("x64");
+}
 
 CompilerLocatorMSVC::~CompilerLocatorMSVC() {}
 
@@ -35,39 +41,53 @@ bool CompilerLocatorMSVC::Locate()
 {
     m_compilers.clear();
 
-    wxArrayString vc_platforms;
-    vc_platforms.Add("x86");
-    vc_platforms.Add("x64");
-
     wxEnvVariableHashMap envvars;
     ::wxGetEnvMap(&envvars);
 
-    for (wxEnvVariableHashMap::const_iterator it = envvars.begin(); it != envvars.end(); ++it) {
+    for(wxEnvVariableHashMap::const_iterator it = envvars.begin(); it != envvars.end(); ++it) {
         wxString const& envvarName = it->first;
         wxString const& envvarPath = it->second;
 
-        if (!envvarName.Matches("VS??*COMNTOOLS") || envvarPath.IsEmpty() || (envvarName.Find('C') < 3)) {
+        if(!envvarName.Matches("VS??*COMNTOOLS") || envvarPath.IsEmpty() || (envvarName.Find('C') < 3)) {
             continue;
         }
 
         wxString vcVersion = envvarName.Mid(2, envvarName.Find('C') - 3);
-        for(size_t j = 0; j < vc_platforms.GetCount(); ++j) {
-            wxString compilerName = "Visual C++ " + vcVersion + " (" + vc_platforms[j] + ")";
-            AddTools(envvarPath, compilerName, vc_platforms[j]);
+        for(size_t j = 0; j < m_vcPlatforms.GetCount(); ++j) {
+            wxString compilerName = "Visual C++ " + vcVersion + " (" + m_vcPlatforms[j] + ")";
+            AddToolsVC2005(envvarPath, compilerName, m_vcPlatforms[j]);
         }
     }
+
+    // Visual Studio 2017 no longer sets the above environment variable on system-wide
+    ScanUninstRegKeys();
 
     return !m_compilers.empty();
 }
 
-void CompilerLocatorMSVC::AddTools(const wxString& masterFolder,
-                                   const wxString& name,
-                                   const wxString& platform)
+void CompilerLocatorMSVC::CheckUninstRegKey(const wxString& displayName, const wxString& installFolder,
+                                            const wxString& displayVersion)
 {
-    wxFileName installPath(masterFolder, "");
-    installPath.RemoveLastDir();
-    installPath.RemoveLastDir();
+    static const wxRegEx reName("^Visual Studio (Community|Professional|Enterprise) ([0-9]{4})$"),
+        reVersion("^([0-9]+).*$");
+    if(reName.Matches(displayName) && reVersion.Matches(displayVersion)) {
+        wxString vcEdition = reName.GetMatch(displayName, 1);
+        wxString vcVersion = reVersion.GetMatch(displayVersion, 1);
+        long lvcVersion;
+        if(!vcVersion.ToLong(&lvcVersion) || lvcVersion < 15) {
+            // This detection is valid for Visual Studio 2017 (version 15)+ only
+            return;
+        }
+        for(size_t i = 0; i < m_vcPlatforms.GetCount(); ++i) {
+            wxString compilerName = "Visual C++ " + vcVersion + " " + vcEdition + " (" + m_vcPlatforms[i] + ")";
+            AddToolsVC2017(installFolder, compilerName, m_vcPlatforms[i]);
+        }
+    }
+}
 
+void CompilerLocatorMSVC::AddTools(const wxString& name, const wxString& platform, const wxFileName& installPath,
+                                   const wxFileName& fnVCvars, const wxFileName& fnIdeFolder)
+{
     CompilerPtr compiler(new Compiler(NULL, Compiler::kRegexVC));
     compiler->SetCompilerFamily(COMPILER_FAMILY_VC);
     compiler->SetName(name);
@@ -93,18 +113,14 @@ void CompilerLocatorMSVC::AddTools(const wxString& masterFolder,
 
     // Resource
     AddTool("rc.exe", "/nologo", "ResourceCompiler", compiler);
-    compiler->AddCmpFileType("rc",
-                       Compiler::CmpFileKindResource,
-                       "$(RcCompilerName) $(RcCmpOptions) "
-                       "$(ObjectSwitch)$(IntermediateDirectory)/"
-                       "$(ObjectName)$(ObjectSuffix) $(RcIncludePath) \"$(FileFullPath)\"");
+    compiler->AddCmpFileType("rc", Compiler::CmpFileKindResource,
+                             "$(RcCompilerName) $(RcCmpOptions) "
+                             "$(ObjectSwitch)$(IntermediateDirectory)/"
+                             "$(ObjectName)$(ObjectSuffix) $(RcIncludePath) \"$(FileFullPath)\"");
 
-    //Make
-    wxFileName fnVCvars(installPath);
-    fnVCvars.AppendDir("VC");
-    fnVCvars.SetFullName("vcvarsall.bat");
-    wxString makeArgs = platform + " > nul";
-    AddTool(fnVCvars.GetFullPath(), makeArgs, "MAKE", compiler);
+    // Make
+    wxString vcVarsArgs = platform + " > nul";
+    AddTool(fnVCvars.GetFullPath(), vcVarsArgs + " && nmake.exe /nologo", "MAKE", compiler);
 
     compiler->SetSwitch("ArchiveOutput", "/OUT:");
     compiler->SetSwitch("Debug", "/Zi ");
@@ -113,38 +129,32 @@ void CompilerLocatorMSVC::AddTools(const wxString& masterFolder,
     compiler->SetSwitch("LibraryPath", "/LIBPATH:");
     compiler->SetSwitch("Object", "/Fo");
     compiler->SetSwitch("Output", "/OUT:");
-    compiler->SetSwitch("PreprocessOnly", "/P");
+    compiler->SetSwitch("PreprocessOnly", "/P /Fi:");
     compiler->SetSwitch("Preprocessor", "/D");
     compiler->SetSwitch("Source", "");
     compiler->SetObjectSuffix(".obj");
 
     // IDE path
-    wxFileName fnIdeFolder(masterFolder, "");
-    fnIdeFolder.RemoveLastDir();
-    fnIdeFolder.AppendDir("IDE");
     compiler->SetPathVariable(fnIdeFolder.GetPath() + ";$PATH");
 
     // include and lib path, check if cl.exe exists
-    wxString includePathCmd = "echo \%INCLUDE\%";
-    WrapInShell(includePathCmd);
-    wxString libPathCmd = "echo \%LIB\%";
-    WrapInShell(libPathCmd);
-    wxString clCheck = "where cl.exe";
-    wxString command = compiler->GetTool("MAKE") + " & " + includePathCmd + " & " + libPathCmd + " & " + clCheck;
-    WrapInShell(command);
+    wxString vcVarsCmd = fnVCvars.GetFullPath();
+    WrapWithQuotes(vcVarsCmd);
+    wxString command = "CMD.EXE /V:ON /C ";
+    command << vcVarsCmd << " " << vcVarsArgs << " & echo !INCLUDE! & echo !LIB! & where cl.exe";
 
     wxArrayString output;
     wxArrayString errors;
     wxExecute(command, output, errors);
 
-    if (output.size() >= 2) {
+    if(output.size() >= 2) {
         wxString includePath = output[0];
-        if (includePath.Trim().Trim(false) != "\%INCLUDE\%") {
+        if(includePath.Trim().Trim(false) != "!INCLUDE!") {
             compiler->SetGlobalIncludePath(includePath);
         }
 
         wxString libPath = output[1];
-        if (libPath.Trim().Trim(false) != "\%LIB\%") {
+        if(libPath.Trim().Trim(false) != "!LIB!") {
             compiler->SetGlobalLibPath(libPath);
         }
     }
@@ -153,15 +163,49 @@ void CompilerLocatorMSVC::AddTools(const wxString& masterFolder,
     AddLinkerOptions(compiler);
 
     // cl.exe exists
-    if (errors.IsEmpty()) {
+    if(errors.IsEmpty()) {
         m_compilers.push_back(compiler);
     }
 }
 
-void CompilerLocatorMSVC::AddTool(const wxString& toolpath,
-                                      const wxString& extraArgs,
-                                      const wxString& toolname,
-                                      CompilerPtr compiler)
+// For Visual Studio 2005 and up to 2015
+void CompilerLocatorMSVC::AddToolsVC2005(const wxString& masterFolder, const wxString& name, const wxString& platform)
+{
+    wxFileName installPath(masterFolder, "");
+    installPath.RemoveLastDir();
+    installPath.RemoveLastDir();
+
+    wxFileName fnVCvars(installPath);
+    fnVCvars.AppendDir("VC");
+    fnVCvars.SetFullName("vcvarsall.bat");
+
+    wxFileName fnIdeFolder(masterFolder, "");
+    fnIdeFolder.RemoveLastDir();
+    fnIdeFolder.AppendDir("IDE");
+
+    AddTools(name, platform, installPath, fnVCvars, fnIdeFolder);
+}
+
+// For Visual Studio 2017 or above
+void CompilerLocatorMSVC::AddToolsVC2017(const wxString& masterFolder, const wxString& name, const wxString& platform)
+{
+    wxFileName installPath(masterFolder, "");
+
+    wxFileName fnVCvars(installPath);
+    fnVCvars.AppendDir("VC");
+    fnVCvars.AppendDir("Auxiliary");
+    fnVCvars.AppendDir("Build");
+    fnVCvars.SetFullName("vcvarsall.bat");
+
+    wxFileName fnIdeFolder(masterFolder, "");
+    fnIdeFolder.AppendDir("Common7");
+    fnIdeFolder.AppendDir("IDE");
+
+    AddTools(name, platform, installPath, fnVCvars, fnIdeFolder);
+}
+
+void CompilerLocatorMSVC::AddTool(const wxString& toolpath, const wxString& extraArgs, const wxString& toolname,
+                                  CompilerPtr compiler)
 {
     wxString tool = toolpath;
     ::WrapWithQuotes(tool);
@@ -174,81 +218,107 @@ void CompilerLocatorMSVC::AddTool(const wxString& toolpath,
 
 void CompilerLocatorMSVC::AddCompilerOptions(CompilerPtr compiler)
 {
-    compiler->AddCompilerOption("/c", "Compiles without linking.");
-    compiler->AddCompilerOption("/MD", "Causes the application to use the multithread-specific and DLL-specific version of the run-time library.");
-    compiler->AddCompilerOption("/MDd", "Causes the application to use the debug multithread-specific and DLL-specific version of the run-time library.");
-    compiler->AddCompilerOption("/MT", "Causes the application to use the multithread, static version of the run-time library.");
-    compiler->AddCompilerOption("/MTd", "Causes the application to use the debug multithread, static version of the run-time library.");
+    compiler->AddCompilerOption("/c", "Compiles without linking");
+    compiler->AddCompilerOption(
+        "/MD",
+        "Causes the application to use the multithread-specific and DLL-specific version of the run-time library");
+    compiler->AddCompilerOption("/MDd", "Causes the application to use the debug multithread-specific and DLL-specific "
+                                        "version of the run-time library");
+    compiler->AddCompilerOption(
+        "/MT", "Causes the application to use the multithread, static version of the run-time library");
+    compiler->AddCompilerOption(
+        "/MTd", "Causes the application to use the debug multithread, static version of the run-time library");
 
-    compiler->AddCompilerOption("/O1", "Creates small code.");
-    compiler->AddCompilerOption("/O2", "Creates fast code.");
-    compiler->AddCompilerOption("/Od", "Disables optimization.");
-    compiler->AddCompilerOption("/Ox", "Uses maximum optimization.");
-    compiler->AddCompilerOption("/Oi", "Generates intrinsic functions.");
+    compiler->AddCompilerOption("/O1", "Creates small code");
+    compiler->AddCompilerOption("/O2", "Creates fast code");
+    compiler->AddCompilerOption("/Od", "Disables optimization");
+    compiler->AddCompilerOption("/Ox", "Uses maximum optimization");
+    compiler->AddCompilerOption("/Oi", "Generates intrinsic functions");
 
-    compiler->AddCompilerOption("/MP", "Compiles multiple source files by using multiple processes.");
-    compiler->AddCompilerOption("/sdl", "Enables additional security features and warnings.");
-    compiler->AddCompilerOption("/errorReport:none", "Reports about internal compiler errors will not be collected or sent to Microsoft.");
-    compiler->AddCompilerOption("/errorReport:prompt", "Prompts you to send a report when you receive an internal compiler error.");
-    compiler->AddCompilerOption("/FS", "Forces writes to the program database (PDB) file to be serialized through MSPDBSRV.EXE.");
-    compiler->AddCompilerOption("/Zs", "Checks syntax only.");
-    compiler->AddCompilerOption("/GA", "Optimizes code for Windows application.");
-    compiler->AddCompilerOption("/GL", "Enables whole program optimization.");
-    compiler->AddCompilerOption("/Gm", "Enables minimal rebuild.");
-    compiler->AddCompilerOption("/Gy", "Enables function-level linking.");
-    compiler->AddCompilerOption("/EHa", "Enable C++ Exceptions with SEH exceptions");
-    compiler->AddCompilerOption("/EHs", "Enable C++ Exceptions with Extern C functions.");
-    compiler->AddCompilerOption("/EHsc", "Enable C++ Exceptions with SEH and Extern C functions.");
+    compiler->AddCompilerOption("/MP", "Compiles multiple source files by using multiple processes");
+    compiler->AddCompilerOption("/sdl", "Enables additional security features and warnings");
+    compiler->AddCompilerOption("/errorReport:none",
+                                "Reports about internal compiler errors will not be collected or sent to Microsoft");
+    compiler->AddCompilerOption("/errorReport:prompt",
+                                "Prompts you to send a report when you receive an internal compiler error");
+    compiler->AddCompilerOption(
+        "/FS", "Forces writes to the program database (PDB) file to be serialized through MSPDBSRV.EXE");
+    compiler->AddCompilerOption("/Zs", "Checks syntax only");
+    compiler->AddCompilerOption("/GA", "Optimizes code for Windows application");
+    compiler->AddCompilerOption("/GL", "Enables whole program optimization");
+    compiler->AddCompilerOption("/Gm", "Enables minimal rebuild");
+    compiler->AddCompilerOption("/Gy", "Enables function-level linking");
+    compiler->AddCompilerOption("/EHa", "Enable C++ Exceptions with SEH exception");
+    compiler->AddCompilerOption("/EHs", "Enable C++ Exceptions with Extern C functions");
+    compiler->AddCompilerOption("/EHsc", "Enable C++ Exceptions with SEH and Extern C functions");
 
-    compiler->AddCompilerOption("/Z7", "Produces an .obj file containing full symbolic debugging information for use with the debugger.");
-    compiler->AddCompilerOption("/Zi", "Produces a program database (PDB) that contains type information and symbolic debugging information for use with the debugger.");
-    compiler->AddCompilerOption("/ZI", "Produces a program database, as described above, in a format that supports the Edit and Continue feature.");
+    compiler->AddCompilerOption(
+        "/Z7", "Produces an .obj file containing full symbolic debugging information for use with the debugger");
+    compiler->AddCompilerOption("/Zi", "Produces a program database (PDB) that contains type information and symbolic "
+                                       "debugging information for use with the debugger");
+    compiler->AddCompilerOption(
+        "/ZI",
+        "Produces a program database, as described above, in a format that supports the Edit and Continue feature");
 
-    compiler->AddCompilerOption("/w", "Disables all compiler warnings.");
-    compiler->AddCompilerOption("/W0", "Disables all warnings.");
-    compiler->AddCompilerOption("/W1", "Displays level 1 (severe) warnings.");
-    compiler->AddCompilerOption("/W2", "Displays level 1 and level 2 (significant) warnings.");
-    compiler->AddCompilerOption("/W3", "Displays level 1, level 2 and level 3 (production quality) warnings.");
-    compiler->AddCompilerOption("/W4", "Displays level 1, level 2, and level 3 warnings, and all level 4 (informational) warnings that are not turned off by default.");
-    compiler->AddCompilerOption("/Wall", "Displays all warnings displayed by /W4 and all other warnings that /W4 does not include.");
-    compiler->AddCompilerOption("/WX", "Treats all compiler warnings as errors.");
+    compiler->AddCompilerOption("/w", "Disables all compiler warnings");
+    compiler->AddCompilerOption("/W0", "Disables all warnings");
+    compiler->AddCompilerOption("/W1", "Displays level 1 (severe) warnings");
+    compiler->AddCompilerOption("/W2", "Displays level 1 and level 2 (significant) warnings");
+    compiler->AddCompilerOption("/W3", "Displays level 1, level 2 and level 3 (production quality) warnings");
+    compiler->AddCompilerOption("/W4", "Displays level 1, level 2, and level 3 warnings, and all level 4 "
+                                       "(informational) warnings that are not turned off by default");
+    compiler->AddCompilerOption(
+        "/Wall", "Displays all warnings displayed by /W4 and all other warnings that /W4 does not include");
+    compiler->AddCompilerOption("/WX", "Treats all compiler warnings as errors");
+
+    compiler->AddCompilerOption("/std:c11", "Enable C11 features");
+    compiler->AddCompilerOption("/std:c++14", "Enable C++14 features");
+    compiler->AddCompilerOption("/std:c++17", "Enable C++17 features");
+    compiler->AddCompilerOption("/std:c++20", "Enable C++20 features");
+    compiler->AddCompilerOption("/std:c++latest", "Enable latest C++ features");
 }
 
 void CompilerLocatorMSVC::AddLinkerOptions(CompilerPtr compiler)
 {
-    compiler->AddLinkerOption("/DEBUG", "Creates debugging information.");
-    compiler->AddLinkerOption("/DYNAMICBASE", "Use address space layout randomization.");
-    compiler->AddLinkerOption("/DYNAMICBASE:NO", "Don't use address space layout randomization");
-    compiler->AddLinkerOption("/ERRORREPORT:NONE", "Reports about internal compiler errors will not be collected or sent to Microsoft.");
-    compiler->AddLinkerOption("/ERRORREPORT:PROMPT", "Prompts you to send a report when you receive an internal compiler error.");
-    compiler->AddLinkerOption("/INCREMENTAL", "Enables incremental linking.");
-    compiler->AddLinkerOption("/INCREMENTAL:NO", "Disables incremental linking.");
-    compiler->AddLinkerOption("/LARGEADDRESSAWARE", "Tells the compiler that the application supports addresses larger than two gigabytes.");
-    compiler->AddLinkerOption("/LARGEADDRESSAWARE:NO", "Tells the compiler that the application does not support addresses larger than two gigabytes.");
+    compiler->AddLinkerOption("/DEBUG", "Creates debugging information");
+    compiler->AddLinkerOption("/DYNAMICBASE", "Use address space layout randomization");
+    compiler->AddLinkerOption("/DYNAMICBASE:NO", "Don't use address space layout randomizatio");
+    compiler->AddLinkerOption("/ERRORREPORT:NONE",
+                              "Reports about internal compiler errors will not be collected or sent to Microsoft");
+    compiler->AddLinkerOption("/ERRORREPORT:PROMPT",
+                              "Prompts you to send a report when you receive an internal compiler error");
+    compiler->AddLinkerOption("/INCREMENTAL", "Enables incremental linking");
+    compiler->AddLinkerOption("/INCREMENTAL:NO", "Disables incremental linking");
+    compiler->AddLinkerOption("/LARGEADDRESSAWARE",
+                              "Tells the compiler that the application supports addresses larger than two gigabytes");
+    compiler->AddLinkerOption(
+        "/LARGEADDRESSAWARE:NO",
+        "Tells the compiler that the application does not support addresses larger than two gigabytes");
 
-    compiler->AddLinkerOption("/LTCG:INCREMENTAL", "Specifies link-time code generation.");
-    compiler->AddLinkerOption("/LTCG:STATUS", "Specifies link-time code generation.");
-    compiler->AddLinkerOption("/LTCG:NOSTATUS", "Specifies link-time code generation.");
-    compiler->AddLinkerOption("/LTCG:OFF", "Specifies link-time code generation.");
-    compiler->AddLinkerOption("/MACHINE:X64", "Specifies the target platform.");
-    compiler->AddLinkerOption("/MACHINE:X86", "Specifies the target platform.");
-    compiler->AddLinkerOption("/NOENTRY", "Creates a resource-only DLL.");
-    compiler->AddLinkerOption("/NXCOMPAT", "Specify Compatibility with Data Execution Prevention.");
-    compiler->AddLinkerOption("/NXCOMPAT:NO", "Specify Compatibility with Data Execution Prevention.");
+    compiler->AddLinkerOption("/LTCG:INCREMENTAL", "Specifies link-time code generation");
+    compiler->AddLinkerOption("/LTCG:STATUS", "Specifies link-time code generation");
+    compiler->AddLinkerOption("/LTCG:NOSTATUS", "Specifies link-time code generation");
+    compiler->AddLinkerOption("/LTCG:OFF", "Specifies link-time code generation");
+    compiler->AddLinkerOption("/MACHINE:X64", "Specifies the target platform");
+    compiler->AddLinkerOption("/MACHINE:X86", "Specifies the target platform");
+    compiler->AddLinkerOption("/NOENTRY", "Creates a resource-only DLL");
+    compiler->AddLinkerOption("/NXCOMPAT", "Specify Compatibility with Data Execution Prevention");
+    compiler->AddLinkerOption("/NXCOMPAT:NO", "Specify Compatibility with Data Execution Prevention");
 
-    compiler->AddLinkerOption("/OPT:REF", "Controls LINK optimizations.");
-    compiler->AddLinkerOption("/OPT:NOREF", "Controls LINK optimizations.");
-    compiler->AddLinkerOption("/OPT:ICF", "Controls LINK optimizations.");
-    compiler->AddLinkerOption("/OPT:NOICF", "Controls LINK optimizations.");
-    compiler->AddLinkerOption("/OPT:LBR", "Controls LINK optimizations.");
-    compiler->AddLinkerOption("/OPT:NOLBR", "Controls LINK optimizations.");
+    compiler->AddLinkerOption("/OPT:REF", "Controls LINK optimizations");
+    compiler->AddLinkerOption("/OPT:NOREF", "Controls LINK optimizations");
+    compiler->AddLinkerOption("/OPT:ICF", "Controls LINK optimizations");
+    compiler->AddLinkerOption("/OPT:NOICF", "Controls LINK optimizations");
+    compiler->AddLinkerOption("/OPT:LBR", "Controls LINK optimizations");
+    compiler->AddLinkerOption("/OPT:NOLBR", "Controls LINK optimizations");
 
-    compiler->AddLinkerOption("/PROFILE", "Produces an output file that can be used with the Performance Tools profiler.");
-    compiler->AddLinkerOption("/SAFESEH", "Image has Safe Exception Handlers.");
-    compiler->AddLinkerOption("/SAFESEH:NO", "Image does not have Safe Exception Handlers");
-    compiler->AddLinkerOption("/SUBSYSTEM:CONSOLE", "Tells the operating system how to run the .exe file.");
-    compiler->AddLinkerOption("/SUBSYSTEM:WINDOWS", "Tells the operating system how to run the .exe file.");
-    compiler->AddLinkerOption("/VERBOSE", "Prints linker progress messages.");
-    compiler->AddLinkerOption("/WX", "Treats linker warnings as errors.");
-    compiler->AddLinkerOption("/WX:NO", "Do not treats linker warnings as errors.");
+    compiler->AddLinkerOption("/PROFILE",
+                              "Produces an output file that can be used with the Performance Tools profiler");
+    compiler->AddLinkerOption("/SAFESEH", "Image has Safe Exception Handlers");
+    compiler->AddLinkerOption("/SAFESEH:NO", "Image does not have Safe Exception Handler");
+    compiler->AddLinkerOption("/SUBSYSTEM:CONSOLE", "Tells the operating system how to run the .exe file");
+    compiler->AddLinkerOption("/SUBSYSTEM:WINDOWS", "Tells the operating system how to run the .exe file");
+    compiler->AddLinkerOption("/VERBOSE", "Prints linker progress messages");
+    compiler->AddLinkerOption("/WX", "Treats linker warnings as errors");
+    compiler->AddLinkerOption("/WX:NO", "Do not treats linker warnings as errors");
 }

--- a/Plugin/CompilerLocatorMSVC.h
+++ b/Plugin/CompilerLocatorMSVC.h
@@ -27,6 +27,7 @@
 #define COMPILERLOCATORMSVC_H
 
 #include "ICompilerLocator.h" // Base class: ICompilerLocator
+#include <wx/filename.h>
 
 //-------------------------------------------------------------------------
 // For a complete list of MSVC compilers
@@ -35,6 +36,8 @@
 
 class CompilerLocatorMSVC : public ICompilerLocator
 {
+    wxArrayString m_vcPlatforms;
+
 public:
     CompilerLocatorMSVC();
     virtual ~CompilerLocatorMSVC();
@@ -42,7 +45,12 @@ public:
     virtual CompilerPtr Locate(const wxString& folder) { return NULL; }
 
 protected:
-    void AddTools(const wxString& masterFolder, const wxString& name, const wxString& platform);
+    virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder,
+                                   const wxString& displayVersion);
+    void AddTools(const wxString& name, const wxString& platform, const wxFileName& installPath,
+                  const wxFileName& fnVCvars, const wxFileName& fnIdeFolder);
+    void AddToolsVC2005(const wxString& masterFolder, const wxString& name, const wxString& platform);
+    void AddToolsVC2017(const wxString& masterFolder, const wxString& name, const wxString& platform);
     void AddTool(const wxString& toolpath, const wxString& extraArgs, const wxString& toolname, CompilerPtr compiler);
     void AddCompilerOptions(CompilerPtr compiler);
     void AddLinkerOptions(CompilerPtr compiler);

--- a/Plugin/CompilerLocatorMinGW.cpp
+++ b/Plugin/CompilerLocatorMinGW.cpp
@@ -207,8 +207,11 @@ bool CompilerLocatorMinGW::Locate()
     return !m_compilers.empty();
 }
 
-void CompilerLocatorMinGW::CheckUninstRegKey(const wxString& displayName, const wxString& installFolder)
+void CompilerLocatorMinGW::CheckUninstRegKey(const wxString& displayName, const wxString& installFolder,
+                                             const wxString& displayVersion)
 {
+    wxUnusedVar(displayVersion);
+
     if(displayName.StartsWith("TDM-GCC")) {
         wxFileName fnTDMBinFolder(installFolder, "");
         fnTDMBinFolder.AppendDir("bin");

--- a/Plugin/CompilerLocatorMinGW.h
+++ b/Plugin/CompilerLocatorMinGW.h
@@ -34,11 +34,13 @@ class WXDLLIMPEXP_SDK CompilerLocatorMinGW : public ICompilerLocator
     wxStringSet_t m_locatedFolders;
 
 protected:
-    void AddTools(const wxString &binFolder, const wxString &name = "");
-    void AddTool(CompilerPtr compiler, const wxString &toolname, const wxString &toolpath, const wxString &extraArgs = "");
-    wxString FindBinFolder(const wxString &parentPath);
-    wxString GetGCCVersion(const wxString &gccBinary);
-    virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder);
+    void AddTools(const wxString& binFolder, const wxString& name = "");
+    void AddTool(CompilerPtr compiler, const wxString& toolname, const wxString& toolpath,
+                 const wxString& extraArgs = "");
+    wxString FindBinFolder(const wxString& parentPath);
+    wxString GetGCCVersion(const wxString& gccBinary);
+    virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder,
+                                   const wxString& displayVersion);
 
 public:
     CompilerLocatorMinGW();

--- a/Plugin/ICompilerLocator.cpp
+++ b/Plugin/ICompilerLocator.cpp
@@ -77,11 +77,12 @@ void ICompilerLocator::ScanUninstRegKeys()
                 if(!subKey.Exists() || !subKey.Open(wxRegKey::Read))
                     continue;
 
-                wxString displayName, installFolder;
+                wxString displayName, installFolder, displayVersion;
                 if(subKey.HasValue("DisplayName") && subKey.HasValue("InstallLocation") &&
-                   subKey.QueryValue("DisplayName", displayName) &&
-                   subKey.QueryValue("InstallLocation", installFolder)) {
-                    CheckUninstRegKey(displayName, installFolder);
+                   subKey.HasValue("DisplayVersion") && subKey.QueryValue("DisplayName", displayName) &&
+                   subKey.QueryValue("InstallLocation", installFolder) &&
+                   subKey.QueryValue("DisplayVersion", displayVersion)) {
+                    CheckUninstRegKey(displayName, installFolder, displayVersion);
                 }
 
                 subKey.Close();

--- a/Plugin/ICompilerLocator.h
+++ b/Plugin/ICompilerLocator.h
@@ -28,7 +28,6 @@
 
 #include "codelite_exports.h"
 #include "compiler.h"
-#include <compiler.h>
 #include <vector>
 #include <wx/sharedptr.h>
 
@@ -62,7 +61,13 @@ protected:
      * @brief windows only: scan registry for uninstall information
      */
     void ScanUninstRegKeys();
-    virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder) {}
+    virtual void CheckUninstRegKey(const wxString& displayName, const wxString& installFolder,
+                                   const wxString& displayVersion)
+    {
+        wxUnusedVar(displayName);
+        wxUnusedVar(installFolder);
+        wxUnusedVar(displayVersion);
+    }
 
 public:
     ICompilerLocator();

--- a/Plugin/build_settings_config.cpp
+++ b/Plugin/build_settings_config.cpp
@@ -406,7 +406,12 @@ std::unordered_map<wxString, wxArrayString> BuildSettingsConfig::GetCompilersGlo
         if(!cmp) {
             continue;
         }
-        M.insert({ name, cmp->GetDefaultIncludePaths() });
+        wxArrayString includePaths = cmp->GetDefaultIncludePaths();
+        if(!cmp->GetGlobalIncludePath().IsEmpty()) {
+            wxArrayString globalIncludePaths = ::wxStringTokenize(cmp->GetGlobalIncludePath(), ";", wxTOKEN_STRTOK);
+            includePaths.insert(includePaths.end(), globalIncludePaths.begin(), globalIncludePaths.end());
+        }
+        M.insert({ name, includePaths });
     }
     return M;
 }

--- a/Plugin/builder_NMake.h
+++ b/Plugin/builder_NMake.h
@@ -37,7 +37,8 @@
  */
 class WXDLLIMPEXP_SDK BuilderNMake : public Builder
 {
-    size_t m_objectChunks;
+    size_t m_objectChunks = 1;
+    bool m_hasObjectPCH = false;
     clProjectFile::Vec_t m_allFiles;
 
 public:

--- a/Plugin/compiler.h
+++ b/Plugin/compiler.h
@@ -235,11 +235,11 @@ public:
 
     void SetLinkerOptions(const CmpCmdLineOptions& cmpOptions) { m_linkerOptions = cmpOptions; }
 
-    void SetGenerateDependeciesFile(const bool& generateDependeciesFile)
+    void SetGenerateDependeciesFile(bool generateDependeciesFile)
     {
         this->m_generateDependeciesFile = generateDependeciesFile;
     }
-    const bool& GetGenerateDependeciesFile() const { return m_generateDependeciesFile; }
+    bool GetGenerateDependeciesFile() const { return IsGnuCompatibleCompiler() && m_generateDependeciesFile; }
     void SetReadObjectFilesFromList(bool readObjectFilesFromList)
     {
         this->m_readObjectFilesFromList = readObjectFilesFromList;

--- a/Plugin/project.cpp
+++ b/Plugin/project.cpp
@@ -2054,8 +2054,8 @@ void Project::CreateCompileFlags(const wxStringMap_t& compilersGlobalPaths)
         ProcessMacros(tmpMacros, macroSet);
 
     } else {
-        wxString cFilePattern = GetCompileLineForCXXFile(compilersGlobalPaths, buildConf, "$FileName", 0);
-        wxString cxxFilePattern = GetCompileLineForCXXFile(compilersGlobalPaths, buildConf, "$FileName", kCxxFile);
+        wxString cFilePattern = GetCompileLineForCXXFile({}, buildConf, "$FileName", 0);
+        wxString cxxFilePattern = GetCompileLineForCXXFile({}, buildConf, "$FileName", kCxxFile);
 
         wxStringSet_t pathsSet;
 
@@ -2089,7 +2089,7 @@ void Project::CreateCompileFlags(const wxStringMap_t& compilersGlobalPaths)
         wxString pchFile = buildConf->GetPrecompiledHeader();
         pchFile.Trim().Trim(false);
         if(!pchFile.IsEmpty()) {
-            compile_flags_content << "-include " << pchFile << "\n";
+            compile_flags_content << "-include\n" << pchFile << "\n";
         }
     }
 

--- a/Runtime/templates/projects/vc-dynamic-library/vc-dynamic-library.project
+++ b/Runtime/templates/projects/vc-dynamic-library/vc-dynamic-library.project
@@ -17,11 +17,11 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       <ResourceCompiler Options=""/>
     </GlobalSettings>
     <Configuration Name="Debug" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="/Zi" C_Options="/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/Od;/Zi" C_Options="/c;/Od;/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="/DEF:$(ProjectName).def /DEBUG" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).dll" IntermediateDirectory="" Command="" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="no" IsGUIProgram="no" IsEnabled="yes"/>
-      <BuildSystem Name="CodeLite Make Generator"/>
+      <BuildSystem Name="NMakefile for MSVC toolset"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>
@@ -54,11 +54,11 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       </Completion>
     </Configuration>
     <Configuration Name="Release" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/O2" C_Options="/c;/O2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="/DEF:$(ProjectName).def" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).dll" IntermediateDirectory="" Command="" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="no" IsGUIProgram="no" IsEnabled="yes"/>
-      <BuildSystem Name="CodeLite Make Generator"/>
+      <BuildSystem Name="NMakefile for MSVC toolset"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>

--- a/Runtime/templates/projects/vc-executable/vc-executable.project
+++ b/Runtime/templates/projects/vc-executable/vc-executable.project
@@ -17,11 +17,11 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       <ResourceCompiler Options=""/>
     </GlobalSettings>
     <Configuration Name="Debug" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="/Zi" C_Options="/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/Od;/Zi" C_Options="/c;/Od;/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="/DEBUG" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).exe" IntermediateDirectory="" Command="$(ProjectName).exe" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
-      <BuildSystem Name="CodeLite Make Generator"/>
+      <BuildSystem Name="NMakefile for MSVC toolset"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>
@@ -54,11 +54,11 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       </Completion>
     </Configuration>
     <Configuration Name="Release" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/O2" C_Options="/c;/O2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).exe" IntermediateDirectory="" Command="$(ProjectName).exe" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
-      <BuildSystem Name="CodeLite Make Generator"/>
+      <BuildSystem Name="NMakefile for MSVC toolset"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>

--- a/Runtime/templates/projects/vc-static-lib/vc-static-lib.project
+++ b/Runtime/templates/projects/vc-static-lib/vc-static-lib.project
@@ -17,11 +17,11 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       <ResourceCompiler Options=""/>
     </GlobalSettings>
     <Configuration Name="Debug" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="/Zi" C_Options="/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/Od;/Zi" C_Options="/c;/Od;/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).lib" IntermediateDirectory="" Command="" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="no" IsGUIProgram="no" IsEnabled="yes"/>
-      <BuildSystem Name="CodeLite Make Generator"/>
+      <BuildSystem Name="NMakefile for MSVC toolset"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>
@@ -54,11 +54,11 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       </Completion>
     </Configuration>
     <Configuration Name="Release" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/O2" C_Options="/c;/O2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).lib" IntermediateDirectory="" Command="" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="no" IsGUIProgram="no" IsEnabled="yes"/>
-      <BuildSystem Name="CodeLite Make Generator"/>
+      <BuildSystem Name="NMakefile for MSVC toolset"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>


### PR DESCRIPTION
I don't know if anyone wants to use CodeLite with MSVC, but I guess there are some demands as it's de facto standard toolchain for Windows.

1. Add support for Visual Studio 2017/2019 detection.

2. Show `Searching for installed compilers...` message during compiler scan.
MSVC locator invokes vcvars*.bat, which takes a bit of time.

3. Fix clangd to refer custom global include paths.
This is required to make clangd to work with standard MSVC headers.

4. Several NMake generator fixes:
    * Compile and include precompiled headers using [/Yc](https://docs.microsoft.com/en-us/cpp/build/reference/yc-create-precompiled-header-file?view=msvc-160), [/Yu](https://docs.microsoft.com/en-us/cpp/build/reference/yu-use-precompiled-header-file?view=msvc-160) and [/FI](https://docs.microsoft.com/en-us/cpp/build/reference/fi-name-forced-include-file?view=msvc-160) switches.
    * Fix `Preprocess Single File` error.
    * Do not quote `$(MAKE)`.
    * etc.

5. Tweak MSVC compiler options for newly created projects:
    * [/c](https://docs.microsoft.com/en-us/cpp/build/reference/c-compile-without-linking?view=msvc-160): Compile without linking (because we invoke the linker afterwards).
    * [/EHsc](https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-160): MSVC emits a warning without this.
    * [/Od, /O2](https://docs.microsoft.com/en-us/cpp/build/reference/o-options-optimize-code?view=msvc-160): Optimization flag, /Od for debug, /O2 for release.

6. Minor refactoring around CheckUninstRegKey().

Tested MSVC versions: 2005 ~ 2019.

This shows how these compilers are detected:
![codelite-msvc-1](https://user-images.githubusercontent.com/32811754/138692776-03b775d4-a1e5-4a12-9c36-d01ef5aa5d56.png)

Building and running example:
![codelite-msvc-2](https://user-images.githubusercontent.com/32811754/138692790-26361e1d-d204-4a8a-a0da-aa3355cb71d6.png)