### PR TITLE
LSP: Add support for `textDocument/hover`

### DIFF
--- a/CodeLite/CodeLite.project
+++ b/CodeLite/CodeLite.project
@@ -45,6 +45,8 @@
     </Plugin>
   </Plugins>
   <VirtualDirectory Name="LSP">
+    <File Name="LSP/HoverRequest.hpp"/>
+    <File Name="LSP/HoverRequest.cpp"/>
     <File Name="LSP/SemanticTokensRquest.cpp"/>
     <File Name="LSP/SemanticTokensRquest.hpp"/>
     <File Name="LSP/FilePath.cpp"/>

--- a/CodeLite/LSP/HoverRequest.cpp
+++ b/CodeLite/LSP/HoverRequest.cpp
@@ -1,0 +1,29 @@
+#include "LSP/LSPEvent.h"
+#include "HoverRequest.hpp"
+
+LSP::HoverRequest::HoverRequest(const wxString& filename, size_t line, size_t column)
+    : m_filename(filename)
+    , m_line(line)
+    , m_column(column)
+{
+    SetMethod("textDocument/hover");
+    m_params.reset(new TextDocumentPositionParams());
+    m_params->As<TextDocumentPositionParams>()->SetTextDocument(TextDocumentIdentifier(filename));
+    m_params->As<TextDocumentPositionParams>()->SetPosition(Position(line, column));
+}
+
+LSP::HoverRequest::~HoverRequest() {}
+
+void LSP::HoverRequest::OnResponse(const LSP::ResponseMessage& response, wxEvtHandler* owner)
+{
+    if(!response.Has("result")) {
+        return;
+    }
+    JSONItem res = response.Get("result");
+    LSP::Hover h;
+    h.FromJSON(res);
+
+    LSPEvent event(wxEVT_LSP_HOVER);
+    event.SetHover(h);
+    owner->AddPendingEvent(event);
+}

--- a/CodeLite/LSP/HoverRequest.hpp
+++ b/CodeLite/LSP/HoverRequest.hpp
@@ -1,0 +1,23 @@
+#ifndef HOVERREQUEST_H
+#define HOVERREQUEST_H
+
+#include "LSP/Request.h"
+#include "LSP/ResponseMessage.h"
+#include <wx/filename.h>
+
+namespace LSP
+{
+class WXDLLIMPEXP_CL HoverRequest : public LSP::Request
+{
+    wxString m_filename;
+    size_t m_line = 0;
+    size_t m_column = 0;
+
+public:
+    explicit HoverRequest(const wxString& filename, size_t line, size_t column);
+    virtual ~HoverRequest();
+
+    void OnResponse(const LSP::ResponseMessage& response, wxEvtHandler* owner);
+};
+};     // namespace LSP
+#endif // HOVERREQUEST_H

--- a/CodeLite/LSP/InitializeRequest.cpp
+++ b/CodeLite/LSP/InitializeRequest.cpp
@@ -35,12 +35,13 @@ JSONItem LSP::InitializeRequest::ToJSON(const wxString& name) const
         }
     }
 
-    auto docFormat = params.AddObject("capabilities")
-                         .AddObject("textDocument")
-                         .AddObject("completion")
-                         .AddObject("completionItem")
-                         .AddArray("documentationFormat");
+    auto textDocumentCapabilities = params.AddObject("capabilities").AddObject("textDocument");
+    auto docFormat =
+        textDocumentCapabilities.AddObject("completion").AddObject("completionItem").AddArray("documentationFormat");
     docFormat.arrayAppend("plaintext");
+    auto hoverFormat = textDocumentCapabilities.AddObject("hover").AddArray("contentFormat");
+    hoverFormat.arrayAppend("markdown");
+    hoverFormat.arrayAppend("plaintext");
     return json;
 }
 

--- a/CodeLite/LSP/LSPEvent.cpp
+++ b/CodeLite/LSP/LSPEvent.cpp
@@ -7,6 +7,7 @@ wxDEFINE_EVENT(wxEVT_LSP_RESTART_NEEDED, LSPEvent);
 wxDEFINE_EVENT(wxEVT_LSP_REPARSE_NEEDED, LSPEvent);
 wxDEFINE_EVENT(wxEVT_LSP_METHOD_NOT_FOUND, LSPEvent);
 wxDEFINE_EVENT(wxEVT_LSP_SIGNATURE_HELP, LSPEvent);
+wxDEFINE_EVENT(wxEVT_LSP_HOVER, LSPEvent);
 wxDEFINE_EVENT(wxEVT_LSP_SET_DIAGNOSTICS, LSPEvent);
 wxDEFINE_EVENT(wxEVT_LSP_CLEAR_DIAGNOSTICS, LSPEvent);
 wxDEFINE_EVENT(wxEVT_LSP_DOCUMENT_SYMBOLS, LSPEvent);
@@ -33,6 +34,7 @@ LSPEvent& LSPEvent::operator=(const LSPEvent& other)
     m_serverName = other.m_serverName;
     m_completions = other.m_completions;
     m_signatureHelp = other.m_signatureHelp;
+    m_hover = other.m_hover;
     m_diagnostics = other.m_diagnostics;
     m_symbolsInformation = other.m_symbolsInformation;
     m_semanticTokens = other.m_semanticTokens;

--- a/CodeLite/LSP/LSPEvent.h
+++ b/CodeLite/LSP/LSPEvent.h
@@ -23,6 +23,7 @@ protected:
     wxString m_serverName;
     LSP::CompletionItem::Vec_t m_completions;
     LSP::SignatureHelp m_signatureHelp;
+    LSP::Hover m_hover;
     std::vector<LSP::Diagnostic> m_diagnostics;
     std::vector<LSP::SymbolInformation> m_symbolsInformation;
     std::vector<LSP::SemanticTokenRange> m_semanticTokens;
@@ -72,6 +73,12 @@ public:
         return *this;
     }
     const LSP::SignatureHelp& GetSignatureHelp() const { return m_signatureHelp; }
+    LSPEvent& SetHover(const LSP::Hover& hover)
+    {
+        this->m_hover = hover;
+        return *this;
+    }
+    const LSP::Hover& GetHover() const { return m_hover; }
     LSPEvent& SetDiagnostics(const std::vector<LSP::Diagnostic>& diagnostics)
     {
         this->m_diagnostics = diagnostics;
@@ -98,6 +105,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_LSP_RESTART_NEEDED, LSPEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_LSP_REPARSE_NEEDED, LSPEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_LSP_METHOD_NOT_FOUND, LSPEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_LSP_SIGNATURE_HELP, LSPEvent);
+wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_LSP_HOVER, LSPEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_LSP_SET_DIAGNOSTICS, LSPEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_LSP_CLEAR_DIAGNOSTICS, LSPEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_LSP_OPEN_FILE, LSPEvent);

--- a/CodeLite/LSP/basic_types.cpp
+++ b/CodeLite/LSP/basic_types.cpp
@@ -45,8 +45,8 @@ JSONItem VersionedTextDocumentIdentifier::ToJSON(const wxString& name) const
 //===----------------------------------------------------------------------------------
 void Position::FromJSON(const JSONItem& json)
 {
-    m_line = json.namedObject("line").toInt(0);
-    m_character = json.namedObject("character").toInt(0);
+    m_line = json.namedObject("line").toInt(wxNOT_FOUND);
+    m_character = json.namedObject("character").toInt(wxNOT_FOUND);
 }
 
 JSONItem Position::ToJSON(const wxString& name) const
@@ -206,6 +206,34 @@ JSONItem SignatureHelp::ToJSON(const wxString& name) const
     }
     json.addProperty("activeSignature", m_activeSignature);
     json.addProperty("activeParameter", m_activeParameter);
+    return json;
+}
+
+void MarkupContent::FromJSON(const JSONItem& json)
+{
+    m_kind = json.namedObject("kind").toString();
+    m_value = json.namedObject("value").toString();
+}
+
+JSONItem MarkupContent::ToJSON(const wxString& name) const
+{
+    JSONItem json = JSONItem::createObject(name);
+    json.addProperty("kind", m_kind);
+    json.addProperty("value", m_value);
+    return json;
+}
+
+void Hover::FromJSON(const JSONItem& json)
+{
+    m_contents.FromJSON(json.namedObject("contents"));
+    m_range.FromJSON(json.namedObject("range"));
+}
+
+JSONItem Hover::ToJSON(const wxString& name) const
+{
+    JSONItem json = JSONItem::createObject(name);
+    json.append(m_contents.ToJSON("contents"));
+    json.append(m_range.ToJSON("range"));
     return json;
 }
 

--- a/CodeLite/LSP/basic_types.h
+++ b/CodeLite/LSP/basic_types.h
@@ -147,6 +147,22 @@ public:
     }
     Position() {}
     virtual ~Position() {}
+    bool operator==(const Position& rhs) const
+    {
+        return this->m_line == rhs.m_line && this->m_character == rhs.m_character;
+    }
+    bool operator!=(const Position& rhs) const { return !(*this == rhs); }
+    bool operator<(const Position& rhs) const
+    {
+        if(this->m_line == rhs.m_line) {
+            return this->m_character < rhs.m_character;
+        } else {
+            return this->m_line < rhs.m_line;
+        }
+    }
+    bool operator>(const Position& rhs) const { return rhs < *this; }
+    bool operator<=(const Position& rhs) const { return !(*this > rhs); }
+    bool operator>=(const Position& rhs) const { return !(*this < rhs); }
     Position& SetCharacter(int character)
     {
         this->m_character = character;
@@ -390,6 +406,54 @@ public:
     int GetActiveParameter() const { return m_activeParameter; }
     int GetActiveSignature() const { return m_activeSignature; }
     const SignatureInformation::Vec_t& GetSignatures() const { return m_signatures; }
+    virtual void FromJSON(const JSONItem& json);
+    virtual JSONItem ToJSON(const wxString& name) const;
+};
+
+class WXDLLIMPEXP_CL MarkupContent : public LSP::Serializable
+{
+    wxString m_kind;
+    wxString m_value;
+
+public:
+    MarkupContent() {}
+    virtual ~MarkupContent() {}
+    MarkupContent& SetKind(const wxString& kind)
+    {
+        this->m_kind = kind;
+        return *this;
+    }
+    const wxString& GetKind() const { return m_kind; }
+    MarkupContent& SetValue(const wxString& value)
+    {
+        this->m_value = value;
+        return *this;
+    }
+    const wxString& GetValue() const { return m_value; }
+    virtual void FromJSON(const JSONItem& json);
+    virtual JSONItem ToJSON(const wxString& name) const;
+};
+
+class WXDLLIMPEXP_CL Hover : public LSP::Serializable
+{
+    MarkupContent m_contents;
+    Range m_range;
+
+public:
+    Hover() {}
+    virtual ~Hover() {}
+    Hover& SetContents(const MarkupContent& contents)
+    {
+        this->m_contents = contents;
+        return *this;
+    }
+    const MarkupContent& GetContents() const { return m_contents; }
+    Hover& SetRange(const Range& range)
+    {
+        this->m_range = range;
+        return *this;
+    }
+    const Range& GetRange() const { return m_range; }
     virtual void FromJSON(const JSONItem& json);
     virtual JSONItem ToJSON(const wxString& name) const;
 };

--- a/Interfaces/ieditor.h
+++ b/Interfaces/ieditor.h
@@ -181,6 +181,11 @@ public:
     virtual const wxString& GetProjectName() const = 0;
 
     /**
+     * @brief return the position under the mouse pointer
+     */
+    virtual int GetPosAtMousePointer() = 0;
+
+    /**
      * \brief return the current word under the caret. May return wxEmptyString
      */
     virtual wxString GetWordAtCaret(bool wordCharsOnly = true) = 0;
@@ -298,6 +303,13 @@ public:
      * @param tip tip to display
      */
     virtual void ShowCalltip(clCallTipPtr tip) = 0;
+
+    /**
+     * @brief display a tooltip
+     * @param tip tip text
+     * @param pos position for the tip. If wxNOT_FOUND the tip is positioned at the mouse
+     */
+    virtual void ShowTooltip(const wxString& tip, const wxString& title, int pos = wxNOT_FOUND) = 0;
 
     /**
      * @brief display a rich tooltip (a tip that supports basic markup, such as <a></a>, <strong></strong> etc)

--- a/LanguageServer/LanguageServerCluster.h
+++ b/LanguageServer/LanguageServerCluster.h
@@ -47,6 +47,7 @@ public:
 
 protected:
     void OnSignatureHelp(LSPEvent& event);
+    void OnHover(LSPEvent& event);
     void OnSymbolFound(LSPEvent& event);
     void OnCompletionReady(LSPEvent& event);
     void OnReparseNeeded(LSPEvent& event);

--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -5304,6 +5304,13 @@ bool clEditor::IsDetached() const
     return (tlw && (clMainFrame::Get() != tlw));
 }
 
+int clEditor::GetPosAtMousePointer()
+{
+    wxPoint mousePtInScreenCoord = ::wxGetMousePosition();
+    wxPoint clientPt = ScreenToClient(mousePtInScreenCoord);
+    return PositionFromPoint(clientPt);
+}
+
 void clEditor::GetWordAtMousePointer(wxString& word, wxRect& wordRect)
 {
     word.clear();
@@ -5312,9 +5319,7 @@ void clEditor::GetWordAtMousePointer(wxString& word, wxRect& wordRect)
     long start = wxNOT_FOUND;
     long end = wxNOT_FOUND;
     if(GetSelectedText().IsEmpty()) {
-        wxPoint mousePtInScreenCoord = ::wxGetMousePosition();
-        wxPoint clientPt = ScreenToClient(mousePtInScreenCoord);
-        int pos = PositionFromPoint(clientPt);
+        int pos = GetPosAtMousePointer();
         if(pos != wxNOT_FOUND) {
             start = WordStartPosition(pos, true);
             end = WordEndPosition(pos, true);
@@ -5334,6 +5339,11 @@ void clEditor::GetWordAtMousePointer(wxString& word, wxRect& wordRect)
 
     word = GetTextRange(start, end);
     wordRect = rr;
+}
+
+void clEditor::ShowTooltip(const wxString& tip, const wxString& title, int pos)
+{
+    DoShowCalltip(pos, title, tip, false);
 }
 
 void clEditor::ShowRichTooltip(const wxString& tip, const wxString& title, int pos)

--- a/LiteEditor/cl_editor.h
+++ b/LiteEditor/cl_editor.h
@@ -839,6 +839,8 @@ public:
     const wxFileName& GetFileName() const override { return m_fileName; }
     const wxString& GetProjectName() const override { return m_project; }
 
+    int GetPosAtMousePointer() override;
+
     /**
      * @brief
      * @return
@@ -956,6 +958,13 @@ public:
      * @brief return true if the current editor is detached from the mainbook
      */
     bool IsDetached() const;
+
+    /**
+     * @brief display a tooltip (title + tip)
+     * @param tip tip text
+     * @param pos position for the tip. If wxNOT_FOUND the tip is positioned at mouse cursor position
+     */
+    void ShowTooltip(const wxString& tip, const wxString& title, int pos = wxNOT_FOUND) override;
 
     /**
      * @brief display a rich tooltip (title + tip)

--- a/Plugin/LanguageServerProtocol.h
+++ b/Plugin/LanguageServerProtocol.h
@@ -85,6 +85,7 @@ protected:
     void OnFindSymbolImpl(clCodeCompletionEvent& event);
     void OnFindSymbol(clCodeCompletionEvent& event);
     void OnFunctionCallTip(clCodeCompletionEvent& event);
+    void OnTypeInfoToolTip(clCodeCompletionEvent& event);
     void OnQuickOutline(clCodeCompletionEvent& event);
     void OnSemanticHighlights(clCodeCompletionEvent& event);
 
@@ -226,6 +227,11 @@ public:
      * @brief ask for function call help
      */
     void FunctionHelp(IEditor* editor);
+
+    /**
+     * @brief ask for available hovertip
+     */
+    void HoverTip(IEditor* editor);
 
     /**
      * @brief manually load file into the server

--- a/Plugin/mdparser.hpp
+++ b/Plugin/mdparser.hpp
@@ -31,6 +31,7 @@ class Tokenizer
     const wxString& m_text;
     size_t m_pos = 0;
     int m_text_sequence = 0;
+    bool m_enable_backslash_esc = true;
 
 private:
     wxChar safe_get_char(size_t pos) const;
@@ -42,6 +43,7 @@ public:
     }
     std::pair<Type, wxString> next();
     void consume_until(wxChar ch);
+    void enable_backslash_esc(bool enable) { m_enable_backslash_esc = enable; }
 };
 
 // font definition


### PR DESCRIPTION
This PR makes `Display type info tooltips` to take the advantage of Language Server:
![lsp-hover-fixed](https://user-images.githubusercontent.com/32811754/142772127-8426484e-8875-4334-acdb-2bf5531669ce.png)