### PR TITLE
Several fixes for MSVC solution importer

### DIFF
--- a/Plugin/BorlandCppBuilderImporter.cpp
+++ b/Plugin/BorlandCppBuilderImporter.cpp
@@ -5,7 +5,7 @@
 #include <wx/wfstream.h>
 #include <wx/xml/xml.h>
 
-bool BorlandCppBuilderImporter::OpenWordspace(const wxString& filename, const wxString& defaultCompiler)
+bool BorlandCppBuilderImporter::OpenWorkspace(const wxString& filename, const wxString& defaultCompiler)
 {
     wsInfo.Assign(filename);
 

--- a/Plugin/BorlandCppBuilderImporter.h
+++ b/Plugin/BorlandCppBuilderImporter.h
@@ -34,7 +34,7 @@
 class BorlandCppBuilderImporter : public GenericImporter
 {
 public:
-    virtual bool OpenWordspace(const wxString& filename, const wxString& defaultCompiler);
+    virtual bool OpenWorkspace(const wxString& filename, const wxString& defaultCompiler);
     virtual bool isSupportedWorkspace();
     virtual GenericWorkspacePtr PerformImport();
 

--- a/Plugin/CodeBlocksImporter.cpp
+++ b/Plugin/CodeBlocksImporter.cpp
@@ -6,7 +6,7 @@
 #include <wx/tokenzr.h>
 #include <wx/xml/xml.h>
 
-bool CodeBlocksImporter::OpenWordspace(const wxString& filename, const wxString& defaultCompiler)
+bool CodeBlocksImporter::OpenWorkspace(const wxString& filename, const wxString& defaultCompiler)
 {
     wsInfo.Assign(filename);
 

--- a/Plugin/CodeBlocksImporter.h
+++ b/Plugin/CodeBlocksImporter.h
@@ -34,7 +34,7 @@
 class CodeBlocksImporter : public GenericImporter
 {
 public:
-    virtual bool OpenWordspace(const wxString& filename, const wxString& defaultCompiler);
+    virtual bool OpenWorkspace(const wxString& filename, const wxString& defaultCompiler);
     virtual bool isSupportedWorkspace();
     virtual GenericWorkspacePtr PerformImport();
 

--- a/Plugin/DevCppImporter.cpp
+++ b/Plugin/DevCppImporter.cpp
@@ -4,7 +4,7 @@
 #include <wx/txtstrm.h>
 #include <wx/wfstream.h>
 
-bool DevCppImporter::OpenWordspace(const wxString& filename, const wxString& defaultCompiler)
+bool DevCppImporter::OpenWorkspace(const wxString& filename, const wxString& defaultCompiler)
 {
     wsInfo.Assign(filename);
 

--- a/Plugin/DevCppImporter.h
+++ b/Plugin/DevCppImporter.h
@@ -34,7 +34,7 @@
 class DevCppImporter : public GenericImporter
 {
 public:
-    virtual bool OpenWordspace(const wxString& filename, const wxString& defaultCompiler);
+    virtual bool OpenWorkspace(const wxString& filename, const wxString& defaultCompiler);
     virtual bool isSupportedWorkspace();
     virtual GenericWorkspacePtr PerformImport();
 

--- a/Plugin/GenericImporter.h
+++ b/Plugin/GenericImporter.h
@@ -105,7 +105,7 @@ typedef std::shared_ptr<GenericWorkspace> GenericWorkspacePtr;
 class GenericImporter
 {
 public:
-    virtual bool OpenWordspace(const wxString& filename, const wxString& defaultCompiler) = 0;
+    virtual bool OpenWorkspace(const wxString& filename, const wxString& defaultCompiler) = 0;
     virtual bool isSupportedWorkspace() = 0;
     virtual GenericWorkspacePtr PerformImport() = 0;
 };

--- a/Plugin/VisualCppImporter.cpp
+++ b/Plugin/VisualCppImporter.cpp
@@ -4,7 +4,7 @@
 #include <wx/txtstrm.h>
 #include <wx/wfstream.h>
 
-bool VisualCppImporter::OpenWordspace(const wxString& filename, const wxString& defaultCompiler)
+bool VisualCppImporter::OpenWorkspace(const wxString& filename, const wxString& defaultCompiler)
 {
     wsInfo.Assign(filename);
 
@@ -426,8 +426,11 @@ void VisualCppImporter::GenerateFromVC7_11(GenericWorkspacePtr genericWorkspace)
             genericProjectData[wxT("projectFullPath")] =
                 wsInfo.GetPath() + wxFileName::GetPathSeparator() + projectFile;
 
-            wxString deps = wxT("");
+            // Fix the paths to match linux style
+            ConvertToLinuxStyle(genericProjectData["projectFile"]);
+            ConvertToLinuxStyle(genericProjectData["projectFullPath"]);
 
+            wxString deps = wxT("");
             while(!fis.Eof()) {
                 line = tis.ReadLine();
 

--- a/Plugin/VisualCppImporter.h
+++ b/Plugin/VisualCppImporter.h
@@ -35,7 +35,7 @@
 class VisualCppImporter : public GenericImporter
 {
 public:
-    virtual bool OpenWordspace(const wxString& filename, const wxString& defaultCompiler);
+    virtual bool OpenWorkspace(const wxString& filename, const wxString& defaultCompiler);
     virtual bool isSupportedWorkspace();
     virtual GenericWorkspacePtr PerformImport();
 

--- a/Plugin/WSImporter.cpp
+++ b/Plugin/WSImporter.cpp
@@ -34,7 +34,7 @@ bool WSImporter::Import(wxString& errMsg)
                         compileName.Contains(wxT("g++")) || compileName.Contains(wxT("mingw"));
 
     for(std::shared_ptr<GenericImporter> importer : importers) {
-        if(importer->OpenWordspace(filename, defaultCompiler)) {
+        if(importer->OpenWorkspace(filename, defaultCompiler)) {
             if(importer->isSupportedWorkspace()) {
                 GenericWorkspacePtr gworskspace = importer->PerformImport();
                 wxString errMsgLocal;
@@ -285,17 +285,18 @@ bool WSImporter::Import(wxString& errMsg)
                             vDir += wxT(":");
                         }
 
-                        proj->AddFile(file->name, vpath);
+                        wxFileName fileNameInfo(project->path + wxFileName::GetPathSeparator() + file->name);
+                        fileNameInfo.Normalize(wxPATH_NORM_DOTS);
+                        proj->AddFile(fileNameInfo.GetFullPath(), vpath);
                     }
 
                     proj->CommitTranscation();
 
                     for(GenericProjectCfgPtr cfg : project->cfgs) {
                         for(GenericProjectFilePtr excludeFile : cfg->excludeFiles) {
-                            wxString vpath = GetVPath(excludeFile->name, excludeFile->vpath);
-
                             wxFileName excludeFileNameInfo(project->path + wxFileName::GetPathSeparator() +
                                                            excludeFile->name);
+                            excludeFileNameInfo.Normalize(wxPATH_NORM_DOTS);
                             proj->AddExcludeConfigForFile(excludeFileNameInfo.GetFullPath());
                         }
                     }


### PR DESCRIPTION
* Apply the fix: 7f488eb for version 7+ solution files as well.
* A full path (not relative path) must be supplied to `Project::AddFile()` in order to make it work properly.
* Fix typo: `GenericImporter::OpenWordspace()` -> `GenericImporter::OpenWorkspace()`.