### PR TITLE
Find & Replace: Regular expression fixes

### DIFF
--- a/CodeLite/search_thread.cpp
+++ b/CodeLite/search_thread.cpp
@@ -382,6 +382,11 @@ void SearchThread::DoSearchLineRE(const wxString& line, const int lineNum, const
             result.SetLen(iCorrectedLen);
             result.SetFlags(data->m_flags);
             result.SetFindWhat(data->GetFindString());
+            wxArrayString regexCaptures;
+            for(size_t i = 0; i < re.GetMatchCount(); ++i) {
+                regexCaptures.Add(re.GetMatch(modLine, i));
+            }
+            result.SetRegexCaptures(regexCaptures);
 
             // Make sure our match is not on a comment
             int position(wxNOT_FOUND);
@@ -667,6 +672,7 @@ JSONItem SearchResult::ToJSON() const
     // json.addProperty("findWhat", m_findWhat);
     // json.addProperty("matchState", (int)m_matchState);
     // json.addProperty("scope", m_scope);
+    json.addProperty("regexCaptures", m_regexCaptures);
     return json;
 }
 
@@ -684,6 +690,7 @@ void SearchResult::FromJSON(const JSONItem& json)
     // m_findWhat = json.namedObject("findWhat").toString(m_findWhat);
     // m_matchState = json.namedObject("matchState").toInt(m_matchState);
     // m_scope = json.namedObject("scope").toString(m_scope);
+    m_regexCaptures = json.namedObject("regexCaptures").toArrayString();
 }
 
 JSONItem SearchSummary::ToJSON() const

--- a/CodeLite/search_thread.h
+++ b/CodeLite/search_thread.h
@@ -165,6 +165,7 @@ class WXDLLIMPEXP_CL SearchResult : public wxObject
     int m_lenInChars;
     short m_matchState;
     wxString m_scope;
+    wxArrayString m_regexCaptures;
 
 public:
     // ctor-dtor, copy constructor and assignment operator
@@ -189,6 +190,7 @@ public:
         m_lenInChars = rhs.m_lenInChars;
         m_matchState = rhs.m_matchState;
         m_scope = rhs.m_scope.c_str();
+        m_regexCaptures = rhs.m_regexCaptures;
         return *this;
     }
 
@@ -233,6 +235,18 @@ public:
 
     void SetScope(const wxString& scope) { this->m_scope = scope.c_str(); }
     const wxString& GetScope() const { return m_scope; }
+
+    void SetRegexCaptures(const wxArrayString& regexCaptures) { this->m_regexCaptures = regexCaptures; }
+    const wxArrayString& GetRegexCaptures() const { return m_regexCaptures; }
+    wxString GetRegexCapture(size_t backref) const
+    {
+        if(m_regexCaptures.size() > backref) {
+            return m_regexCaptures[backref];
+        } else {
+            return wxEmptyString;
+        }
+    }
+
     // return a foramtted message
     wxString GetMessage() const
     {

--- a/LiteEditor/quickfindbar.cpp
+++ b/LiteEditor/quickfindbar.cpp
@@ -902,7 +902,7 @@ TargetRange QuickFindBar::DoFind(size_t find_flags, const TargetRange& target)
     size_t stc_search_options = 0;
 
     if(search_options & wxSTC_FIND_REGEXP)
-        stc_search_options |= wxSTC_FIND_REGEXP;
+        stc_search_options |= wxSTC_FIND_REGEXP | wxSTC_FIND_POSIX;
     if(search_options & wxSTC_FIND_MATCHCASE)
         stc_search_options |= wxSTC_FIND_MATCHCASE;
     if(search_options & wxSTC_FIND_WHOLEWORD)

--- a/LiteEditor/replaceinfilespanel.h
+++ b/LiteEditor/replaceinfilespanel.h
@@ -45,6 +45,11 @@ protected:
 
     wxStyledTextCtrl* DoGetEditor(const wxString& fileName);
 
+    /*
+     * @brief get replacement text (regular expression backrefs applied)
+     */
+    wxString DoGetReplaceWith(const SearchResult& res) const;
+
     // Event handlers
     virtual void OnSearchStart(wxCommandEvent& e);
     virtual void OnSearchMatch(wxCommandEvent& e);


### PR DESCRIPTION
1. `Quick Find Bar`: Use POSIX-style syntax in regular expression mode.
Without [this flag](https://www.scintilla.org/SciTERegEx.html), `\(` `\)` are meant for capturing, whereas `(` `)` are for plain parentheses, which is exact opposite of more widely used syntax.
This change also make the behavior consistent with `Find in Files` search (which uses `wxRegEx` class).

2. `Find in Files`: Allow backref replace in regular expression mode.
`\number` (up to 9 captures) can be used as placeholder for captured strings.

Here's a typical example:
```c++
if(a == false) { /* ... */ }
if(bb == true) { /* ... */ }
if(ccc == false) { /* ... */ }
if(dddd == true) { /* ... */ }
if(eeeee == false) { /* ... */ }
if(ffffff == true) { /* ... */ }
```
the following replacement:
![quickfindbar-regex](https://user-images.githubusercontent.com/32811754/145997921-6154e29e-6007-4520-9790-456e84a0ccab.png)
produces:
```c++
if(!a) { /* ... */ }
if(bb == true) { /* ... */ }
if(!ccc) { /* ... */ }
if(dddd == true) { /* ... */ }
if(!eeeee) { /* ... */ }
if(ffffff == true) { /* ... */ }
```