### PR TITLE
Several bug fixes 3

### DIFF
--- a/CodeLite/LSP/CompletionItem.cpp
+++ b/CodeLite/LSP/CompletionItem.cpp
@@ -18,10 +18,11 @@ void LSP::CompletionItem::FromJSON(const JSONItem& json)
     if(doc.isOk()) {
         if(doc.isString()) {
             // plain string, nothing more to be done here
-            m_documentation = doc.toString();
+            m_documentation.SetKind("plaintext");
+            m_documentation.SetValue(doc.toString());
         } else {
             // an object of type MarkupContent
-            m_documentation = doc["value"].toString();
+            m_documentation.FromJSON(doc);
         }
     }
 
@@ -42,7 +43,7 @@ void LSP::CompletionItem::FromJSON(const JSONItem& json)
     m_insertText.Trim().Trim(false);
     m_label.Trim().Trim(false);
     m_detail.Trim().Trim(false);
-    m_documentation.Trim().Trim(false);
+    m_documentation.SetValue(wxString(m_documentation.GetValue()).Trim().Trim(false));
     if(json.hasNamedObject("textEdit") && !json.namedObject("textEdit").isNull()) {
         m_textEdit.reset(new LSP::TextEdit());
         m_textEdit->FromJSON(json.namedObject("textEdit"));

--- a/CodeLite/LSP/CompletionItem.h
+++ b/CodeLite/LSP/CompletionItem.h
@@ -13,7 +13,7 @@ class WXDLLIMPEXP_CL CompletionItem : public Serializable
     wxString m_label;
     int m_kind = wxNOT_FOUND;
     wxString m_detail;
-    wxString m_documentation;
+    MarkupContent m_documentation;
     wxString m_filterText;
     wxString m_insertText;
     wxString m_insertTextFormat;
@@ -67,13 +67,13 @@ public:
     virtual JSONItem ToJSON(const wxString& name) const;
     virtual void FromJSON(const JSONItem& json);
     void SetDetail(const wxString& detail) { this->m_detail = detail; }
-    void SetDocumentation(const wxString& documentation) { this->m_documentation = documentation; }
+    void SetDocumentation(const MarkupContent& documentation) { this->m_documentation = documentation; }
     void SetFilterText(const wxString& filterText) { this->m_filterText = filterText; }
     void SetInsertText(const wxString& insertText) { this->m_insertText = insertText; }
     void SetKind(int kind) { this->m_kind = kind; }
     void SetLabel(const wxString& label) { this->m_label = label; }
     const wxString& GetDetail() const { return m_detail; }
-    const wxString& GetDocumentation() const { return m_documentation; }
+    const MarkupContent& GetDocumentation() const { return m_documentation; }
     const wxString& GetFilterText() const { return m_filterText; }
     const wxString& GetInsertText() const { return m_insertText; }
     int GetKind() const { return m_kind; }

--- a/CodeLite/LSP/HoverRequest.cpp
+++ b/CodeLite/LSP/HoverRequest.cpp
@@ -1,10 +1,7 @@
-#include "LSP/LSPEvent.h"
 #include "HoverRequest.hpp"
+#include "LSP/LSPEvent.h"
 
 LSP::HoverRequest::HoverRequest(const wxString& filename, size_t line, size_t column)
-    : m_filename(filename)
-    , m_line(line)
-    , m_column(column)
 {
     SetMethod("textDocument/hover");
     m_params.reset(new TextDocumentPositionParams());

--- a/CodeLite/LSP/HoverRequest.hpp
+++ b/CodeLite/LSP/HoverRequest.hpp
@@ -3,20 +3,14 @@
 
 #include "LSP/Request.h"
 #include "LSP/ResponseMessage.h"
-#include <wx/filename.h>
 
 namespace LSP
 {
 class WXDLLIMPEXP_CL HoverRequest : public LSP::Request
 {
-    wxString m_filename;
-    size_t m_line = 0;
-    size_t m_column = 0;
-
 public:
     explicit HoverRequest(const wxString& filename, size_t line, size_t column);
     virtual ~HoverRequest();
-
     void OnResponse(const LSP::ResponseMessage& response, wxEvtHandler* owner);
 };
 };     // namespace LSP

--- a/LiteEditor/BuildTab.cpp
+++ b/LiteEditor/BuildTab.cpp
@@ -452,13 +452,13 @@ wxString BuildTab::CreateSummaryLine()
         text << "\n";
         if(m_error_count) {
             text = _("==== build ended with ");
-            text << WrapLineInColour("errors", eAsciiColours::RED, true);
+            text << WrapLineInColour(_("errors"), eAsciiColours::RED, true);
         } else if(m_warn_count) {
             text = _("=== build ended with ");
-            text << WrapLineInColour("warnings", eAsciiColours::YELLOW, true);
+            text << WrapLineInColour(_("warnings"), eAsciiColours::YELLOW, true);
         } else {
             text = _("=== build completed ");
-            text << WrapLineInColour("successfully", eAsciiColours::GREEN, true);
+            text << WrapLineInColour(_("successfully"), eAsciiColours::GREEN, true);
         }
         text << " (" << m_error_count << _(" errors, ") << m_warn_count << _(" warnings)");
         if(!total_time.empty()) {

--- a/LiteEditor/manager.cpp
+++ b/LiteEditor/manager.cpp
@@ -1030,7 +1030,7 @@ void Manager::RetagWorkspace(TagsManager::RetagType type)
         parsingRequest->SetParent(this);
         parsingRequest->SetQuickRetag(type == TagsManager::Retag_Quick);
         ParseThreadST::Get()->Add(parsingRequest);
-        clMainFrame::Get()->GetStatusBar()->SetMessage("Scanning for include files to parse...");
+        clMainFrame::Get()->GetStatusBar()->SetMessage(_("Scanning for include files to parse..."));
 
     } else if(type == TagsManager::Retag_Quick_No_Scan) {
         parsingRequest->SetType(ParseRequest::PR_PARSE_FILE_NO_INCLUDES);

--- a/LiteEditor/menu_event_handlers.cpp
+++ b/LiteEditor/menu_event_handlers.cpp
@@ -91,7 +91,7 @@ void EditHandler::ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event)
 
     } else if(event.GetId() == XRCID("label_current_state")) {
         wxString label =
-            wxGetTextFromUser("What would you like to call the current state?", "Label current state", "", editor);
+            wxGetTextFromUser(_("What would you like to call the current state?"), _("Label current state"), "", editor);
         if(!label.empty()) { editor->GetCommandsProcessor().SetUserLabel(label); }
 
     } else if(event.GetId() == XRCID("delete_line_end")) {

--- a/LiteEditor/ps_general_page.cpp
+++ b/LiteEditor/ps_general_page.cpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <wx/dirdlg.h>
 #include <wx/filedlg.h>
+#include <wx/regex.h>
 
 PSGeneralPage::PSGeneralPage(wxWindow* parent, const wxString& projectName, const wxString& conf,
                              ProjectSettingsDlg* dlg)

--- a/LiteEditor/reconcileproject.cpp
+++ b/LiteEditor/reconcileproject.cpp
@@ -783,7 +783,7 @@ void ReconcileProjectFiletypesDlg::OnIgnoreRemoveUpdateUI(wxUpdateUIEvent& event
 
 void ReconcileProjectFiletypesDlg::OnIgnoreFileBrowse(wxCommandEvent& WXUNUSED(event))
 {
-    wxString name = wxGetTextFromUser("Enter the filename to ignore e.g. foo*.cpp", _("CodeLite"), "", this);
+    wxString name = wxGetTextFromUser(_("Enter the filename to ignore e.g. foo*.cpp"), _("CodeLite"), "", this);
     if(!name.empty()) {
         if(m_listIgnoreFiles->FindString(name) == wxNOT_FOUND) {
             m_listIgnoreFiles->Append(name);

--- a/Outline/outline_tab.cpp
+++ b/Outline/outline_tab.cpp
@@ -159,7 +159,7 @@ void OutlineTab::OnSearchSymbol(wxCommandEvent& event)
     }
     event.Skip(false);
 
-    wxString text = ::wxGetTextFromUser("Find Symbol:", "Outline");
+    wxString text = ::wxGetTextFromUser(_("Find Symbol:"), _("Outline"));
     if(text.empty()) {
         return;
     }

--- a/PHPRefactoring/phprefactoring.cpp
+++ b/PHPRefactoring/phprefactoring.cpp
@@ -135,7 +135,7 @@ void PHPRefactoring::OnExtractMethod(wxCommandEvent& e)
 
     int startLine = editor->LineFromPos(editor->GetSelectionStart()) + 1;
     int endLine = editor->LineFromPos(editor->GetSelectionEnd()) + 1;
-    wxString method = wxGetTextFromUser("Name the new method");
+    wxString method = wxGetTextFromUser(_("Name the new method"));
     if(method.IsEmpty()) {
         return;
     }
@@ -173,7 +173,7 @@ void PHPRefactoring::RenameVariable(const wxString& action)
         return;
     }
 
-    wxString newName = wxGetTextFromUser("New name for " + oldName);
+    wxString newName = wxGetTextFromUser(_("New name for ") + oldName);
     newName.Trim().Trim(false);
 
     // If it starts with $ sign, remove it

--- a/Plugin/CompilerLocatorMSVC.cpp
+++ b/Plugin/CompilerLocatorMSVC.cpp
@@ -26,6 +26,7 @@
 #include "CompilerLocatorMSVC.h"
 #include "compiler.h"
 #include <globals.h>
+#include <wx/regex.h>
 
 CompilerLocatorMSVC::CompilerLocatorMSVC()
 {

--- a/Plugin/NewProjectDialog.cpp
+++ b/Plugin/NewProjectDialog.cpp
@@ -10,6 +10,7 @@
 #include <unordered_set>
 #include <wx/arrstr.h>
 #include <wx/msgdlg.h>
+#include <wx/regex.h>
 
 namespace
 {
@@ -215,6 +216,7 @@ void NewProjectDialog::OnOK(wxCommandEvent& event)
 void NewProjectDialog::OnCompilerChanged(wxCommandEvent& event)
 {
     wxUnusedVar(event);
+#ifdef __WXMSW__
     wxString newCompiler = m_choiceCompiler->GetStringSelection();
 
     auto compiler = BuildSettingsConfigST::Get()->GetCompiler(newCompiler);
@@ -222,7 +224,8 @@ void NewProjectDialog::OnCompilerChanged(wxCommandEvent& event)
 
     // Check if the selected compiler is "MSYS", however, its not from the mingwNN repository
     wxString cxx = compiler->GetTool("CXX");
-    bool isUnixGeneratorRequired = newCompiler.Contains("MSYS") && !cxx.Contains("mingw64") && !cxx.Contains("mingw32");
+    static const wxRegEx re("(clang(arm)?|mingw|ucrt)(32|64)", wxRE_DEFAULT | wxRE_NOSUB);
+    bool isUnixGeneratorRequired = newCompiler.Contains("MSYS") && !re.Matches(cxx);
 
     if(isUnixGeneratorRequired && m_choiceBuild->GetStringSelection() != GENRATOR_UNIX) {
         if(::wxMessageBox(
@@ -235,4 +238,5 @@ void NewProjectDialog::OnCompilerChanged(wxCommandEvent& event)
             m_choiceBuild->SetSelection(unixMakefiles);
         }
     }
+#endif
 }

--- a/Plugin/clMarkdownRenderer.cpp
+++ b/Plugin/clMarkdownRenderer.cpp
@@ -92,7 +92,7 @@ wxSize clMarkdownRenderer::DoRender(wxWindow* win, wxDC& dc, const wxString& tex
 
             yy += text_size.GetHeight() / 2;
             if(do_draw) {
-                dc.DrawLine(xx, yy, rect.GetRight(), yy);
+                dc.DrawLine(xx, yy, rect.GetRight() - X_MARGIN, yy);
             }
             xx = X_MARGIN;
             yy += text_size.GetHeight() / 2;

--- a/Plugin/clRowEntry.cpp
+++ b/Plugin/clRowEntry.cpp
@@ -166,7 +166,7 @@ void clRowEntry::InsertChild(clRowEntry* child, clRowEntry* prev)
     child->SetIndentsCount(GetIndentsCount() + 1);
 
     // We need the last item of this subtree (prev 'this' is the root)
-    if(prev == nullptr) {
+    if(prev == nullptr || prev == this) {
         // make it the first item
         m_children.insert(m_children.begin(), child);
     } else {

--- a/Plugin/clTreeCtrlModel.cpp
+++ b/Plugin/clTreeCtrlModel.cpp
@@ -204,7 +204,7 @@ wxTreeItemId clTreeCtrlModel::InsertItem(const wxTreeItemId& parent, const wxTre
 
     clRowEntry* pPrev = ToPtr(previous);
     clRowEntry* parentNode = ToPtr(parent);
-    if(pPrev->GetParent() != parentNode) {
+    if(pPrev != parentNode && pPrev->GetParent() != parentNode) {
         return wxTreeItemId();
     }
 

--- a/Plugin/compiler.cpp
+++ b/Plugin/compiler.cpp
@@ -205,9 +205,6 @@ Compiler::Compiler(wxXmlNode* node, Compiler::eRegexType regexType)
         // For backward compatibility, if the compiler / linker options are empty - add them
         if(IsGnuCompatibleCompiler()) {
             AddDefaultGnuComplierOptions();
-        }
-
-        if(IsGnuCompatibleCompiler()) {
             AddDefaultGnuLinkerOptions();
         }
 
@@ -607,7 +604,7 @@ bool Compiler::IsGnuCompatibleCompiler() const
 {
     static wxStringSet_t gnu_compilers = { COMPILER_FAMILY_CLANG, COMPILER_FAMILY_MINGW, COMPILER_FAMILY_GCC,
                                            COMPILER_FAMILY_CYGWIN, COMPILER_FAMILY_MSYS2 };
-    return m_compilerFamily.IsEmpty() || gnu_compilers.count(m_compilerFamily);
+    return !m_compilerFamily.IsEmpty() && gnu_compilers.count(m_compilerFamily);
 }
 
 void Compiler::AddDefaultGnuComplierOptions()

--- a/Plugin/macrosdlg.cpp
+++ b/Plugin/macrosdlg.cpp
@@ -63,7 +63,7 @@ void MacrosDlg::Initialize()
 
     // Only show third column if we can expand the macros
     if(m_project && m_editor) {
-        m_listCtrlMacros->InsertColumn(2, wxT("Value"));
+        m_listCtrlMacros->InsertColumn(2, _("Value"));
     }
 
     switch(m_content) {

--- a/Plugin/workspace.cpp
+++ b/Plugin/workspace.cpp
@@ -1462,14 +1462,14 @@ bool clCxxWorkspace::DoLoadWorkspace(const wxString& fileName, wxString& errMsg)
     m_buildMatrix.Reset(NULL);
     wxFileName workSpaceFile(fileName);
     if(workSpaceFile.FileExists() == false) {
-        errMsg = wxString::Format(wxT("Could not open workspace file: '%s'"), fileName.c_str());
+        errMsg = wxString::Format(_("Could not open workspace file: '%s'"), fileName.c_str());
         return false;
     }
 
     m_fileName = workSpaceFile;
     m_doc.Load(m_fileName.GetFullPath());
     if(!m_doc.IsOk()) {
-        errMsg = wxT("Corrupted workspace file");
+        errMsg = _("Corrupted workspace file");
         return false;
     }
 

--- a/Plugin/wxCodeCompletionBox.cpp
+++ b/Plugin/wxCodeCompletionBox.cpp
@@ -1,5 +1,7 @@
+#include "wxCodeCompletionBox.h"
 #include "ColoursAndFontsManager.h"
 #include "CxxTemplateFunction.h"
+#include "StringUtils.h"
 #include "bitmap_loader.h"
 #include "cc_box_tip_window.h"
 #include "cl_command_event.h"
@@ -11,7 +13,6 @@
 #include "ieditor.h"
 #include "imanager.h"
 #include "macros.h"
-#include "wxCodeCompletionBox.h"
 #include "wxCodeCompletionBoxManager.h"
 #include <wx/app.h>
 #include <wx/dcbuffer.h>
@@ -641,10 +642,15 @@ wxCodeCompletionBox::LSPCompletionsToEntries(const LSP::CompletionItem::Vec_t& c
 
         wxString comment;
         if(!completion->GetDetail().IsEmpty()) {
-            comment << completion->GetDetail();
+            wxString detail = completion->GetDetail();
+            StringUtils::DisableMarkdownStyling(detail);
+            comment << detail;
         }
-        if(!completion->GetDocumentation().IsEmpty()) {
-            comment << "\n" << completion->GetDocumentation();
+        if(!completion->GetDocumentation().GetValue().IsEmpty()) {
+            if(!comment.IsEmpty()) {
+                comment << "\n---\n";
+            }
+            comment << completion->GetDocumentation().GetValue();
         }
 
         // if 'insertText' is provided, use it instead of the label

--- a/codelite_vim/vimCommands.cpp
+++ b/codelite_vim/vimCommands.cpp
@@ -1946,7 +1946,7 @@ bool VimCommand::search_word(SEARCH_DIRECTION direction, int flag, long start_po
     } else {
         pos = start_pos;
     }
-    m_mgr->GetStatusBar()->SetMessage("Searching:" + m_searchWord);
+    m_mgr->GetStatusBar()->SetMessage(_("Searching: ") + m_searchWord);
     bool found = false;
     int pos_prev;
     if(direction == SEARCH_DIRECTION::BACKWARD) {

--- a/codelite_vim/vim_manager.cpp
+++ b/codelite_vim/vim_manager.cpp
@@ -213,10 +213,10 @@ void VimManager::updateVimMessage()
         m_mgr->GetStatusBar()->SetMessage(_("Saving and Closing"));
         break;
     case MESSAGES_VIM::SEARCHING_WORD:
-        m_mgr->GetStatusBar()->SetMessage("Searching: " + m_currentCommand.getSearchedWord());
+        m_mgr->GetStatusBar()->SetMessage(_("Searching: ") + m_currentCommand.getSearchedWord());
         break;
     default:
-        m_mgr->GetStatusBar()->SetMessage("Unknown Error");
+        m_mgr->GetStatusBar()->SetMessage(_("Unknown Error"));
         break;
     }
 }

--- a/codelitephp/php-plugin/php_workspace_view.cpp
+++ b/codelitephp/php-plugin/php_workspace_view.cpp
@@ -1566,14 +1566,14 @@ void PHPWorkspaceView::OnFindInFilesShowing(clFindInFilesEvent& e)
 void PHPWorkspaceView::OnWorkspaceSyncStart(clCommandEvent& event)
 {
     m_scanInProgress = true;
-    CallAfter(&PHPWorkspaceView::DoSetStatusBarText, "Scanning for PHP files...", wxNOT_FOUND);
+    CallAfter(&PHPWorkspaceView::DoSetStatusBarText, _("Scanning for PHP files..."), wxNOT_FOUND);
     m_treeCtrlView->Enable(false);
 }
 
 void PHPWorkspaceView::OnWorkspaceSyncEnd(clCommandEvent& event)
 {
     m_scanInProgress = false;
-    CallAfter(&PHPWorkspaceView::DoSetStatusBarText, "Scanning for PHP files completed", 3);
+    CallAfter(&PHPWorkspaceView::DoSetStatusBarText, _("Scanning for PHP files completed"), 3);
     PHPWorkspace::Get()->ParseWorkspace(false);
     CallAfter(&PHPWorkspaceView::LoadWorkspaceView);
     m_treeCtrlView->Enable(true);

--- a/cppchecker/cppchecksettingsdlg.cpp
+++ b/cppchecker/cppchecksettingsdlg.cpp
@@ -247,7 +247,7 @@ void CppCheckSettingsDialog::OnRemoveIncludeDir(wxCommandEvent& WXUNUSED(e))
 void CppCheckSettingsDialog::OnAddDefinition(wxCommandEvent& WXUNUSED(e))
 {
     wxString newitem =
-        wxGetTextFromUser("Enter a definition e.g. 'FOO' or 'BAR=1' (not '-DFoo')", "CodeLite", "", this);
+        wxGetTextFromUser(_("Enter a definition e.g. 'FOO' or 'BAR=1' (not '-DFoo')"), "CodeLite", "", this);
     if(!newitem.empty()) {
         m_listBoxDefinelist->Append(newitem);
     }
@@ -270,7 +270,7 @@ void CppCheckSettingsDialog::OnClearDefinitions(wxCommandEvent& e)
 void CppCheckSettingsDialog::OnAddUndefine(wxCommandEvent& WXUNUSED(e))
 {
     wxString newitem =
-        wxGetTextFromUser("Enter a definition NOT to check e.g. 'FOO' or 'BAR=1' (not '-UFoo')", "CodeLite", "", this);
+        wxGetTextFromUser(_("Enter a definition NOT to check e.g. 'FOO' or 'BAR=1' (not '-UFoo')"), "CodeLite", "", this);
     if(!newitem.empty()) {
         m_listBoxUndefineList->Append(newitem);
     }

--- a/wxcrafter/main.cpp
+++ b/wxcrafter/main.cpp
@@ -89,6 +89,9 @@ bool wxcApp::OnInit()
 #ifdef __WXGTK__
     // Redirect stdout/error to a file
     wxFileName stdout_err(wxStandardPaths::Get().GetUserDataDir(), "wxcrafter-stdout-stderr.log");
+#ifndef NDEBUG
+    stdout_err.SetPath(stdout_err.GetPath() + "-dbg");
+#endif
     FILE* new_stdout = ::freopen(stdout_err.GetFullPath().mb_str(wxConvISO8859_1).data(), "a+b", stdout);
     FILE* new_stderr = ::freopen(stdout_err.GetFullPath().mb_str(wxConvISO8859_1).data(), "a+b", stderr);
     wxUnusedVar(new_stderr);

--- a/wxcrafter/wxgui_helpers.cpp
+++ b/wxcrafter/wxgui_helpers.cpp
@@ -922,6 +922,9 @@ wxString wxCrafter::ToolTypeToWX(TOOL_TYPE type)
 wxString wxCrafter::GetUserDataDir()
 {
     wxFileName dir(wxStandardPaths::Get().GetUserDataDir(), wxT("dummy.txt"));
+#ifndef NDEBUG
+    dir.SetPath(dir.GetPath() + "-dbg");
+#endif
     dir.AppendDir(wxT("wxcrafter"));
 
     if(!wxFileName::DirExists(dir.GetPath())) {
@@ -942,6 +945,9 @@ void wxCrafter::SetStatusMessage(const wxString& msg)
 wxString wxCrafter::GetConfigFile()
 {
     wxFileName dir(wxStandardPaths::Get().GetUserDataDir(), wxT("wxcrafter.conf"));
+#ifndef NDEBUG
+    dir.SetPath(dir.GetPath() + "-dbg");
+#endif
     dir.AppendDir(wxT("config"));
 
     if(!wxFileName::DirExists(dir.GetPath())) {

--- a/wxcrafter/wxguicraft_main_view.cpp
+++ b/wxcrafter/wxguicraft_main_view.cpp
@@ -1196,26 +1196,14 @@ void GUICraftMainPanel::DoBuildTree(wxTreeItemId& itemToSelect, wxcWidget* wrapp
         wxTreeItemId insertionItem = beforeItem;
         if(insertBefore) {
             insertionItem = m_treeControls->GetPrevSibling(beforeItem);
-
-            if(insertionItem.IsOk() == false) {
-                item =
-                    m_treeControls->AppendItem(parent, wrapper->GetName(), imgId, imgId, new GUICraftItemData(wrapper));
-                if(itemToSelect.IsOk() == false)
-                    itemToSelect = item;
-
-            } else {
-                item = m_treeControls->InsertItem(parent, insertionItem, wrapper->GetName(), imgId, imgId,
-                                                  new GUICraftItemData(wrapper));
-                if(itemToSelect.IsOk() == false)
-                    itemToSelect = item;
-            }
-
-        } else {
-            item = m_treeControls->InsertItem(parent, insertionItem, wrapper->GetName(), imgId, imgId,
-                                              new GUICraftItemData(wrapper));
-            if(itemToSelect.IsOk() == false)
-                itemToSelect = item;
+            if(insertionItem.IsOk() == false)
+                insertionItem = parent;
         }
+
+        item = m_treeControls->InsertItem(parent, insertionItem, wrapper->GetName(), imgId, imgId,
+                                          new GUICraftItemData(wrapper));
+        if(itemToSelect.IsOk() == false)
+            itemToSelect = item;
 
     } else {
 


### PR DESCRIPTION
1. LSP `Find Symbol`: Make text selection UTF-8 aware (like we did in 28639de and d3ac8c9).

2. LSP Completion: Update code completion tip:
    * Draw a horizontal line between 'detail' and 'documentation' field.
    * Disable markdown text in the 'detail' field.

    Here's a comparison of the old and new one:
    ![ccboxtip-old](https://user-images.githubusercontent.com/32811754/143486024-c6671e12-07c9-42f5-a50d-b74455c9f85f.png)
    ![ccboxtip-new-2](https://user-images.githubusercontent.com/32811754/143668460-51ad2c42-f590-4dea-94b8-87c905b8c682.png)

3. LSP Hover: Remove unused member variables.

4. Create New C++ Project: `CodeLite Makefile Generator - UNIX` is not required for MSYS2 Clang too.

5. Compiler: Don't consider invalid compilers as 'GNU compatible' because this may entirely break `clangd`:
    ```c++
    static wxArrayString GetExtraFlags(CompilerPtr compiler)
    {
        wxArrayString flags;
        if(compiler->HasMetadata()) {          // synonym of Compiler::IsGnuCompatibleCompiler(), i.e. true
            flags.Add("-target");
            auto md = compiler->GetMetadata(); // actually there's no metadata
            flags.Add(md.GetTarget());         // md.GetTarget() is empty
            // compile_flags.txt is now invalid (no argument for -target)
        }
        return flags;
    }
    ```

6. wxCrafter: Use `-dbg` suffixed user directory in `Debug` build.

7. wxCrafter: Fix wrong tree order on the first sibling widget duplication:
![2021-11-26 03-19-08.mp4](https://user-images.githubusercontent.com/32811754/143487424-bc74fb98-b134-4ded-a83d-2a10df78e388.mp4)
In this video, the left tree shows `AAA, BBB, CCC, AAA`, while the preview is `AAA, AAA, BBB, CCC`.

8. Add some missing translations.