### PR TITLE
A few regression fixes

### DIFF
--- a/LiteEditor/buildorderbasepage.cpp
+++ b/LiteEditor/buildorderbasepage.cpp
@@ -29,7 +29,7 @@ BuildOrderDialogBase::BuildOrderDialogBase(wxWindow* parent, wxWindowID id, cons
 
     boxSizer32->Add(boxSizer1, 1, wxALL | wxEXPAND, WXC_FROM_DIP(0));
 
-    m_staticText3 = new wxStaticText(this, wxID_ANY, wxT("Select build order for configuration:"), wxDefaultPosition,
+    m_staticText3 = new wxStaticText(this, wxID_ANY, _("Select build order for configuration:"), wxDefaultPosition,
                                      wxDLG_UNIT(this, wxSize(-1, -1)), 0);
 
     boxSizer1->Add(m_staticText3, 0, wxLEFT | wxRIGHT | wxTOP, WXC_FROM_DIP(10));
@@ -54,17 +54,17 @@ BuildOrderDialogBase::BuildOrderDialogBase(wxWindow* parent, wxWindowID id, cons
 
     flexGridSizer10->Add(m_dvListCtrlProjects, 1, wxALL | wxEXPAND, WXC_FROM_DIP(5));
 
-    m_dvListCtrlProjects->AppendTextColumn(wxT("Projects"), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(-2), wxALIGN_LEFT,
+    m_dvListCtrlProjects->AppendTextColumn(_("Projects"), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(-2), wxALIGN_LEFT,
                                            wxDATAVIEW_COL_RESIZABLE);
     wxBoxSizer* boxSizer3 = new wxBoxSizer(wxVERTICAL);
 
     flexGridSizer10->Add(boxSizer3, 1, wxALL | wxEXPAND | wxALIGN_TOP, WXC_FROM_DIP(5));
 
-    m_button22 = new wxButton(this, wxID_ANY, wxT("-->"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
+    m_button22 = new wxButton(this, wxID_ANY, _("-->"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
 
     boxSizer3->Add(m_button22, 0, wxALL, WXC_FROM_DIP(5));
 
-    m_button24 = new wxButton(this, wxID_ANY, wxT("<--"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
+    m_button24 = new wxButton(this, wxID_ANY, _("<--"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
 
     boxSizer3->Add(m_button24, 0, wxALL, WXC_FROM_DIP(5));
 
@@ -85,7 +85,7 @@ BuildOrderDialogBase::BuildOrderDialogBase(wxWindow* parent, wxWindowID id, cons
 
     bSizer5->Add(m_dvListCtrlBuildOrder, 1, wxALL | wxEXPAND, WXC_FROM_DIP(5));
 
-    m_dvListCtrlBuildOrder->AppendTextColumn(wxT("Build Order"), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(-2), wxALIGN_LEFT,
+    m_dvListCtrlBuildOrder->AppendTextColumn(_("Build Order"), wxDATAVIEW_CELL_INERT, WXC_FROM_DIP(-2), wxALIGN_LEFT,
                                              wxDATAVIEW_COL_RESIZABLE);
     wxBoxSizer* bSizer6 = new wxBoxSizer(wxVERTICAL);
 
@@ -95,11 +95,11 @@ BuildOrderDialogBase::BuildOrderDialogBase(wxWindow* parent, wxWindowID id, cons
 
     bSizer6->Add(bSizer8, 1, wxEXPAND, WXC_FROM_DIP(5));
 
-    m_buttonUp = new wxButton(this, wxID_UP, wxT("Up"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
+    m_buttonUp = new wxButton(this, wxID_UP, _("Up"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
 
     bSizer8->Add(m_buttonUp, 0, wxALL | wxEXPAND, WXC_FROM_DIP(5));
 
-    m_buttonDown = new wxButton(this, wxID_DOWN, wxT("Down"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
+    m_buttonDown = new wxButton(this, wxID_DOWN, _("Down"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
 
     bSizer8->Add(m_buttonDown, 0, wxALL | wxEXPAND, WXC_FROM_DIP(5));
 
@@ -107,8 +107,7 @@ BuildOrderDialogBase::BuildOrderDialogBase(wxWindow* parent, wxWindowID id, cons
 
     bSizer6->Add(bSizer7, 0, 0, WXC_FROM_DIP(5));
 
-    m_buttonApply =
-        new wxButton(this, wxID_APPLY, wxT("Apply"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
+    m_buttonApply = new wxButton(this, wxID_APPLY, _("Apply"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), 0);
     m_buttonApply->SetDefault();
     m_buttonApply->SetFocus();
 

--- a/LiteEditor/buildorderbasepage.h
+++ b/LiteEditor/buildorderbasepage.h
@@ -77,7 +77,7 @@ public:
     wxButton* GetButtonUp() { return m_buttonUp; }
     wxButton* GetButtonDown() { return m_buttonDown; }
     wxButton* GetButtonApply() { return m_buttonApply; }
-    BuildOrderDialogBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Build Order"),
+    BuildOrderDialogBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("Build Order"),
                          const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(-1, -1),
                          long style = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
     virtual ~BuildOrderDialogBase();

--- a/LiteEditor/depend_dlg_page.wxcp
+++ b/LiteEditor/depend_dlg_page.wxcp
@@ -9,7 +9,7 @@
 		"m_outputFileName":	"buildorderbasepage",
 		"m_firstWindowId":	1000,
 		"m_useEnum":	false,
-		"m_useUnderscoreMacro":	false,
+		"m_useUnderscoreMacro":	true,
 		"m_addHandlers":	true,
 		"m_templateClasses":	[]
 	},

--- a/Plugin/LanguageServerProtocol.cpp
+++ b/Plugin/LanguageServerProtocol.cpp
@@ -552,12 +552,9 @@ void LanguageServerProtocol::HoverTip(IEditor* editor)
     }
 
     if(ShouldHandleFile(filename)) {
-        wxString word;
-        wxRect rect;
-        editor->GetWordAtMousePointer(word, rect);
         int pos = editor->GetPosAtMousePointer();
         // trigger a hover request only when we are hovering something
-        if(pos != wxNOT_FOUND && !word.empty()) {
+        if(pos != wxNOT_FOUND && isgraph(editor->GetCharAtPos(pos))) {
             LSP::HoverRequest::Ptr_t req = LSP::MessageWithParams::MakeRequest(
                 new LSP::HoverRequest(filename, editor->LineFromPos(pos), editor->GetColumnInChars(pos)));
             QueueMessage(req);


### PR DESCRIPTION
* LSP Hover: Use `isgraph()` to sanity a word hover.
Non-alphabet characters, such as `<`, won't be considered as a word and triggers no hover tip.
However, some Language Servers may provide some useful tip on it (in this case, `clangd` can provide a detail for overloaded operator `<` or `<<`) so we prefer not to reject it:
![clangd-operator<<-hover](https://user-images.githubusercontent.com/32811754/146565418-f7292882-7fcf-4260-87f7-368117e3e7c5.png)

* `depend_dlg_page.wxcp`: Re-enable translations.