### PR TITLE
Calltip: Auto-adjust X/Y position to fit into the display screen

### DIFF
--- a/LiteEditor/cl_editor.h
+++ b/LiteEditor/cl_editor.h
@@ -763,6 +763,10 @@ public:
     void DelAllCompilerMarkers() override;
 
     void DoShowCalltip(int pos, const wxString& title, const wxString& tip, bool strip_html_tags = true);
+    /**
+     * @brief adjust calltip window position to fit into the display screen
+     */
+    void DoAdjustCalltipPos(wxPoint& pt) const;
     void DoCancelCalltip();
     void DoCancelCodeCompletionBox();
     int DoGetOpenBracePos();


### PR DESCRIPTION
If calltip was too long and doesn't fit well into the display screen, adjust the calltip window position to ensure that the whole text is readable:
![unpatched-tip](https://user-images.githubusercontent.com/32811754/146964964-e9740328-1109-449d-a529-8b396e33f4de.png)
↓
![adjusted-tip](https://user-images.githubusercontent.com/32811754/146964979-8227cea5-13a7-4247-a1af-a8510743eecc.png)
