### PR TITLE
CYGWIN: avoid use of options for ELF targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ if( UNIX AND NOT APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isystem /usr/include/harfbuzz") # Needed for fedora 31 so far, but will spread. See https://gitlab.kitware.com/cmake/cmake/issues/19531
 endif()
 
-if( UNIX AND NOT APPLE)
+if( UNIX AND NOT APPLE AND NOT CYGWIN )
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--disable-new-dtags")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--disable-new-dtags")
 endif()


### PR DESCRIPTION
CYGWIN is recognized by CMake as UNIX, but it does not use ELF executables.
It uses the usual COFF-PE format.
The option "--disable-new-dtags" is unsupported because it can be appied only for ELF targets.
So, GCC hangs with an error when you try to link something on CYGWIN with that.
This PR suggests a tiny correction for fixing this error.