### PR TITLE
Add workflow build for stable wxwidgets

### DIFF
--- a/.github/workflows/build-ubuntu-latest-wx-stable.yml
+++ b/.github/workflows/build-ubuntu-latest-wx-stable.yml
@@ -1,0 +1,97 @@
+name: build-ubuntu-latest-wx-stable
+
+on: [push, pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac. You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+        include:
+          - compiler: gcc
+            cc: gcc
+            cxx: g++
+          - compiler: clang
+            cc: clang
+            cxx: clang++
+
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_NOSTATS: yes
+      CCACHE_MAXFILES: 0
+      CCACHE_MAXSIZE: 4G
+      CCACHE_LIMIT_MULTIPLE: 0.9
+      CCACHE_COMPRESS: yes
+      CCACHE_COMPRESSLEVEL: 5
+      CCACHE_COMPILERCHECK: "%compiler% -dumpversion"
+      CCACHE_COMPILERTYPE: auto
+      CCACHE_NODEPEND: yes
+      CCACHE_NODIRECT: yes
+      CCACHE_CPP2: yes
+      CCACHE_SLOPPINESS: "clang_index_store,include_file_ctime,include_file_mtime,locale,time_macros"
+      CCACHE_NOHASHDIR: yes
+      CCACHE_NOCOMMENTS: yes
+      CCACHE_NOINODECACHE: yes
+      CCACHE_NOHARDLINK: yes
+      CCACHE_NOFILECLONE: yes
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: Install libraries
+      run: |
+        sudo apt-get update
+        sudo apt-get install gnupg2 software-properties-common
+        sudo apt-key adv --fetch-keys https://repos.codelite.org/CodeLite.asc
+        sudo apt-add-repository 'deb https://repos.codelite.org/wx3.1.3/ubuntu/ bionic universe'
+        sudo apt-get install ccache ninja-build
+        sudo apt-get install pkg-config build-essential git cmake libgtk-3-dev libsqlite3-dev libssh-dev libedit-dev libhunspell-dev clang-format-8 xterm libnotify4
+        sudo apt-get install libwxbase3.0-0v5 libwxbase3.0-dev libwxgtk3.0-gtk3-0v5 libwxgtk3.0-gtk3-dev wx3.0-headers wx-common
+
+    - name: ccache
+      id: ccache
+      uses: actions/cache@v1.1.2
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ccache-${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+        restore-keys: ccache-${{ runner.os }}-${{ matrix.compiler }}
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source
+      # and build directories, but this is only available with CMake 3.13 and higher.
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake ${GITHUB_WORKSPACE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # Execute the build. You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config ${BUILD_TYPE} -j`nproc`
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${BUILD_TYPE}


### PR DESCRIPTION
This github action workflow is a clone of the existing build-ubuntu-latest.yml

It will help by automatically revealing commits that fails on the stable wxWidgets releases - this seems to be an recurring problem

