### PR TITLE
Project Settings and Builder improvement

### DIFF
--- a/CMakePlugin/CMakeBuilder.cpp
+++ b/CMakePlugin/CMakeBuilder.cpp
@@ -120,9 +120,13 @@ wxString CMakeBuilder::GetBuildToolCommand(const wxString& project, const wxStri
         return buildTool + " ";
     }
 }
-wxString CMakeBuilder::GetOutputFile() const
+
+Builder::OptimalBuildConfig CMakeBuilder::GetOptimalBuildConfig(const wxString& projectType) const
 {
+    OptimalBuildConfig conf;
     wxChar sep = wxFileName::GetPathSeparator();
-    return wxString() << "$(WorkspacePath)" << sep << CMAKE_BUILD_FOLDER_PREFIX << "$(WorkspaceConfiguration)" << sep
-                      << "output" << sep << "$(ProjectName)";
+    conf.command << "$(WorkspacePath)" << sep << CMAKE_BUILD_FOLDER_PREFIX << "$(WorkspaceConfiguration)" << sep
+                 << "output" << sep << "$(ProjectName)";
+    conf.workingDirectory << "$(WorkspacePath)" << sep << "cmake-build-$(WorkspaceConfiguration)" << sep << "output";
+    return conf;
 }

--- a/CMakePlugin/CMakeBuilder.h
+++ b/CMakePlugin/CMakeBuilder.h
@@ -6,7 +6,7 @@
 class CMakeBuilder : public Builder
 {
 public:
-    virtual wxString GetOutputFile() const;
+    virtual OptimalBuildConfig GetOptimalBuildConfig(const wxString& projectType) const;
     static wxString GetWorkspaceBuildFolder(bool wrapWithQuotes);
     static wxString GetProjectBuildFolder(const wxString& project, bool wrapWithQuotes);
 

--- a/LiteEditor/manager.cpp
+++ b/LiteEditor/manager.cpp
@@ -538,10 +538,11 @@ void Manager::CreateProject(ProjectData& data, const wxString& workspaceFolder)
     // set the compiler type
     ProjectSettingsCookie cookie;
     BuildConfigPtr bldConf = settings->GetFirstBuildConfiguration(cookie);
+    wxString projectType = settings->GetProjectType(wxEmptyString);
     BuilderPtr builder = BuildManagerST::Get()->GetBuilder(data.m_builderName);
-    wxString outputfile;
+    Builder::OptimalBuildConfig optimalConf;
     if(builder) {
-        outputfile = builder->GetOutputFile();
+        optimalConf = builder->GetOptimalBuildConfig(projectType);
     }
     while(bldConf) {
 #ifndef __WXMSW__
@@ -565,33 +566,14 @@ void Manager::CreateProject(ProjectData& data, const wxString& workspaceFolder)
 
         // Update the build system
         bldConf->SetBuildSystem(data.m_builderName);
-        if(data.m_builderName == "CodeLite Make Generator" || data.m_builderName == "CodeLite Makefile Generator") {
-            bldConf->SetIntermediateDirectory("");
-            bldConf->SetOutputFileName("$(ProjectName)");
-            bldConf->SetCommand("$(WorkspacePath)/build-$(WorkspaceConfiguration)/bin/$(OutputFile)");
-            bldConf->SetWorkingDirectory("$(WorkspacePath)/build-$(WorkspaceConfiguration)/lib");
-
-        } else if(data.m_builderName == "CMake") {
-            bldConf->SetIntermediateDirectory("");
-            bldConf->SetOutputFileName("$(ProjectName)");
-            bldConf->SetCommand("$(WorkspacePath)/cmake-build-$(WorkspaceConfiguration)/output/$(ProjectName)");
-            bldConf->SetWorkingDirectory("$(WorkspacePath)/cmake-build-$(WorkspaceConfiguration)/output");
-        } else { // All other generators are based on the "Default" one
-            bldConf->SetIntermediateDirectory("$(ConfigurationName)");
-            bldConf->SetOutputFileName("$(IntermediateDirectory)/$(ProjectName)");
-            bldConf->SetCommand("$(OutputFile)");
-            bldConf->SetWorkingDirectory("");
-        }
-
-        // Set the output file name
-        if(!outputfile.IsEmpty()) {
-            bldConf->SetOutputFileName(wxEmptyString);
-            bldConf->SetCommand(outputfile);
-        }
+        bldConf->SetIntermediateDirectory(optimalConf.intermediateDirectory);
+        bldConf->SetOutputFileName(optimalConf.outputFile);
+        bldConf->SetCommand(optimalConf.command);
+        bldConf->SetWorkingDirectory(optimalConf.workingDirectory);
 
         // Make sure that the build configuration has a project type associated with it
         if(bldConf->GetProjectType().IsEmpty()) {
-            bldConf->SetProjectType(settings->GetProjectType(wxEmptyString));
+            bldConf->SetProjectType(projectType);
         }
         bldConf = settings->GetNextBuildConfiguration(cookie);
     }

--- a/LiteEditor/project_settings.wxcp
+++ b/LiteEditor/project_settings.wxcp
@@ -1003,6 +1003,13 @@
 									"m_functionNameAndSignature":	"OnCustomEditorClicked(wxCommandEvent& event)",
 									"m_description":	"Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the custom editor button is clicked.",
 									"m_noBody":	false
+								}, {
+									"m_eventName":	"wxEVT_PG_CHANGING",
+									"m_eventClass":	"wxPropertyGridEvent",
+									"m_eventHandler":	"wxPropertyGridEventHandler",
+									"m_functionNameAndSignature":	"OnValueChanging(wxPropertyGridEvent& event)",
+									"m_description":	"Respond to wxEVT_PG_CHANGING event, generated when property value is about to be changed by user. Use wxPropertyGridEvent::GetValue() to take a peek at the pending value, and wxPropertyGridEvent::Veto() to prevent change from taking place, if necessary",
+									"m_noBody":	false
 								}],
 							"m_children":	[{
 									"m_type":	4486,

--- a/LiteEditor/project_settings_base_dlg.cpp
+++ b/LiteEditor/project_settings_base_dlg.cpp
@@ -267,6 +267,7 @@ PSGeneralPageBase::PSGeneralPageBase(wxWindow* parent, wxWindowID id, const wxPo
     m_pgMgr136->Connect(wxEVT_UPDATE_UI, wxUpdateUIEventHandler(PSGeneralPageBase::OnProjectCustumBuildUI), NULL, this);
     m_pgMgr136->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(PSGeneralPageBase::OnCustomEditorClicked),
                         NULL, this);
+    m_pgMgr136->Connect(wxEVT_PG_CHANGING, wxPropertyGridEventHandler(PSGeneralPageBase::OnValueChanging), NULL, this);
 }
 
 PSGeneralPageBase::~PSGeneralPageBase()
@@ -278,6 +279,8 @@ PSGeneralPageBase::~PSGeneralPageBase()
                            this);
     m_pgMgr136->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
                            wxCommandEventHandler(PSGeneralPageBase::OnCustomEditorClicked), NULL, this);
+    m_pgMgr136->Disconnect(wxEVT_PG_CHANGING, wxPropertyGridEventHandler(PSGeneralPageBase::OnValueChanging), NULL,
+                           this);
 }
 
 PSCompilerPageBase::PSCompilerPageBase(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size,

--- a/LiteEditor/project_settings_base_dlg.h
+++ b/LiteEditor/project_settings_base_dlg.h
@@ -115,6 +115,7 @@ protected:
     virtual void OnValueChanged(wxPropertyGridEvent& event) { event.Skip(); }
     virtual void OnProjectCustumBuildUI(wxUpdateUIEvent& event) { event.Skip(); }
     virtual void OnCustomEditorClicked(wxCommandEvent& event) { event.Skip(); }
+    virtual void OnValueChanging(wxPropertyGridEvent& event) { event.Skip(); }
 
 public:
     wxCheckBox* GetCheckBoxEnabled() { return m_checkBoxEnabled; }

--- a/LiteEditor/ps_general_page.cpp
+++ b/LiteEditor/ps_general_page.cpp
@@ -23,25 +23,18 @@
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
+#include "ps_general_page.h"
 #include "build_settings_config.h"
+#include "builder.h"
 #include "buildmanager.h"
 #include "dirsaver.h"
 #include "globals.h"
 #include "manager.h"
 #include "project.h"
 #include "project_settings_dlg.h"
-#include "ps_general_page.h"
 #include <algorithm>
 #include <wx/dirdlg.h>
 #include <wx/filedlg.h>
-
-#ifdef __WXMSW__
-#define DYNAMIC_LIB_EXT "dll"
-#elif defined(__WXGTK__)
-#define DYNAMIC_LIB_EXT "so"
-#else
-#define DYNAMIC_LIB_EXT "dylib"
-#endif
 
 PSGeneralPage::PSGeneralPage(wxWindow* parent, const wxString& projectName, const wxString& conf,
                              ProjectSettingsDlg* dlg)
@@ -166,11 +159,44 @@ void PSGeneralPage::Clear()
     m_checkBoxEnabled->SetValue(true);
 }
 
+void PSGeneralPage::OnValueChanging(wxPropertyGridEvent& event)
+{
+    event.Skip();
+    if(event.GetProperty() == m_pgPropProjectType) {
+        BuilderPtr builder = BuildManagerST::Get()->GetBuilder(m_pgPropMakeGenerator->GetValueAsString());
+        if(!builder) {
+            return;
+        }
+        // The project type has changed, adjust the output file extension
+        wxVariant variant = event.GetPropertyValue();
+        wxString oldProjectType = m_pgPropProjectType->GetValueAsString(),
+                 newProjectType = m_pgPropProjectType->ValueToString(variant);
+        static const wxRegEx reFileExt("^(.*)(\\.[a-zA-Z]+)$"); // libfoobar.a -> (libfoobar) (.a)
+        wxString outputFile = m_pgPropOutputFile->GetValueAsString();
+        if(outputFile.IsEmpty()) {
+            // The output file was blank, simply set a default value
+            outputFile = builder->GetOptimalBuildConfig(newProjectType).outputFile;
+        } else if(reFileExt.Matches(outputFile) &&
+                  reFileExt.GetMatch(outputFile, 2).IsSameAs(builder->GetOutputFileSuffix(oldProjectType), false)) {
+            // Update the old file extension
+            outputFile = reFileExt.GetMatch(outputFile, 1) + builder->GetOutputFileSuffix(newProjectType);
+        } else {
+            // Append a file extension because no known extension was set
+            outputFile << builder->GetOutputFileSuffix(newProjectType);
+        }
+        m_pgPropOutputFile->SetValue(outputFile);
+    }
+}
+
 void PSGeneralPage::OnValueChanged(wxPropertyGridEvent& event)
 {
     m_dlg->SetIsDirty(true);
 
     if(event.GetProperty() == m_pgPropMakeGenerator) {
+        BuilderPtr builder = BuildManagerST::Get()->GetBuilder(m_pgPropMakeGenerator->GetValueAsString());
+        if(!builder) {
+            return;
+        }
         wxString dlgmsg;
         dlgmsg = _("Adjust settings to fit this generator?");
         if(::wxMessageBox(dlgmsg, "CodeLite", wxICON_QUESTION | wxYES_NO | wxCANCEL | wxCANCEL_DEFAULT,
@@ -178,106 +204,12 @@ void PSGeneralPage::OnValueChanged(wxPropertyGridEvent& event)
             return;
         }
         // Update the settings
-        m_pgPropOutputFile->SetValue(GetValueFor(kFT_OutputFile));
-        m_pgPropIntermediateFolder->SetValue(GetValueFor(kFT_IntermediateFolder));
-        m_pgPropWorkingDirectory->SetValue(GetValueFor(kFT_WorkingDirectory));
-        eProjectType projectType = GetProjectType();
-        if(projectType == kPT_Executable) {
-            m_pgPropProgram->SetValue(GetValueFor(kFT_Command));
-        }
-    }
-}
-
-wxString PSGeneralPage::GetValueFor(eFieldType fieldType) const
-{
-    eBuildSystem buildSystem = GetBuildSystemType();
-    eProjectType projectType = GetProjectType();
-    if(buildSystem == kBS_CodeLiteMakefileGenerator || buildSystem == kBS_CodeLiteMakefileGeneratorUNIX) {
-        switch(fieldType) {
-        case kFT_OutputFile: {
-            switch(projectType) {
-            case kPT_Executable:
-                return "$(ProjectName)";
-            case kPT_DynamicLibrary:
-                return "lib$(ProjectName).a";
-            default:
-                return (wxString() << "lib$(ProjectName)." << DYNAMIC_LIB_EXT);
-            }
-        }
-        case kFT_IntermediateFolder:
-            return "";
-        case kFT_WorkingDirectory:
-            return "$(WorkspacePath)/build-$(WorkspaceConfiguration)/lib"; // for any dll that this workspace generates
-        case kFT_Command:
-            return "$(WorkspacePath)/build-$(WorkspaceConfiguration)/bin/$(OutputFile)";
-        }
-    } else if(buildSystem == kBS_CMake) {
-        switch(fieldType) {
-        case kFT_OutputFile: {
-            switch(projectType) {
-            case kPT_Executable:
-                return "$(ProjectName)";
-            case kPT_DynamicLibrary:
-                return "lib$(ProjectName).a";
-            default:
-                return (wxString() << "lib$(ProjectName)." << DYNAMIC_LIB_EXT);
-            }
-        }
-        case kFT_IntermediateFolder:
-            return wxEmptyString;
-        case kFT_WorkingDirectory:
-            return "$(WorkspacePath)/cmake-build-$(WorkspaceConfiguration)/output";
-        case kFT_Command:
-            return "$(OutputFile)";
-        }
-    } else { // All other generators are based on the Default generator
-        switch(fieldType) {
-        case kFT_OutputFile: {
-            switch(projectType) {
-            case kPT_Executable:
-                return "$(IntermediateDirectory)/$(ProjectName)";
-            case kPT_DynamicLibrary:
-                return "$(IntermediateDirectory)/lib$(ProjectName).a";
-            default:
-                return (wxString() << "$(IntermediateDirectory)/lib$(ProjectName)." << DYNAMIC_LIB_EXT);
-            }
-        }
-        case kFT_IntermediateFolder:
-            return "$(ConfigurationName)";
-        case kFT_WorkingDirectory:
-            return wxEmptyString;
-        case kFT_Command:
-            return "$(OutputFile)";
-        }
-    }
-    return "";
-}
-
-PSGeneralPage::eProjectType PSGeneralPage::GetProjectType() const
-{
-    wxString projtype = m_pgPropProjectType->GetValueAsString();
-    if(projtype == PROJECT_TYPE_EXECUTABLE) {
-        return kPT_Executable;
-    } else if(projtype == PROJECT_TYPE_STATIC_LIBRARY) {
-        return kPT_StatisLibrary;
-    } else {
-        return kPT_DynamicLibrary;
-    }
-}
-
-PSGeneralPage::eBuildSystem PSGeneralPage::GetBuildSystemType() const
-{
-    wxString generatorName = m_pgPropMakeGenerator->GetValueAsString();
-    if(generatorName == "CodeLite Make Generator" || generatorName == "CodeLite Makefile Generator") {
-        return kBS_CodeLiteMakefileGenerator;
-    } else if(generatorName == "Default") {
-        return kBS_Default;
-    } else if(generatorName == "CMake") {
-        return kBS_CMake;
-    } else if(generatorName == "CodeLite Makefile Generator - UNIX") {
-        return kBS_CodeLiteMakefileGeneratorUNIX;
-    } else {
-        return kBS_Other;
+        Builder::OptimalBuildConfig optimalConf =
+            builder->GetOptimalBuildConfig(m_pgPropProjectType->GetValueAsString());
+        m_pgPropIntermediateFolder->SetValue(optimalConf.intermediateDirectory);
+        m_pgPropOutputFile->SetValue(optimalConf.outputFile);
+        m_pgPropProgram->SetValue(optimalConf.command);
+        m_pgPropWorkingDirectory->SetValue(optimalConf.workingDirectory);
     }
 }
 

--- a/LiteEditor/ps_general_page.h
+++ b/LiteEditor/ps_general_page.h
@@ -46,37 +46,13 @@ class PSGeneralPage : public PSGeneralPageBase, public IProjectSettingsPage
     wxString m_configName;
 
 protected:
-    enum eFieldType {
-        kFT_OutputFile,
-        kFT_IntermediateFolder,
-        kFT_WorkingDirectory,
-        kFT_Command,
-    };
-
-    enum eBuildSystem {
-        kBS_Default,
-        kBS_CodeLiteMakefileGenerator,
-        kBS_CodeLiteMakefileGeneratorUNIX,
-        kBS_CMake, // via plugin
-        kBS_Other,
-    };
-
-    enum eProjectType {
-        kPT_Executable,
-        kPT_DynamicLibrary,
-        kPT_StatisLibrary,
-    };
-
-protected:
     virtual void OnCustomEditorClicked(wxCommandEvent& event);
     virtual void OnProjectEnabled(wxCommandEvent& event);
+    virtual void OnValueChanging(wxPropertyGridEvent& event);
     virtual void OnValueChanged(wxPropertyGridEvent& event);
 
     wxString GetPropertyAsString(wxPGProperty* prop) const;
     bool GetPropertyAsBool(wxPGProperty* prop) const;
-    wxString GetValueFor(eFieldType fieldType) const;
-    PSGeneralPage::eBuildSystem GetBuildSystemType() const;
-    eProjectType GetProjectType() const;
 
 protected:
     // Handlers for PSGeneralPageBase events.

--- a/Plugin/builder.cpp
+++ b/Plugin/builder.cpp
@@ -25,9 +25,10 @@
 
 #include "builder.h"
 #include "build_settings_config.h"
-#include "workspace.h"
 #include "buildmanager.h"
 #include "macros.h"
+#include "project.h"
+#include "workspace.h"
 
 Builder::Builder(const wxString& name)
     : m_name(name)
@@ -69,4 +70,39 @@ void Builder::SetActive()
         else if(builder)
             builder->m_isActive = false;
     }
+}
+
+Builder::OptimalBuildConfig Builder::GetOptimalBuildConfig(const wxString& projectType) const
+{
+    OptimalBuildConfig conf;
+    conf.intermediateDirectory = "$(ConfigurationName)";
+    conf.outputFile = "$(IntermediateDirectory)/";
+    conf.command = "$(OutputFile)";
+
+    if(projectType == PROJECT_TYPE_STATIC_LIBRARY || projectType == PROJECT_TYPE_DYNAMIC_LIBRARY) {
+        conf.outputFile << "lib";
+    }
+    conf.outputFile << "$(ProjectName)" << GetOutputFileSuffix(projectType);
+
+    return conf;
+}
+
+wxString Builder::GetOutputFileSuffix(const wxString& projectType) const
+{
+    if(projectType == PROJECT_TYPE_EXECUTABLE) {
+#ifdef __WXMSW__
+        return ".exe";
+#endif
+    } else if(projectType == PROJECT_TYPE_STATIC_LIBRARY) {
+        return GetStaticLibSuffix();
+    } else if(projectType == PROJECT_TYPE_DYNAMIC_LIBRARY) {
+#ifdef __WXMSW__
+        return ".dll";
+#elif defined(__WXGTK__)
+        return ".so";
+#elif defined(__WXOSX__)
+        return ".dylib";
+#endif
+    }
+    return wxEmptyString;
 }

--- a/Plugin/builder.h
+++ b/Plugin/builder.h
@@ -155,12 +155,34 @@ public:
         const wxString& project, const wxString& confToBuild, const wxString& arguments) = 0;
 
     /**
-     * @brief return the output file path. Return here a path for the output file (the executable or library)
-     * Use CodeLite macros to make it 'portable' and configuration aware
-     * @return if an empty string is returned, CodeLite will use the default
-     * $(IntermediateDirectory)/$(ProjectName)
+     * @brief the optimal build config for use with this builder
      */
-    virtual wxString GetOutputFile() const { return wxEmptyString; }
+    struct OptimalBuildConfig {
+        wxString intermediateDirectory; ///< intermediate directory
+        wxString outputFile;            ///< output file name e.g. lib$(ProjectName).a
+        wxString command;               ///< program execution command
+        wxString workingDirectory;      ///< program execution working directory
+    };
+
+    /**
+     * @brief return the optimal build config for use with this builder
+     * Use CodeLite macros to make it 'portable' and configuration aware
+     * @param projectType executable, static library or dynamic library
+     */
+    virtual OptimalBuildConfig GetOptimalBuildConfig(const wxString& projectType) const;
+
+    /**
+     * @brief return the best file extension (depends on platform) for the project type
+     * @param projectType executable, static library or dynamic library
+     * @return .exe / .dll (Windows), .so (Unix), .dylib (macOS), .a / .lib (static library) or empty
+     */
+    wxString GetOutputFileSuffix(const wxString& projectType) const;
+
+    /**
+     * @brief return static library file extension for the targeted compiler
+     * @return usually .a for GCC, .lib for MSVC
+     */
+    virtual wxString GetStaticLibSuffix() const { return ".a"; }
 };
 
 typedef SmartPtr<Builder> BuilderPtr;

--- a/Plugin/builder_NMake.cpp
+++ b/Plugin/builder_NMake.cpp
@@ -942,15 +942,7 @@ void BuilderNMake::CreateCleanTargets(ProjectPtr proj, const wxString& confToBui
         text << wxT("\t") << wxT("@del /Q ") << imd << "*$(ObjectSuffix)" << wxT("\n");
         text << wxT("\t") << wxT("@del /Q ") << imd << "*$(DependSuffix)" << wxT("\n");
         // delete the output file as well
-        wxString exeExt(wxEmptyString);
-        if(proj->GetSettings()->GetProjectType(bldConf->GetName()) == PROJECT_TYPE_EXECUTABLE) {
-            // under windows, g++ automatically adds the .exe extension to executable
-            // make sure we delete it as well
-            exeExt = wxT(".exe");
-        }
-
         text << wxT("\t") << wxT("@del /Q ") << wxT("$(OutputFile)") << wxT("\n");
-        text << wxT("\t") << wxT("@del /Q ") << wxT("$(OutputFile)") << exeExt << wxT("\n");
         text << wxT("\t") << wxT("@del /Q ") << DoGetMarkerFileDir(proj->GetName(), proj->GetFileName().GetPath())
              << wxT("\n");
 
@@ -1036,7 +1028,7 @@ void BuilderNMake::CreateTargets(const wxString& type, BuildConfigPtr bldConf, w
     CompilerPtr cmp = bldConf->GetCompiler();
 
     // this is a special target that creates a file with the content of the
-    // $(Objects) variable (to be used with the @<file-name> option of the LINK
+    // $(Objects) variable (to be used with the @<file-name> option of the LINK)
     if(m_hasObjectPCH) {
         text << "\t@echo $(ObjectPCH) > $(ObjectsFileList)\n";
     }
@@ -1944,4 +1936,13 @@ bool BuilderNMake::SendBuildEvent(int eventId, const wxString& projectName, cons
     e.SetProjectName(projectName);
     e.SetConfigurationName(configurationName);
     return EventNotifier::Get()->ProcessEvent(e);
+}
+
+Builder::OptimalBuildConfig BuilderNMake::GetOptimalBuildConfig(const wxString& projectType) const
+{
+    OptimalBuildConfig conf;
+    conf.intermediateDirectory = "$(ConfigurationName)";
+    conf.outputFile << "$(IntermediateDirectory)/$(ProjectName)" << GetOutputFileSuffix(projectType);
+    conf.command = "$(OutputFile)";
+    return conf;
 }

--- a/Plugin/builder_NMake.h
+++ b/Plugin/builder_NMake.h
@@ -59,6 +59,8 @@ public:
                                           const wxString& arguments, const wxString& fileName, wxString& errMsg);
     virtual wxString GetPORebuildCommand(const wxString& project, const wxString& confToBuild,
                                          const wxString& arguments);
+    virtual OptimalBuildConfig GetOptimalBuildConfig(const wxString& projectType) const;
+    virtual wxString GetStaticLibSuffix() const { return ".lib"; }
 
 protected:
     virtual void CreateListMacros(ProjectPtr proj, const wxString& confToBuild, wxString& text);

--- a/Plugin/builder_gnumake_default.cpp
+++ b/Plugin/builder_gnumake_default.cpp
@@ -1854,3 +1854,17 @@ bool BuilderGnuMake::IsResourceFile(const Compiler::CmpFileTypeInfo& file_type) 
 {
     return file_type.kind == Compiler::CmpFileKindResource;
 }
+
+Builder::OptimalBuildConfig BuilderGnuMake::GetOptimalBuildConfig(const wxString& projectType) const
+{
+    OptimalBuildConfig conf;
+    conf.command = "$(WorkspacePath)/build-$(WorkspaceConfiguration)/bin/$(OutputFile)";
+    conf.workingDirectory = "$(WorkspacePath)/build-$(WorkspaceConfiguration)/lib";
+
+    if(projectType == PROJECT_TYPE_STATIC_LIBRARY || projectType == PROJECT_TYPE_DYNAMIC_LIBRARY) {
+        conf.outputFile << "lib";
+    }
+    conf.outputFile << "$(ProjectName)" << GetOutputFileSuffix(projectType);
+
+    return conf;
+}

--- a/Plugin/builder_gnumake_default.h
+++ b/Plugin/builder_gnumake_default.h
@@ -69,6 +69,7 @@ public:
                                           const wxString& arguments, const wxString& fileName, wxString& errMsg);
     virtual wxString GetPORebuildCommand(const wxString& project, const wxString& confToBuild,
                                          const wxString& arguments);
+    virtual OptimalBuildConfig GetOptimalBuildConfig(const wxString& projectType) const;
 
 protected:
     virtual wxString MakeDir(const wxString& path);

--- a/Runtime/templates/projects/vc-dynamic-library/vc-dynamic-library.project
+++ b/Runtime/templates/projects/vc-dynamic-library/vc-dynamic-library.project
@@ -17,7 +17,7 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       <ResourceCompiler Options=""/>
     </GlobalSettings>
     <Configuration Name="Debug" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="/c;/EHsc;/Od;/Zi" C_Options="/c;/Od;/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/MDd;/Od;/Zi" C_Options="/c;/MDd;/Od;/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="/DEF:$(ProjectName).def /DEBUG" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).dll" IntermediateDirectory="" Command="" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="no" IsGUIProgram="no" IsEnabled="yes"/>
@@ -54,7 +54,7 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       </Completion>
     </Configuration>
     <Configuration Name="Release" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="/c;/EHsc;/O2" C_Options="/c;/O2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/MD;/O2" C_Options="/c;/MD;/O2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="/DEF:$(ProjectName).def" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).dll" IntermediateDirectory="" Command="" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="no" IsGUIProgram="no" IsEnabled="yes"/>

--- a/Runtime/templates/projects/vc-executable/vc-executable.project
+++ b/Runtime/templates/projects/vc-executable/vc-executable.project
@@ -17,7 +17,7 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       <ResourceCompiler Options=""/>
     </GlobalSettings>
     <Configuration Name="Debug" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="/c;/EHsc;/Od;/Zi" C_Options="/c;/Od;/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/MDd;/Od;/Zi" C_Options="/c;/MDd;/Od;/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="/DEBUG" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).exe" IntermediateDirectory="" Command="$(ProjectName).exe" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
@@ -54,7 +54,7 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       </Completion>
     </Configuration>
     <Configuration Name="Release" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="/c;/EHsc;/O2" C_Options="/c;/O2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/MD;/O2" C_Options="/c;/MD;/O2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).exe" IntermediateDirectory="" Command="$(ProjectName).exe" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>

--- a/Runtime/templates/projects/vc-static-lib/vc-static-lib.project
+++ b/Runtime/templates/projects/vc-static-lib/vc-static-lib.project
@@ -17,7 +17,7 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       <ResourceCompiler Options=""/>
     </GlobalSettings>
     <Configuration Name="Debug" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="/c;/EHsc;/Od;/Zi" C_Options="/c;/Od;/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/MDd;/Od;/Zi" C_Options="/c;/MDd;/Od;/Zi" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).lib" IntermediateDirectory="" Command="" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="no" IsGUIProgram="no" IsEnabled="yes"/>
@@ -54,7 +54,7 @@ Note that this project is set to work with the Microsoft(R) toolchain (CL, LINK)
       </Completion>
     </Configuration>
     <Configuration Name="Release" CompilerType="VC++" DebuggerType="GNU gdb debugger" Type="" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="/c;/EHsc;/O2" C_Options="/c;/O2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
+      <Compiler Options="/c;/EHsc;/MD;/O2" C_Options="/c;/MD;/O2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="1"/>
       <Linker Options="" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(ProjectName).lib" IntermediateDirectory="" Command="" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="no" IsGUIProgram="no" IsEnabled="yes"/>


### PR DESCRIPTION
* Makefile builder's *best project settings* can be obtained from the builder object.
They were previously hard-coded in two places: `LiteEditor/manager.cpp` and `LiteEditor/ps_general_page.cpp`, so I've moved them to the builder's `GetOptimalBuildConfig()` method.

* Auto-detect and set proper output file extension (`exe`, `lib`, `dll`, `a`, `so`, `dylib`) for the given project type.
Whenever the `Project Type` or `Makefile Generator` changes, adjust the `Output File` as well, for example:
`Executable`: `Foo` or `Foo.exe`.
`Static Library`: `libFoo.a` or `Foo.lib`.
`Dynamic Library`: `libFoo.so`, `libFoo.dylib` or `Foo.dll`.

* MSVC project templates: Use [/MT(d)](https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-160) compiler option by default (just like their IDE).