### PR TITLE
Several bug fixes

### DIFF
--- a/CodeFormatter/codeformatterdlg.cpp
+++ b/CodeFormatter/codeformatterdlg.cpp
@@ -460,7 +460,7 @@ void CodeFormatterDlg::OnExportClangFormatFile(wxCommandEvent& event)
     if(m_mgr->IsWorkspaceOpen()) {
         defaultDir = m_mgr->GetWorkspace()->GetFileName().GetPath();
     }
-    wxString path = ::wxDirSelector(_("Export .clang-format file..."));
+    wxString path = ::wxDirSelector(_("Export .clang-format file..."), defaultDir);
     if(path.empty()) {
         return;
     }
@@ -473,7 +473,7 @@ void CodeFormatterDlg::OnExportClangFormatFile(wxCommandEvent& event)
         }
     }
 
-    if(!m_options.ExportClangFormatFile(clang_format.GetFullPath())) {
+    if(!m_options.ExportClangFormatFile(clang_format)) {
         ::wxMessageBox(_("Failed to save file:\n") + clang_format.GetFullPath(), _("Source Code Formatter"),
                        wxOK | wxICON_ERROR);
     }

--- a/CodeLite/clConsoleBash.cpp
+++ b/CodeLite/clConsoleBash.cpp
@@ -42,9 +42,9 @@ wxFileName clConsoleBash::PrepareExecScript() const
             for(size_t i = 0; i < arr.size(); ++i) {
                 fileContent << "args[" << i << "]=\"" << arr[i] << "\"\n";
             }
-            fileContent << cdCommand << "${command} \"${args[@]}\"\n";
+            fileContent << cdCommand << "\"${command}\" \"${args[@]}\"\n";
         } else {
-            fileContent << cdCommand << "${command}\n";
+            fileContent << cdCommand << "\"${command}\"\n";
         }
         if(IsWaitWhenDone()) {
             fileContent << "echo Hit any key to continue...\nread";

--- a/CodeLite/typedef_parser.cpp
+++ b/CodeLite/typedef_parser.cpp
@@ -477,7 +477,6 @@ std::string typedef_consumBracketsContent(char openBrace)
 void typedef_consumeDefaultValue(char c1, char c2)
 {
 	int depth = 0;
-	bool cont(true);
 
 	while (depth >= 0) {
     	int ch = cl_scope_lex();

--- a/CodeLite/var_parser.cpp
+++ b/CodeLite/var_parser.cpp
@@ -659,7 +659,6 @@ void var_consumeDefaultValueIfNeeded()
 void var_consumeDefaultValue(char c1, char c2)
 {
     int depth = 0;
-    bool cont(true);
 
     curr_var.m_defaultValue.clear();
     while (depth >= 0) {

--- a/CxxParser/cpp_variables_grammar.y
+++ b/CxxParser/cpp_variables_grammar.y
@@ -635,7 +635,6 @@ void var_consumeDefaultValueIfNeeded()
 void var_consumeDefaultValue(char c1, char c2)
 {
     int depth = 0;
-    bool cont(true);
 
     curr_var.m_defaultValue.clear();
     while (depth >= 0) {

--- a/CxxParser/typedef_grammar.y
+++ b/CxxParser/typedef_grammar.y
@@ -352,7 +352,6 @@ std::string typedef_consumBracketsContent(char openBrace)
 void typedef_consumeDefaultValue(char c1, char c2)
 {
 	int depth = 0;
-	bool cont(true);
 
 	while (depth >= 0) {
     	int ch = cl_scope_lex();

--- a/CxxParser/typedef_parser.cpp
+++ b/CxxParser/typedef_parser.cpp
@@ -477,7 +477,6 @@ std::string typedef_consumBracketsContent(char openBrace)
 void typedef_consumeDefaultValue(char c1, char c2)
 {
 	int depth = 0;
-	bool cont(true);
 
 	while (depth >= 0) {
     	int ch = cl_scope_lex();

--- a/CxxParser/var_parser.cpp
+++ b/CxxParser/var_parser.cpp
@@ -659,7 +659,6 @@ void var_consumeDefaultValueIfNeeded()
 void var_consumeDefaultValue(char c1, char c2)
 {
     int depth = 0;
-    bool cont(true);
 
     curr_var.m_defaultValue.clear();
     while (depth >= 0) {

--- a/Interfaces/debugger.h
+++ b/Interfaces/debugger.h
@@ -228,7 +228,7 @@ public:
         arch.Write(wxT("useRelativeFilePaths"), useRelativeFilePaths);
         arch.Write(wxT("maxCallStackFrames"), maxCallStackFrames);
         arch.Write(wxT("catchThrow"), catchThrow);
-        arch.Write(wxT("showTooltips"), showTooltipsOnlyWithControlKeyIsDown);
+        arch.Write(wxT("showTooltipsOnlyWithControlKeyIsDown"), showTooltipsOnlyWithControlKeyIsDown);
         arch.Write(wxT("debugAsserts"), debugAsserts);
         arch.WriteCData(wxT("startupCommands"), initFileCommands);
         arch.Write(wxT("maxDisplayStringSize"), maxDisplayStringSize);
@@ -237,11 +237,11 @@ public:
         arch.Write(wxT("autoExpandTipItems"), autoExpandTipItems);
         arch.Write(wxT("applyBreakpointsAfterProgramStarted"), applyBreakpointsAfterProgramStarted);
         arch.Write(wxT("whenBreakpointHitRaiseCodelite"), whenBreakpointHitRaiseCodelite);
-        arch.Write(wxT("cygwinPathCommand"), cygwinPathCommand);
         arch.Write(wxT("charArrAsPtr"), charArrAsPtr);
         arch.Write(wxT("enableGDBPrettyPrinting"), enableGDBPrettyPrinting);
         arch.Write(wxT("defaultHexDisplay"), defaultHexDisplay);
         arch.Write("flags", flags);
+        arch.Write(wxT("cygwinPathCommand"), cygwinPathCommand);
     }
 
     void DeSerialize(Archive& arch)

--- a/LiteEditor/ps_general_page.cpp
+++ b/LiteEditor/ps_general_page.cpp
@@ -140,7 +140,6 @@ void PSGeneralPage::Save(BuildConfigPtr buildConf, ProjectSettingsPtr projSettin
     projSettingsPtr->SetProjectType(GetPropertyAsString(m_pgPropProjectType));
     buildConf->SetBuildSystemArguments(GetPropertyAsString(m_pgPropMakeGeneratorArgs));
     buildConf->SetBuildSystem(GetPropertyAsString(m_pgPropMakeGenerator));
-    buildConf->SetCompilerType(GetPropertyAsString(m_pgPropCompiler));
     buildConf->SetDebuggerType(GetPropertyAsString(m_pgPropDebugger));
     buildConf->SetPauseWhenExecEnds(GetPropertyAsBool(m_pgPropPause));
     buildConf->SetProjectType(GetPropertyAsString(m_pgPropProjectType));
@@ -148,6 +147,12 @@ void PSGeneralPage::Save(BuildConfigPtr buildConf, ProjectSettingsPtr projSettin
     buildConf->SetIsGUIProgram(GetPropertyAsBool(m_pgPropGUIApp));
     buildConf->SetIsProjectEnabled(m_checkBoxEnabled->IsChecked());
     buildConf->SetUseSeparateDebugArgs(GetPropertyAsBool(m_pgPropUseSeparateDebuggerArgs));
+
+    // Do not set an empty compiler, this will be prompted later by the CompilersModifiedDlg
+    wxString compilerType = GetPropertyAsString(m_pgPropCompiler);
+    if(!compilerType.IsEmpty()) {
+        buildConf->SetCompilerType(compilerType);
+    }
 }
 
 void PSGeneralPage::Clear()

--- a/Plugin/builder_gnumake_default.cpp
+++ b/Plugin/builder_gnumake_default.cpp
@@ -1146,13 +1146,14 @@ void BuilderGnuMake::CreateConfigsVariables(ProjectPtr proj, BuildConfigPtr bldC
 
     // Expand the build macros into the generated makefile
     wxString projectName = proj->GetName();
-    wxString projectpath, workspacepath, startupdir;
+    wxString projectpath, workspacepath, startupdir, intermediatedir;
     workspacepath = clCxxWorkspaceST::Get()->GetWorkspaceFileName().GetPath();
     projectpath = proj->GetFileName().GetPath();
     startupdir = clCxxWorkspaceST::Get()->GetStartupDir();
     workspacepath.Replace("\\", "/");
     projectpath.Replace("\\", "/");
     startupdir.Replace("\\", "/");
+    intermediatedir = GetIntermediateFolder(proj, workspacepath);
 
     wxFileName fnOutputFile(GetOutputFolder(proj, bldConf), outputFile.AfterLast('/'));
     outputFile = fnOutputFile.GetFullPath();
@@ -1163,8 +1164,8 @@ void BuilderGnuMake::CreateConfigsVariables(ProjectPtr proj, BuildConfigPtr bldC
     text << "WorkspaceConfiguration := $(ConfigurationName)\n";
     text << "WorkspacePath          :=" << ::WrapWithQuotes(workspacepath) << "\n";
     text << "ProjectPath            :=" << ::WrapWithQuotes(projectpath) << "\n";
-    text << "IntermediateDirectory  :=" << GetIntermediateFolder(proj, workspacepath) << "\n";
-    text << "OutDir                 :=" << GetIntermediateFolder(proj, workspacepath) << "\n";
+    text << "IntermediateDirectory  :=" << intermediatedir << "\n";
+    text << "OutDir                 :=" << intermediatedir << "\n";
     text << "CurrentFileName        :=\n";
     text << "CurrentFilePath        :=\n";
     text << "CurrentFileFullPath    :=\n";

--- a/Plugin/project.cpp
+++ b/Plugin/project.cpp
@@ -1619,7 +1619,7 @@ void Project::GetCompilers(wxStringSet_t& compilers)
     }
 }
 
-void Project::ReplaceCompilers(wxStringMap_t& compilers)
+void Project::ReplaceCompilers(const wxStringMap_t& compilers)
 {
     ProjectSettingsPtr pSettings = GetSettings();
     CHECK_PTR_RET(pSettings);

--- a/Plugin/project.h
+++ b/Plugin/project.h
@@ -409,7 +409,7 @@ public:
      * @brief replace compilers by name. compilers contains a map of the "olbd" compiler
      * name and the new compiler name
      */
-    void ReplaceCompilers(wxStringMap_t& compilers);
+    void ReplaceCompilers(const wxStringMap_t& compilers);
 
     /**
      * @brief the const version of the above

--- a/Plugin/workspace.cpp
+++ b/Plugin/workspace.cpp
@@ -1174,7 +1174,7 @@ void clCxxWorkspace::GetCompilers(wxStringSet_t& compilers)
     }
 }
 
-void clCxxWorkspace::ReplaceCompilers(wxStringMap_t& compilers)
+void clCxxWorkspace::ReplaceCompilers(const wxStringMap_t& compilers)
 {
     clCxxWorkspace::ProjectMap_t::iterator iter = m_projects.begin();
     for(; iter != m_projects.end(); ++iter) {

--- a/Plugin/workspace.h
+++ b/Plugin/workspace.h
@@ -193,7 +193,7 @@ public:
      * @brief replace compilers for all projects and build configurations
      * @param compilers a map of compilers where the key is the old compiler and the value is the new compiler
      */
-    void ReplaceCompilers(wxStringMap_t& compilers);
+    void ReplaceCompilers(const wxStringMap_t& compilers);
 
     /**
      * Returns the workspace file name


### PR DESCRIPTION
* GNU make & bash builder: Fix build and run error with parent directory name containing spaces, for example:
```Makefile
IntermediateDirectory  :="/home/user/a\ directory\ containing\ spaces/workspace"/build-$(ConfigurationName)/__/__/__/__/__
OutDir                 :="/home/user/a\ directory\ containing\ spaces/workspace"/build-$(ConfigurationName)/__/__/__/__/__
```
* CodeFormatter: `Export .clang-format file` points to the workspace directory by default
* CxxParser: Suppress unused variable warnings
* Debugger: Fix a regression (ce33e48) that the setting `Use CTRL key to evaluate expressions under the cursor` doesn't remember its value
* Project Settings: Don't try to save or clone an unnamed compiler