### PR TITLE
Fix navigation bar persistency

### DIFF
--- a/LiteEditor/frame.cpp
+++ b/LiteEditor/frame.cpp
@@ -4566,7 +4566,7 @@ bool clMainFrame::SaveLayoutAndSession()
     SetFrameFlag(IsMaximized(), CL_MAXIMIZE_FRAME);
     SetFrameFlag(IsFullScreen(), CL_FULLSCREEN);
     EditorConfigST::Get()->WriteObject(wxT("GeneralInfo"), &m_frameGeneralInfo);
-    EditorConfigST::Get()->SetInteger(wxT("ShowNavBar"), m_mainBook->IsNavBarShown() ? 1 : 0);
+    EditorConfigST::Get()->SetInteger(wxT("ShowNavBar"), m_mainBook->IsNavBarEnabled() ? 1 : 0);
     GetWorkspacePane()->SaveWorkspaceViewTabOrder();
     GetOutputPane()->SaveTabOrder();
 

--- a/LiteEditor/mainbook.h
+++ b/LiteEditor/mainbook.h
@@ -163,7 +163,14 @@ public:
     void ShowQuickBar(const wxString& findWhat, bool showReplace);
     void ShowTabBar(bool b);
     void ShowNavBar(bool s = true);
-    bool IsNavBarShown() { return m_navBar && m_navBar->IsShown(); }
+    /**
+     * @brief is navigation bar enabled by user?
+     */
+    bool IsNavBarEnabled() const { return m_navBar && m_navBar->ShouldShow(); }
+    /**
+     * @brief is navigation bar shown (either by user or automatically)?
+     */
+    bool IsNavBarShown() const { return m_navBar && m_navBar->IsShown(); }
     clEditorBar* GetEditorBar() { return m_navBar; }
     void SetEditorBar(clEditorBar* bar) { m_navBar = bar; }
 

--- a/Plugin/clEditorBar.h
+++ b/Plugin/clEditorBar.h
@@ -40,6 +40,7 @@ public:
     clEditorBar(wxWindow* parent);
     virtual ~clEditorBar();
     void SetMessage(const wxString& className, const wxString& function);
+    bool ShouldShow() const { return m_shouldShow; }
     void DoShow(bool s);
     void SetLabel(const wxString& text);
     void ClearLabel() { SetLabel(wxEmptyString); }


### PR DESCRIPTION
Navigation bar automatically hides when all editors are closed, so it doesn't imply that it was intentionally disabled by user.