### PR TITLE
A few more LSP hover and markdown fixes

### DIFF
--- a/CodeLite/LSP/HoverRequest.hpp
+++ b/CodeLite/LSP/HoverRequest.hpp
@@ -1,5 +1,5 @@
-#ifndef HOVERREQUEST_H
-#define HOVERREQUEST_H
+#ifndef HOVERREQUEST_HPP
+#define HOVERREQUEST_HPP
 
 #include "LSP/Request.h"
 #include "LSP/ResponseMessage.h"
@@ -20,4 +20,4 @@ public:
     void OnResponse(const LSP::ResponseMessage& response, wxEvtHandler* owner);
 };
 };     // namespace LSP
-#endif // HOVERREQUEST_H
+#endif // HOVERREQUEST_HPP

--- a/CodeLite/StringUtils.cpp
+++ b/CodeLite/StringUtils.cpp
@@ -90,6 +90,17 @@ void StringUtils::StripTerminalColouring(const wxString& buffer, wxString& modbu
     }
 }
 
+void StringUtils::DisableMarkdownStyling(wxString& buffer)
+{
+    buffer.Replace("\\", "\\\\");
+    buffer.Replace("#", "\\#");
+    buffer.Replace("-", "\\-");
+    buffer.Replace("=", "\\=");
+    buffer.Replace("*", "\\*");
+    buffer.Replace("~", "\\~");
+    buffer.Replace("`", "\\`");
+}
+
 #define ARGV_STATE_NORMAL 0
 #define ARGV_STATE_DQUOTE 1
 #define ARGV_STATE_SQUOTE 2

--- a/CodeLite/StringUtils.h
+++ b/CodeLite/StringUtils.h
@@ -26,8 +26,8 @@
 #define STRINGUTILS_H
 
 #include "codelite_exports.h"
-#include <wx/string.h>
 #include <wx/arrstr.h>
+#include <wx/string.h>
 
 class WXDLLIMPEXP_CL StringUtils
 {
@@ -36,7 +36,7 @@ public:
      * @brief convert string into std::string
      */
     static std::string ToStdString(const wxString& str);
-    
+
     /**
      * @brief remove terminal colours from buffer
      */
@@ -47,17 +47,22 @@ public:
      * @param modbuffer
      */
     static void StripTerminalColouring(const wxString& buffer, wxString& modbuffer);
-    
+
+    /**
+     * @brief add backslash to markdown styling characters
+     */
+    static void DisableMarkdownStyling(wxString& buffer);
+
     /**
      * @brief build argv out of str
      */
-    static char** BuildArgv(const wxString& str, int &argc);
-    
+    static char** BuildArgv(const wxString& str, int& argc);
+
     /**
      * @brief build argv out of str
      */
     static wxArrayString BuildArgv(const wxString& str);
-    
+
     /**
      * @brief free argv created by StringUtils::BuildArgv method
      */

--- a/Interfaces/ieditor.h
+++ b/Interfaces/ieditor.h
@@ -309,7 +309,7 @@ public:
      * @param tip tip text
      * @param pos position for the tip. If wxNOT_FOUND the tip is positioned at the mouse
      */
-    virtual void ShowTooltip(const wxString& tip, const wxString& title, int pos = wxNOT_FOUND) = 0;
+    virtual void ShowTooltip(const wxString& tip, const wxString& title = wxEmptyString, int pos = wxNOT_FOUND) = 0;
 
     /**
      * @brief display a rich tooltip (a tip that supports basic markup, such as <a></a>, <strong></strong> etc)

--- a/LanguageServer/LanguageServerCluster.cpp
+++ b/LanguageServer/LanguageServerCluster.cpp
@@ -184,7 +184,13 @@ void LanguageServerCluster::OnHover(LSPEvent& event)
         }
     }
 
-    editor->ShowTooltip(contents.GetValue(), "");
+    if(contents.GetKind() == "markdown") {
+        editor->ShowTooltip(contents.GetValue());
+    } else {
+        wxString fixedTip = contents.GetValue();
+        StringUtils::DisableMarkdownStyling(fixedTip);
+        editor->ShowTooltip(fixedTip);
+    }
 }
 
 void LanguageServerCluster::OnMethodNotFound(LSPEvent& event)

--- a/LiteEditor/cl_editor.h
+++ b/LiteEditor/cl_editor.h
@@ -964,7 +964,7 @@ public:
      * @param tip tip text
      * @param pos position for the tip. If wxNOT_FOUND the tip is positioned at mouse cursor position
      */
-    void ShowTooltip(const wxString& tip, const wxString& title, int pos = wxNOT_FOUND) override;
+    void ShowTooltip(const wxString& tip, const wxString& title = wxEmptyString, int pos = wxNOT_FOUND) override;
 
     /**
      * @brief display a rich tooltip (title + tip)

--- a/Plugin/clMarkdownRenderer.cpp
+++ b/Plugin/clMarkdownRenderer.cpp
@@ -41,6 +41,7 @@ void clMarkdownRenderer::UpdateFont(wxDC& dc, const mdparser::Style& style)
     f.SetPointSize(point_size);
     f.SetWeight(style.font_weight == mdparser::Style::FONTWEIGHT_BOLD ? wxFONTWEIGHT_BOLD : wxFONTWEIGHT_NORMAL);
     f.SetStyle(style.font_style == mdparser::Style::FONTSTYLE_ITALIC ? wxFONTSTYLE_ITALIC : wxFONTSTYLE_NORMAL);
+    f.SetStrikethrough(style.font_strikethrough);
     dc.SetFont(f);
 }
 

--- a/Plugin/mdparser.cpp
+++ b/Plugin/mdparser.cpp
@@ -59,6 +59,14 @@ std::pair<mdparser::Type, wxString> mdparser::Tokenizer::next()
                 RETURN_TYPE(T_ITALIC, "*", 0);
             }
             break;
+        case '~':
+            // strikethrough
+            if(ch1 == '~') {
+                RETURN_TYPE(T_STRIKE, "~~", 1);
+            } else {
+                RETURN_TYPE(T_TEXT, ch0, 0);
+            }
+            break;
         case '`':
             // code blocks ``` & `
             if(ch1 == '`' && ch2 == '`') {
@@ -150,6 +158,7 @@ void mdparser::Parser::parse(const wxString& input_str, write_callback_t on_writ
             // below are style styles
             case T_BOLD:
             case T_ITALIC:
+            case T_STRIKE:
                 flush_buffer(buffer, style, false);
                 style.toggle_property(tok.first);
                 break;

--- a/Plugin/mdparser.hpp
+++ b/Plugin/mdparser.hpp
@@ -12,18 +12,20 @@
 namespace mdparser
 {
 enum Type : int {
-    T_TEXT = (1 << 0),      // normal state
-    T_H1 = (1 << 1),        // #
-    T_H2 = (1 << 2),        // ##
-    T_H3 = (1 << 3),        // ###
-    T_LI = (1 << 4),        // -
-    T_HR = (1 << 5),        // === or ---
-    T_BOLD = (1 << 6),      // **
-    T_ITALIC = (1 << 7),    // *
-    T_CODE = (1 << 8),      // `
-    T_CODEBLOCK = (1 << 9), // ```
-    T_EOL = (1 << 10),      // \n
-    T_EOF = 0,              // End of file
+    // See also: StringUtils::DisableMarkdownStyling()
+    T_TEXT = (1 << 0),       // normal state
+    T_H1 = (1 << 1),         // #
+    T_H2 = (1 << 2),         // ##
+    T_H3 = (1 << 3),         // ###
+    T_LI = (1 << 4),         // -
+    T_HR = (1 << 5),         // === or ---
+    T_BOLD = (1 << 6),       // **
+    T_ITALIC = (1 << 7),     // *
+    T_STRIKE = (1 << 8),     // ~~
+    T_CODE = (1 << 9),       // `
+    T_CODEBLOCK = (1 << 10), // ```
+    T_EOL = (1 << 11),       // \n
+    T_EOF = 0,               // End of file
 };
 
 class Tokenizer
@@ -80,6 +82,7 @@ public:
     FontFamily font_family = FONTFAMILY_NORMAL;
     FontWeight font_weight = FONTWEIGHT_NORMAL;
     FontStyle font_style = FONTSTYLE_NORMAL;
+    bool font_strikethrough = false;
 
     void toggle_property(Type prop)
     {
@@ -98,6 +101,7 @@ public:
         font_family = FONTFAMILY_NORMAL;
         font_weight = FONTWEIGHT_NORMAL;
         font_style = FONTSTYLE_NORMAL;
+        font_strikethrough = has_flag(T_STRIKE);
         horizontal_rule = has_flag(T_HR);
 
         if(has_flag(T_CODE) || has_flag(T_CODEBLOCK)) {
@@ -137,6 +141,9 @@ public:
         }
         if(font_flags & mdparser::T_BOLD) {
             str << ":BOLD";
+        }
+        if(font_flags & mdparser::T_STRIKE) {
+            str << ":STRIKE";
         }
         if(font_flags & mdparser::T_H1) {
             str << ":H1";


### PR DESCRIPTION
A few more trivial patches for my earlier PR #2872:

1. LSP/HoverRequest.hpp: Correct include guard.
I forgot to change the name; it's `.hpp`, not `.h`.

2. LSP Hover: Disable markdown styling characters in `plaintext` format.
In `plaintext` tooltip (in case of Language Server without markdown support), disable special markdown symbols to prevent text corruption.

3. Markdown: Implement ~~\~\~strikethrough\~\~~~.