### PR TITLE
clEditor: Update editor marker tooltip

### DIFF
--- a/CodeLite/StringUtils.cpp
+++ b/CodeLite/StringUtils.cpp
@@ -1,4 +1,5 @@
 #include "StringUtils.h"
+
 #include <vector>
 
 std::string StringUtils::ToStdString(const wxString& str)
@@ -97,6 +98,7 @@ void StringUtils::DisableMarkdownStyling(wxString& buffer)
     buffer.Replace("-", "\\-");
     buffer.Replace("=", "\\=");
     buffer.Replace("*", "\\*");
+    buffer.Replace("_", "\\_");
     buffer.Replace("~", "\\~");
     buffer.Replace("`", "\\`");
 }

--- a/LiteEditor/breakpointsmgr.h
+++ b/LiteEditor/breakpointsmgr.h
@@ -33,6 +33,7 @@
 #include "wx/arrstr.h"
 #include "wx/dragimag.h"
 #include "wx/string.h"
+
 #include <set>
 
 class myDragImage;
@@ -41,10 +42,9 @@ class myDragImage;
 
 class BreakptMgr : public wxEvtHandler
 {
-    clDebuggerBreakpoint::Vec_t m_bps; // The vector of breakpoints
-    clDebuggerBreakpoint::Vec_t
-        m_pendingBreakpointsList; // These are any breakpoints that the debugger won't (yet) accept
-                                  // (often because they're in a plugin)
+    clDebuggerBreakpoint::Vec_t m_bps;                    // The vector of breakpoints
+    clDebuggerBreakpoint::Vec_t m_pendingBreakpointsList; // These are any breakpoints that the debugger won't (yet)
+                                                          // accept (often because they're in a plugin)
 
     int NextInternalID; // Used to give each bp a unique internal ID. Start at 10k to avoid confusion with gdb's IDs
 

--- a/LiteEditor/context_cpp.cpp
+++ b/LiteEditor/context_cpp.cpp
@@ -273,7 +273,7 @@ bool ContextCpp::GetHoverTip(int pos)
         if(tooltip.IsEmpty()) {
             return false;
         }
-        rCtrl.DoShowCalltip(-1, "", tooltip, false);
+        rCtrl.DoShowCalltip(wxNOT_FOUND, "", tooltip, false);
         return true;
     } else {
         return false;

--- a/Plugin/mdparser.cpp
+++ b/Plugin/mdparser.cpp
@@ -54,11 +54,19 @@ std::pair<mdparser::Type, wxString> mdparser::Tokenizer::next()
         case '\n':
             RETURN_TYPE(T_EOL, "\n", 0);
         case '*':
-            // bold & italic
+            // bold (**) & italic (*)
             if(ch1 == '*') {
                 RETURN_TYPE(T_BOLD, "**", 1);
             } else {
                 RETURN_TYPE(T_ITALIC, "*", 0);
+            }
+            break;
+        case '_':
+            // bold (__) & italic (_)
+            if(ch1 == '_') {
+                RETURN_TYPE(T_BOLD, "__", 1);
+            } else {
+                RETURN_TYPE(T_ITALIC, "_", 0);
             }
             break;
         case '~':

--- a/Plugin/mdparser.hpp
+++ b/Plugin/mdparser.hpp
@@ -19,8 +19,8 @@ enum Type : int {
     T_H3 = (1 << 3),         // ###
     T_LI = (1 << 4),         // -
     T_HR = (1 << 5),         // === or ---
-    T_BOLD = (1 << 6),       // **
-    T_ITALIC = (1 << 7),     // *
+    T_BOLD = (1 << 6),       // ** or __
+    T_ITALIC = (1 << 7),     // * or _
     T_STRIKE = (1 << 8),     // ~~
     T_CODE = (1 << 9),       // `
     T_CODEBLOCK = (1 << 10), // ```


### PR DESCRIPTION
* Markdown: Add support for alternate \_\_bold\_\_ & \_italic\_ syntax.
* Disable markdown tags for warning/error messages provided by compiler or Language Server:
![compiler-markdown-old](https://user-images.githubusercontent.com/32811754/147659072-30d2c74d-d3db-493e-9977-5e5e6b0b43f5.png)
![compiler-markdown-new](https://user-images.githubusercontent.com/32811754/147659093-8e8affed-480b-4ed9-9f09-bea8e5045ed0.png)
* Generate breakpoint and bookmark tooltip in markdown format:
![breakpoint-markdown](https://user-images.githubusercontent.com/32811754/147659139-53a75a71-6e00-4447-9565-84f10ff4fb78.png)
(Note: I had to use the underscore syntax because `CCBoxTipWindow_ShrinkTip()` takes it as a comment.)