### PR TITLE
CYGWIN: fpos_t is a scalar item, not a structure.

### DIFF
--- a/sdk/codelite_indexer/libctags/read.c
+++ b/sdk/codelite_indexer/libctags/read.c
@@ -602,7 +602,7 @@ extern int readChars (char *buffer, size_t bufferSize, fpos_t location, fpos_t e
 	size_t count     = 0;
 	long sizeToRead  = -1;
 
-#if defined(__WXMSW__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__WXMSW__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__CYGWIN__)
 	if(location < 0)
 		return 0;
 #elif defined(__NetBSD__)
@@ -620,7 +620,7 @@ extern int readChars (char *buffer, size_t bufferSize, fpos_t location, fpos_t e
 
 	memset(buffer, 0, bufferSize);
 
-#if defined(__WXMSW__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__WXMSW__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__CYGWIN__)
 	sizeToRead = endPos - location;
 #elif defined(__NetBSD__)
 	sizeToRead = endPos._pos - location._pos;


### PR DESCRIPTION
For compiling this source under CYGWIN, it is needed to handle fpos_t as a scalar item.

When pushing, I got this warning:

![immagine](https://user-images.githubusercontent.com/30959007/147794671-31716d05-ba3c-427d-93b8-75d638e85d0b.png)

So, I think that this is the reason because the PR includes also a change not visible on line ending near two include files.