### PR TITLE
Several bug fixes 4

### DIFF
--- a/HelpPlugin/helpplugin.cpp
+++ b/HelpPlugin/helpplugin.cpp
@@ -27,7 +27,7 @@ CL_PLUGIN_API PluginInfo* GetPluginInfo()
     static PluginInfo info;
     info.SetAuthor(wxT("Eran Ifrah"));
     info.SetName(wxT("HelpPlugin"));
-    info.SetDescription(wxT("Provide help based on selected words"));
+    info.SetDescription(_("Provide help based on selected words"));
     info.SetVersion(wxT("v1.0"));
     return &info;
 }

--- a/LiteEditor/breakpointdlgbase.cpp
+++ b/LiteEditor/breakpointdlgbase.cpp
@@ -69,7 +69,9 @@ BreakpointTabBase::BreakpointTabBase(wxWindow* parent, wxWindowID id, const wxPo
 
     SetName(wxT("BreakpointTabBase"));
     SetSize(wxDLG_UNIT(this, wxSize(-1, -1)));
-    if(GetSizer()) { GetSizer()->Fit(this); }
+    if(GetSizer()) {
+        GetSizer()->Fit(this);
+    }
     // Connect events
     m_dvListCtrlBreakpoints->Connect(wxEVT_COMMAND_DATAVIEW_ITEM_CONTEXT_MENU,
                                      wxDataViewEventHandler(BreakpointTabBase::OnContextMenu), NULL, this);
@@ -290,7 +292,7 @@ BreakpointPropertiesDlgBase::BreakpointPropertiesDlgBase(wxWindow* parent, wxWin
         new wxTextCtrl(this, wxID_ANY, wxT(""), wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), wxTE_MULTILINE);
     m_textCond->SetToolTip(
         _("You can add a condition to any breakpoint or watchpoint. The debugger will then stop only if the condition "
-          "is met.\nThe condition can be any simple or complex expression in your programming language,providing it "
+          "is met.\nThe condition can be any simple or complex expression in your programming language, providing it "
           "returns a bool. However any variables that you use must be in scope.\nIf you've previously set a condition "
           "and no longer want it, just clear this textctrl."));
 
@@ -376,7 +378,9 @@ BreakpointPropertiesDlgBase::BreakpointPropertiesDlgBase(wxWindow* parent, wxWin
 
     SetName(wxT("BreakpointPropertiesDlgBase"));
     SetSize(wxDLG_UNIT(this, wxSize(-1, -1)));
-    if(GetSizer()) { GetSizer()->Fit(this); }
+    if(GetSizer()) {
+        GetSizer()->Fit(this);
+    }
     if(GetParent()) {
         CentreOnParent();
     } else {

--- a/LiteEditor/breakpointdlgbase.h
+++ b/LiteEditor/breakpointdlgbase.h
@@ -7,6 +7,7 @@
 #ifndef _CODELITE_LITEEDITOR_BREAKPOINTDLG_BASE_CLASSES_H
 #define _CODELITE_LITEEDITOR_BREAKPOINTDLG_BASE_CLASSES_H
 
+// clang-format off
 #include <wx/settings.h>
 #include <wx/xrc/xmlres.h>
 #include <wx/xrc/xh_bmp.h>
@@ -42,6 +43,8 @@
 #else
 #define WXC_FROM_DIP(x) x
 #endif
+
+// clang-format on
 
 class BreakpointTabBase : public wxPanel
 {

--- a/LiteEditor/breakpointsmgr.cpp
+++ b/LiteEditor/breakpointsmgr.cpp
@@ -31,8 +31,10 @@
 #include "file_logger.h"
 #include "frame.h"
 #include "manager.h"
-#include "wx/numdlg.h"
-#include "wx/regex.h"
+
+#include <wx/numdlg.h>
+#include <wx/regex.h>
+#include <wx/tokenzr.h>
 
 //---------------------------------------------------------
 BreakptMgr::BreakptMgr()
@@ -207,7 +209,12 @@ void BreakptMgr::GetTooltip(const wxString& fileName, int lineno, wxString& tip,
         tip << _("Condition: ") << "`" << bp.conditions << "`\n";
     }
     if(!bp.commandlist.IsEmpty()) {
-        tip << _("Commands: ") << "`" << bp.commandlist << "`\n";
+        tip << _("Commands: ") << "\n";
+
+        wxArrayString commands = ::wxStringTokenize(bp.commandlist, "\n", wxTOKEN_STRTOK);
+        for(const wxString& command : commands) {
+            tip << "  `" << command << "`\n";
+        }
     }
 
     tip.Trim().Trim(false);

--- a/MacBundler/macbundler.cpp
+++ b/MacBundler/macbundler.cpp
@@ -296,7 +296,7 @@ CL_PLUGIN_API PluginInfo* GetPluginInfo()
     static PluginInfo info;
     info.SetAuthor(wxT("Auria"));
     info.SetName(wxT("MacBundler"));
-    info.SetDescription(wxT("MacBundler : manage OS X app bundles"));
+    info.SetDescription(_("MacBundler : manage OS X app bundles"));
     info.SetVersion(wxT("v0.1"));
     return &info;
 }

--- a/Plugin/cc_box_tip_window.cpp
+++ b/Plugin/cc_box_tip_window.cpp
@@ -191,20 +191,28 @@ void CCBoxTipWindow::DoInitialize(size_t numOfTips, bool simpleTip)
     }
     text_rect.Inflate(5);
 
-    // make sure that the tip window, is not bigger than the screen
-    auto display = GetDisplay(this);
-    wxRect display_size = display->GetGeometry();
-
-    if(text_rect.GetHeight() > display_size.GetHeight()) {
-        text_rect.SetHeight(display_size.GetHeight());
-    }
-    if(text_rect.GetWidth() >= display_size.GetWidth()) {
-        text_rect.SetWidth(display_size.GetWidth());
-    }
+    wxSize shrinked_size = text_rect.GetSize();
+    ShrinkToScreen(shrinked_size);
+    text_rect.SetSize(shrinked_size);
 
     SetSizeHints(text_rect.GetSize());
     SetSize(text_rect.GetSize());
     Layout();
+}
+
+void CCBoxTipWindow::ShrinkToScreen(wxSize& size) const
+{
+    // make sure that the tip window, is not bigger than the screen
+    auto display = GetDisplay(this);
+    // shrink up to the client area to preserve an extra space to un-hover it
+    wxRect display_rect = display->GetClientArea();
+
+    if(size.GetHeight() > display_rect.GetHeight()) {
+        size.SetHeight(display_rect.GetHeight());
+    }
+    if(size.GetWidth() >= display_rect.GetWidth()) {
+        size.SetWidth(display_rect.GetWidth());
+    }
 }
 
 void CCBoxTipWindow::PositionRelativeTo(wxWindow* win, wxPoint caretPos, IEditor* focusEdior)
@@ -331,6 +339,8 @@ void CCBoxTipWindow::DoDrawTip(wxDC& dc)
     clMarkdownRenderer renderer;
     wxSize size = renderer.Render(this, dc, m_tip, GetClientRect());
     wxSize client_rect = GetClientRect().GetSize();
+
+    ShrinkToScreen(size);
 
     if(m_ratio == 0.0 && size.GetWidth() > client_rect.GetWidth()) {
         m_ratio = (double)size.GetWidth() / (double)client_rect.GetWidth();

--- a/Plugin/cc_box_tip_window.h
+++ b/Plugin/cc_box_tip_window.h
@@ -51,6 +51,8 @@ protected:
     void DoInitialize(size_t numOfTips, bool simpleTip);
     void DoDrawTip(wxDC& dc);
 
+    void ShrinkToScreen(wxSize& size) const;
+
 public:
     CCBoxTipWindow(wxWindow* parent, const wxString& tip, bool strip_html_tags);
     virtual ~CCBoxTipWindow();

--- a/Plugin/clKeyboardManager.cpp
+++ b/Plugin/clKeyboardManager.cpp
@@ -50,7 +50,7 @@ clKeyboardManager::clKeyboardManager()
     m_keyCodes.insert("ENTER");
     m_keyCodes.insert("CAPITAL");
     m_keyCodes.insert("SCROLL_LOCK");
-    m_keyCodes.insert("PASUE");
+    m_keyCodes.insert("PAUSE");
     m_keyCodes.insert(";");
     m_keyCodes.insert("'");
     m_keyCodes.insert("\\");
@@ -432,6 +432,7 @@ wxArrayString clKeyboardManager::GetAllUnasignedKeyboardShortcuts() const
     wxArrayString allUnasigned;
     std::set_difference(m_allShorcuts.begin(), m_allShorcuts.end(), usedShortcuts.begin(), usedShortcuts.end(),
                         std::back_inserter(allUnasigned));
+    allUnasigned.Sort();
     return allUnasigned;
 }
 

--- a/Plugin/newkeyshortcutdlg.cpp
+++ b/Plugin/newkeyshortcutdlg.cpp
@@ -25,6 +25,7 @@
 #include "newkeyshortcutdlg.h"
 
 #include "clSingleChoiceDialog.h"
+#include "globals.h"
 #include "windowattrmanager.h"
 
 #include <wx/tokenzr.h>
@@ -237,6 +238,7 @@ NewKeyShortcutDlg::~NewKeyShortcutDlg() {}
 void NewKeyShortcutDlg::OnSuggest(wxCommandEvent& event)
 {
     clSingleChoiceDialog dlg(this, clKeyboardManager::Get()->GetAllUnasignedKeyboardShortcuts(), 0);
+    ::clSetDialogSizeAndPosition(&dlg, 1.2); // give it a reasonable size
     dlg.SetLabel(_("Select a Keyboard Shortcut"));
     if(dlg.ShowModal() == wxID_OK) {
         Initialise(dlg.GetSelection());

--- a/Rust/RustPlugin.cpp
+++ b/Rust/RustPlugin.cpp
@@ -193,7 +193,7 @@ void RustPlugin::OnNewWorkspace(clCommandEvent& e)
         e.Skip(false);
         // Prompt the user for the folder to run 'cargo new'
         NewFileSystemWorkspaceDialog dlg(EventNotifier::Get()->TopFrame(), false /* do not auto update the name */);
-        dlg.SetLabel("Select the folder to run 'cargo new'");
+        dlg.SetLabel(_("Select the folder to run 'cargo new'"));
         if(dlg.ShowModal() != wxID_OK) {
             return;
         }


### PR DESCRIPTION
* VisualCppImporter: Import `LibraryPath` and `IncludePath` from project
These properties are worth importing to make the migration step easier.

* Keyboard Shortcut: `Suggest` dialog fixes
    * `Suggest` dialog should claim more dialog size:
![2022-01-08 01-06-56](https://user-images.githubusercontent.com/32811754/148571746-29d70663-402a-45b5-b538-65c9c27a623d.png)
    * Sort the list of unused keyboard shortcuts for better discovery.
    * Fix typo: PASUE -> PAUSE.

* CCBoxTipWindow: Perform another sanity-check for the tooltip window size

Here's an *extreme* example:
```c++
// ################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
void
hover_me_first()
{
}

void
then_here()
{
}
```

By hovering `hover_me_first()` -> `then_here()` results in:
![2022-01-08 01-11-57](https://user-images.githubusercontent.com/32811754/148572377-db0669ff-f03c-46ab-82cf-062a62f49fc1.png)

* `BreakptMgr::GetTooltip()`: Make tooltip compatible with multiple breakpoint commands

* Add some missing translations