### PR TITLE
codelite_indexer:  wxWidgets files must be included before others

### DIFF
--- a/sdk/codelite_indexer/utils.cpp
+++ b/sdk/codelite_indexer/utils.cpp
@@ -1,3 +1,4 @@
+// clang-format off
 #include <wx/arrstr.h>
 #include <wx/regex.h>
 #include <wx/string.h>
@@ -35,6 +36,7 @@
 #define strdup _strdup
 #endif
 #endif
+// clang-format on
 
 /**
  * helper string methods

--- a/sdk/codelite_indexer/utils.cpp
+++ b/sdk/codelite_indexer/utils.cpp
@@ -1,13 +1,13 @@
+#include <wx/arrstr.h>
+#include <wx/regex.h>
+#include <wx/string.h>
+#include <wx/tokenzr.h>
 #include "utils.h"
 #include "pptable.h"
 #include <map>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <wx/arrstr.h>
-#include <wx/regex.h>
-#include <wx/string.h>
-#include <wx/tokenzr.h>
 
 #ifdef __WXMSW__
 #include <windows.h>


### PR DESCRIPTION
Similarly to PR #2906, wxWidgets files must be included first because they need to declare `_GNU_SOURCE` before using system headers.