### PR TITLE
PCH: fix error with _C and _U macros on CYGWIN

### DIFF
--- a/PCH/precompiled_header_dbg.h
+++ b/PCH/precompiled_header_dbg.h
@@ -101,7 +101,7 @@
 // 3. To convert literal strings, use _T()
 /////////////////////////////////////////////////////////////////////////////
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__CYGWIN__)
     #include <ctype.h>
     #undef _C /* _CTYPE_C */
     #undef _U /* _CTYPE_U */

--- a/PCH/precompiled_header_release.h
+++ b/PCH/precompiled_header_release.h
@@ -102,7 +102,7 @@
 // 3. To convert literal strings, use _T()
 /////////////////////////////////////////////////////////////////////////////
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__CYGWIN__)
     #include <ctype.h>
     #undef _C /* _CTYPE_C */
     #undef _U /* _CTYPE_U */

--- a/PCH/precompiled_header_release_32.h
+++ b/PCH/precompiled_header_release_32.h
@@ -102,7 +102,7 @@
 // 3. To convert literal strings, use _T()
 /////////////////////////////////////////////////////////////////////////////
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__CYGWIN__)
     #include <ctype.h>
     #undef _C /* _CTYPE_C */
     #undef _U /* _CTYPE_U */


### PR DESCRIPTION
I'm getting an error on CYGWIN because the files into PCH defines some macros called _C and _U, but they already exist into ctype.h. Here I fixed it by using the same hack made for Apple.