### PR TITLE
Build error fixes

### DIFF
--- a/Plugin/clAuiMainNotebookTabArt.cpp
+++ b/Plugin/clAuiMainNotebookTabArt.cpp
@@ -97,7 +97,13 @@ void clAuiMainNotebookTabArt::DrawTab(wxDC& wxdc, wxWindow* wnd, const wxAuiNote
     wxColour penColour = page.active ? m_activeTabPenColour : m_penColour;
     wxColour bgColour = page.active ? m_activeTabBgColour : m_tabBgColour;
 
-    wxSize sz = GetTabSize(dc, wnd, page.caption, page.bitmap, page.active, close_button_state, x_extent);
+#if wxCHECK_VERSION(3, 1, 6)
+    const wxBitmap& bitmap = page.bitmap.GetBitmapFor(wnd);
+#else
+    const wxBitmap& bitmap = page.bitmap;
+#endif
+
+    wxSize sz = GetTabSize(dc, wnd, page.caption, bitmap, page.active, close_button_state, x_extent);
     if(sz.GetHeight() < in_rect.GetHeight()) { sz.SetHeight(in_rect.GetHeight()); }
 
     wxRect rr(in_rect.GetTopLeft(), sz);
@@ -177,10 +183,10 @@ void clAuiMainNotebookTabArt::DrawTab(wxDC& wxdc, wxWindow* wnd, const wxAuiNote
     if(caption == "Tp") { caption.Clear(); }
 
     /// Draw the bitmap
-    if(page.bitmap.IsOk()) {
-        int bmpy = (rr.y + (rr.height - page.bitmap.GetScaledHeight()) / 2);
-        dc.DrawBitmap(page.bitmap, curx, bmpy);
-        curx += page.bitmap.GetScaledWidth();
+    if(bitmap.IsOk()) {
+        int bmpy = (rr.y + (rr.height - bitmap.GetScaledHeight()) / 2);
+        dc.DrawBitmap(bitmap, curx, bmpy);
+        curx += bitmap.GetScaledWidth();
         curx += X_PADDING;
     }
 

--- a/cmake/Modules/FindLibLLDB.cmake
+++ b/cmake/Modules/FindLibLLDB.cmake
@@ -6,6 +6,14 @@ if (UNIX)
                      HINTS  
                      /usr/lib 
                      /usr/local/lib 
+                     /usr/lib/llvm-20/lib
+                     /usr/lib/llvm-19/lib
+                     /usr/lib/llvm-18/lib
+                     /usr/lib/llvm-17/lib
+                     /usr/lib/llvm-16/lib
+                     /usr/lib/llvm-15/lib
+                     /usr/lib/llvm-14/lib
+                     /usr/lib/llvm-13/lib
                      /usr/lib/llvm-12/lib
                      /usr/lib/llvm-11/lib
                      /usr/lib/llvm-10/lib
@@ -13,6 +21,14 @@ if (UNIX)
                      /usr/lib/llvm-8/lib
                      /usr/lib/llvm-7/lib
                      /usr/lib/llvm-6/lib
+                     /usr/lib/llvm-20.0/lib
+                     /usr/lib/llvm-19.0/lib
+                     /usr/lib/llvm-18.0/lib
+                     /usr/lib/llvm-17.0/lib
+                     /usr/lib/llvm-16.0/lib
+                     /usr/lib/llvm-15.0/lib
+                     /usr/lib/llvm-14.0/lib
+                     /usr/lib/llvm-13.0/lib
                      /usr/lib/llvm-12.0/lib
                      /usr/lib/llvm-11.0/lib
                      /usr/lib/llvm-10.0/lib
@@ -38,11 +54,27 @@ if (UNIX)
 
         find_path(LIBLLDB_INCLUDE_T NAMES lldb/API/SBDebugger.h
                   HINTS 
+                  /usr/lib/llvm-20/include
+                  /usr/lib/llvm-19/include
+                  /usr/lib/llvm-18/include
+                  /usr/lib/llvm-17/include
+                  /usr/lib/llvm-16/include
+                  /usr/lib/llvm-15/include
+                  /usr/lib/llvm-14/include
+                  /usr/lib/llvm-13/include
                   /usr/lib/llvm-12/include
                   /usr/lib/llvm-11/include
                   /usr/lib/llvm-10/include
                   /usr/lib/llvm-9/include
                   /usr/lib/llvm-8/include
+                  /usr/lib/llvm-20.0/include
+                  /usr/lib/llvm-19.0/include
+                  /usr/lib/llvm-18.0/include
+                  /usr/lib/llvm-17.0/include
+                  /usr/lib/llvm-16.0/include
+                  /usr/lib/llvm-15.0/include
+                  /usr/lib/llvm-14.0/include
+                  /usr/lib/llvm-13.0/include
                   /usr/lib/llvm-12.0/include
                   /usr/lib/llvm-11.0/include
                   /usr/lib/llvm-10.0/include


### PR DESCRIPTION
1. Fix build error with wxWidgets from current `master` branch.
`page.bitmap` is now [wxBitmapBundle](https://docs.wxwidgets.org/trunk/classwx_bitmap_bundle.html) since wxWidgets/wxWidgets@391080e77d7f78d5d136f30fc5ac02ee89e6ec2e.

2. CMake: Add LLVM version 13+ detection.