### PR TITLE
wxWidgets files should be the first to be included

### DIFF
--- a/codelitephp/PHPParserUnitTests/main.cpp
+++ b/codelitephp/PHPParserUnitTests/main.cpp
@@ -1,7 +1,7 @@
-#include <stdio.h>
-#include "PHPSourceFile.h"
 #include <wx/ffile.h>
 #include <wx/init.h>
+#include <stdio.h>
+#include "PHPSourceFile.h"
 #include "PHPLookupTable.h"
 #include "PHPExpression.h"
 #include "PHPEntityFunction.h"


### PR DESCRIPTION
I got an error when compiling codelitephp\PHPParserUnitTests\main.cpp.
It happened that many functions like strdup(), strncasecmp() and others are not declared when the preprocessor parses the include files of wxWidgets.
The reason is:
1) first, main.cpp includes stdio.h. There are several functions that are declared only if _GNU_SOURCE macro is defined. But since it is not defined at this point, those declarations are missing.
2) the include files of wxWidgets first define _GNU_SOURCE macro (for the platforms that need it) and then it includes system headers like stdio.h. But since stdio.h has been included before, that inclusion is actually useless and it rises an error when the prerpocessor reaches a point where the undeclared functions are used.

Hopefully, the solution is quite simple: the include files of wxWidgets just need to be called before stdio.h.

This is an extract of the messages that I'm getting on the console before applying the PR:

```
In file included from /usr/include/wx-3.0/wx/string.h:45,
                 from /home/Carlo/codelite/CodeLite/PHPEntityBase.h:33,
                 from /home/Carlo/codelite/CodeLite/PHPSourceFile.h:29,
                 from /home/Carlo/codelite/codelitephp/PHPParserUnitTests/main.cpp:2:
/usr/include/wx-3.0/wx/wxcrtbase.h: In function ‘char* wxStrdup(const char*)’:
/usr/include/wx-3.0/wx/wxcrtbase.h:687:47: error: ‘strdup’ was not declared in this scope; did you mean ‘strcmp’?
  687 | inline char* wxStrdup(const char *s) { return wxCRT_StrdupA(s); }
      |                                               ^~~~~~~~~~~~~
/usr/include/wx-3.0/wx/wxcrtbase.h: In function ‘wchar_t* wxStrdup(const wchar_t*’:
/usr/include/wx-3.0/wx/wxcrtbase.h:688:53: error: ‘wcsdup’ was not declared in this scope; did you mean ‘wcscmp’?
  688 | inline wchar_t* wxStrdup(const wchar_t *s) { return wxCRT_StrdupW(s); }
      |                                                     ^~~~~~~~~~~~~
/usr/include/wx-3.0/wx/string.h: In function ‘int Stricmp(const char*, const char*)’:
/usr/include/wx-3.0/wx/string.h:143:14: error: ‘strcasecmp’ was not declared in this scope; did you mean ‘strncmp’?
  143 |     { return wxCRT_StricmpA(psz1, psz2); }
      |              ^~~~~~~~~~~~~~
/usr/include/wx-3.0/wx/wxcrt.h: In function ‘size_t wxStrnlen(const char*, size_t’:
/usr/include/wx-3.0/wx/wxcrt.h:173:66: error: ‘strnlen’ was not declared in this scope; did you mean ‘strlen’?
  173 | inline size_t wxStrnlen(const char *str, size_t maxlen) { return wxCRT_StrnlenA(str, maxlen); }
      |                                                                  ^~~~~~~~~~~~~~
/usr/include/wx-3.0/wx/wxcrt.h: In function ‘size_t wxStrnlen(const wchar_t*, size_t)’:
/usr/include/wx-3.0/wx/wxcrt.h:187:69: error: ‘wcsnlen’ was not declared in this scope; did you mean ‘wcslen’?
```

...etc.