### PR TITLE
A few more patches for my earlier PR #2899

### DIFF
--- a/CodeLite/StringUtils.cpp
+++ b/CodeLite/StringUtils.cpp
@@ -1,5 +1,4 @@
 #include "StringUtils.h"
-
 #include <vector>
 
 std::string StringUtils::ToStdString(const wxString& str)
@@ -98,7 +97,6 @@ void StringUtils::DisableMarkdownStyling(wxString& buffer)
     buffer.Replace("-", "\\-");
     buffer.Replace("=", "\\=");
     buffer.Replace("*", "\\*");
-    buffer.Replace("_", "\\_");
     buffer.Replace("~", "\\~");
     buffer.Replace("`", "\\`");
 }

--- a/LiteEditor/breakpointsmgr.cpp
+++ b/LiteEditor/breakpointsmgr.cpp
@@ -183,7 +183,7 @@ void BreakptMgr::GetTooltip(const wxString& fileName, int lineno, wxString& tip,
 
     int id = (bp.debugger_id > 0 ? bp.debugger_id : bp.internal_id - FIRST_INTERNAL_ID);
     wxString strike = (bp.is_enabled ? "" : "~~");
-    title << "__" << strike << _("Breakpoint# ") << id << strike << "__";
+    title << "### " << strike << _("Breakpoint# ") << id << strike;
 
     if(bp.is_temp && !bp.conditions.IsEmpty()) {
         tip << _("Temporary conditional breakpoint");

--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -3181,7 +3181,7 @@ void clEditor::OnChangeActiveBookmarkType(wxCommandEvent& event)
 
 void clEditor::GetBookmarkTooltip(int lineno, wxString& tip, wxString& title)
 {
-    title << "__" << _("Bookmarks") << "__";
+    title << "### " << _("Bookmarks");
     // If we've arrived here we know there's a bookmark on the line; however we don't know which type(s)
     // If multiple, list each, with the visible one first
     int linebits = MarkerGet(lineno);

--- a/Plugin/mdparser.cpp
+++ b/Plugin/mdparser.cpp
@@ -54,19 +54,11 @@ std::pair<mdparser::Type, wxString> mdparser::Tokenizer::next()
         case '\n':
             RETURN_TYPE(T_EOL, "\n", 0);
         case '*':
-            // bold (**) & italic (*)
+            // bold & italic
             if(ch1 == '*') {
                 RETURN_TYPE(T_BOLD, "**", 1);
             } else {
                 RETURN_TYPE(T_ITALIC, "*", 0);
-            }
-            break;
-        case '_':
-            // bold (__) & italic (_)
-            if(ch1 == '_') {
-                RETURN_TYPE(T_BOLD, "__", 1);
-            } else {
-                RETURN_TYPE(T_ITALIC, "_", 0);
             }
             break;
         case '~':

--- a/Plugin/mdparser.hpp
+++ b/Plugin/mdparser.hpp
@@ -19,8 +19,8 @@ enum Type : int {
     T_H3 = (1 << 3),         // ###
     T_LI = (1 << 4),         // -
     T_HR = (1 << 5),         // === or ---
-    T_BOLD = (1 << 6),       // ** or __
-    T_ITALIC = (1 << 7),     // * or _
+    T_BOLD = (1 << 6),       // **
+    T_ITALIC = (1 << 7),     // *
     T_STRIKE = (1 << 8),     // ~~
     T_CODE = (1 << 9),       // `
     T_CODEBLOCK = (1 << 10), // ```


### PR DESCRIPTION
* Revert a commit a53babb, as it messes a lot of snake_case texts:
![markdown-underscore-sideeffect](https://user-images.githubusercontent.com/32811754/147688573-4441ba41-7280-4aa1-bf90-f3257d76c310.png)
* Use H3 heading (###) instead for breakpoint and bookmark tooltip title.
Now it looks like this:
![new_breakpoint_tooltip](https://user-images.githubusercontent.com/32811754/147688607-35ec075a-3542-46a5-bdd6-9f697eeb9207.png)