### PR TITLE
Add option to enable spell checking on wxTextCtrl from within wxCrafter.

### DIFF
--- a/wxcrafter/text_ctrl_wrapper.cpp
+++ b/wxcrafter/text_ctrl_wrapper.cpp
@@ -43,6 +43,11 @@ TextCtrlWrapper::TextCtrlWrapper()
     AddProperty(new StringProperty(PROP_HINT, "", _("Sets a hint shown in an empty unfocused text control")));
     AddProperty(new StringProperty(PROP_MAXLENGTH, wxT("0"),
                                    _("The maximum length of user entered text. Only for single-line wxTextCtrls.")));
+#if wxUSE_SPELLCHECK
+    AddProperty(new BoolProperty(PROP_SPELLCHECK, false, 
+        _("Enable spell checking using the operating system provided text proofing tools. "
+          "This function is only available on OSX, Windows 8 (or newer), and GTK3 (or newer).")));
+#endif // wxUSE_SPELLCHECK
     AddProperty(new BoolProperty(
         PROP_AUTO_COMPLETE_DIRS, false,
         _("Enable auto-completion of the text using the file system directories. Notice that currently this function "
@@ -73,6 +78,14 @@ wxString TextCtrlWrapper::CppCtorCode() const
         code << GetName() << "->SetHint(" << wxCrafter::UNDERSCORE(PropertyString(PROP_HINT)) << ");\n";
         code << wxCrafter::WXVER_CHECK_BLOCK_END();
     }
+
+#if wxUSE_SPELLCHECK
+    if(IsPropertyChecked(PROP_SPELLCHECK)) {
+        code << "\n#if wxUSE_SPELLCHECK\n";
+        code << GetName() << "->EnableProofCheck();\n";
+        code << "#endif\n";
+    }
+#endif // wxUSE_SPELLCHECK
 
     if(IsPropertyChecked(PROP_AUTO_COMPLETE_DIRS)) {
         code << GetName() << "->AutoCompleteDirectories();\n";

--- a/wxcrafter/wxgui_defs.h
+++ b/wxcrafter/wxgui_defs.h
@@ -269,6 +269,7 @@ class wxcWidget;
 #define PROP_DIRECTION wxTRANSLATE("Direction")
 #define PROP_ANIM_AUTO_PLAY wxTRANSLATE("Load and play")
 #define PROP_PROPORTION wxTRANSLATE("Proportion:")
+#define PROP_SPELLCHECK wxTRANSLATE("Enable Spell Checking")
 ///////////////////////////////////////////////////////////////////////////////////////
 
 struct WxStyleInfo {


### PR DESCRIPTION
Recent updates to wxWidgets include native spell checking on wxTextCtrl widgets. 

This pull request adds an option to wxCrafter to enable spell checking on individual wxTextCtrl if required.

Note: This feature is only available on newer versions of Windows (>= 8) and GTK (>= 3). All recent versions of OSX should also work.