### PR TITLE
wxCrafter: Several tweaks and bugfixes

### DIFF
--- a/Runtime/templates/projects/executable-wxcrafter-dialog/wxcrafter.hpp
+++ b/Runtime/templates/projects/executable-wxcrafter-dialog/wxcrafter.hpp
@@ -44,9 +44,9 @@ protected:
 
 protected:
 public:
-    wxStaticLine* GetStaticLine15() { return m_staticLine15; }
-    wxButton* GetButtonOK() { return m_buttonOK; }
-    wxButton* GetButtonCancel() { return m_buttonCancel; }
+    wxStaticLine* GetStaticLine15() noexcept { return m_staticLine15; }
+    wxButton* GetButtonOK() noexcept { return m_buttonOK; }
+    wxButton* GetButtonCancel() noexcept { return m_buttonCancel; }
     MainDialogBaseClass(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("My Dialog"),
                         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(500, 300),
                         long style = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);

--- a/Runtime/templates/projects/executable-wxcrafter-dialog/wxcrafter.wxcp
+++ b/Runtime/templates/projects/executable-wxcrafter-dialog/wxcrafter.wxcp
@@ -11,6 +11,7 @@
 		"m_useEnum":	true,
 		"m_useUnderscoreMacro":	true,
 		"m_addHandlers":	true,
+		"m_keepSizers":	false,
 		"m_templateClasses":	[]
 	},
 	"windows":	[{

--- a/Runtime/templates/projects/executable-wxcrafter-frame/wxcrafter.hpp
+++ b/Runtime/templates/projects/executable-wxcrafter-frame/wxcrafter.hpp
@@ -52,9 +52,9 @@ protected:
     virtual void OnAbout(wxCommandEvent& event) { event.Skip(); }
 
 public:
-    wxPanel* GetMainPanel() { return m_mainPanel; }
-    wxMenuBar* GetMainMenuBar() { return m_mainMenuBar; }
-    wxToolBar* GetMainToolbar() { return m_mainToolbar; }
+    wxPanel* GetMainPanel() noexcept { return m_mainPanel; }
+    wxMenuBar* GetMainMenuBar() noexcept { return m_mainMenuBar; }
+    wxToolBar* GetMainToolbar() noexcept { return m_mainToolbar; }
     MainFrameBaseClass(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("My Frame"),
                        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(500, 300),
                        long style = wxCAPTION | wxRESIZE_BORDER | wxMAXIMIZE_BOX | wxMINIMIZE_BOX | wxSYSTEM_MENU |

--- a/Runtime/templates/projects/executable-wxcrafter-frame/wxcrafter.wxcp
+++ b/Runtime/templates/projects/executable-wxcrafter-frame/wxcrafter.wxcp
@@ -11,6 +11,7 @@
 		"m_useEnum":	true,
 		"m_useUnderscoreMacro":	true,
 		"m_addHandlers":	true,
+		"m_keepSizers":	false,
 		"m_templateClasses":	[]
 	},
 	"windows":	[{

--- a/wxcrafter/box_sizer_wrapper.cpp
+++ b/wxcrafter/box_sizer_wrapper.cpp
@@ -1,6 +1,8 @@
 #include "box_sizer_wrapper.h"
+
 #include "allocator_mgr.h"
 #include "choice_property.h"
+#include "wxc_project_metadata.h"
 #include "wxgui_defs.h"
 #include "wxgui_helpers.h"
 #include "xmlutils.h"
@@ -20,7 +22,10 @@ BoxSizerWrapper::BoxSizerWrapper()
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);
 
-    m_namePattern = wxT("boxSizer");
+    m_namePattern = "boxSizer";
+    if(wxcProjectMetadata::Get().IsKeepSizers()) {
+        m_namePattern.Prepend("m_");
+    }
     SetName(GenerateName());
 }
 
@@ -31,7 +36,8 @@ wxString BoxSizerWrapper::GetWxClassName() const { return wxT("wxBoxSizer"); }
 wxString BoxSizerWrapper::CppCtorCode() const
 {
     wxString code;
-    if(!wxcSettings::Get().HasFlag(wxcSettings::SIZERS_AS_MEMBERS)) code << "wxBoxSizer* ";
+    if(!wxcProjectMetadata::Get().IsKeepSizers())
+        code << "wxBoxSizer* ";
 
     code << GetName() << " = new wxBoxSizer(" << PropertyString(PROP_ORIENTATION) << ");\n";
 
@@ -67,7 +73,9 @@ void BoxSizerWrapper::LoadPropertiesFromXRC(const wxXmlNode* node)
     wxcWidget::LoadPropertiesFromXRC(node);
 
     wxXmlNode* propertynode = XmlUtils::FindFirstByTagName(node, wxT("orient"));
-    if(propertynode) { SetPropertyString(PROP_ORIENTATION, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_ORIENTATION, propertynode->GetNodeContent());
+    }
 }
 
 void BoxSizerWrapper::LoadPropertiesFromwxSmith(const wxXmlNode* node)
@@ -77,10 +85,14 @@ void BoxSizerWrapper::LoadPropertiesFromwxSmith(const wxXmlNode* node)
 
     // wxSmith doesn't use "name" here, but "variable" means the same thing afaict
     wxString value = XmlUtils::ReadString(node, wxT("variable"));
-    if(!value.empty()) { SetName(value); }
+    if(!value.empty()) {
+        SetName(value);
+    }
 
     wxXmlNode* propertynode = XmlUtils::FindFirstByTagName(node, wxT("orient"));
-    if(propertynode) { SetPropertyString(PROP_ORIENTATION, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_ORIENTATION, propertynode->GetNodeContent());
+    }
 }
 
 void BoxSizerWrapper::LoadPropertiesFromwxFB(const wxXmlNode* node)
@@ -89,5 +101,7 @@ void BoxSizerWrapper::LoadPropertiesFromwxFB(const wxXmlNode* node)
     wxcWidget::LoadPropertiesFromwxFB(node);
 
     wxXmlNode* propertynode = XmlUtils::FindNodeByName(node, "property", "orient");
-    if(propertynode) { SetPropertyString(PROP_ORIENTATION, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_ORIENTATION, propertynode->GetNodeContent());
+    }
 }

--- a/wxcrafter/flexgridsizer_wrapper.cpp
+++ b/wxcrafter/flexgridsizer_wrapper.cpp
@@ -1,5 +1,7 @@
 #include "flexgridsizer_wrapper.h"
+
 #include "allocator_mgr.h"
+#include "wxc_project_metadata.h"
 #include "wxgui_helpers.h"
 #include "xmlutils.h"
 
@@ -13,15 +15,17 @@ FlexGridSizerWrapper::FlexGridSizerWrapper()
     AddProperty(new StringProperty(PROP_ROWS, wxT("0"), _("Number of rows in the grid")));
     AddProperty(
         new StringProperty(PROP_GROW_COLS, wxT(""), _("Which columns are allowed to grow. Comma separated list")));
-    AddProperty(
-        new StringProperty(PROP_GROW_ROWS, wxT(""), _("Which rows are allowed to grow. Comma separated list")));
+    AddProperty(new StringProperty(PROP_GROW_ROWS, wxT(""), _("Which rows are allowed to grow. Comma separated list")));
     AddProperty(new StringProperty(PROP_HGAP, wxT("0"), _("The horizontal gap between grid cells")));
     AddProperty(new StringProperty(PROP_VGAP, wxT("0"), _("The vertical gap between grid cells")));
-    m_namePattern = wxT("flexGridSizer");
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);
 
+    m_namePattern = "flexGridSizer";
+    if(wxcProjectMetadata::Get().IsKeepSizers()) {
+        m_namePattern.Prepend("m_");
+    }
     SetName(GenerateName());
 }
 
@@ -34,7 +38,8 @@ wxString FlexGridSizerWrapper::CppCtorCode() const
     wxArrayString growCols = wxCrafter::Split(PropertyString(PROP_GROW_COLS), wxT(","));
     wxArrayString growRows = wxCrafter::Split(PropertyString(PROP_GROW_ROWS), wxT(","));
 
-    if(!wxcSettings::Get().HasFlag(wxcSettings::SIZERS_AS_MEMBERS)) code << "wxFlexGridSizer* ";
+    if(!wxcProjectMetadata::Get().IsKeepSizers())
+        code << "wxFlexGridSizer* ";
 
     code << GetName() << " = new wxFlexGridSizer(" << PropertyString(PROP_ROWS) << wxT(", ")
          << PropertyString(PROP_COLS) << wxT(", ") << PropertyString(PROP_VGAP) << wxT(", ")
@@ -89,22 +94,34 @@ void FlexGridSizerWrapper::LoadPropertiesFromwxSmith(const wxXmlNode* node)
 void FlexGridSizerWrapper::DoLoadXRCProperties(const wxXmlNode* node)
 {
     wxXmlNode* propertynode = XmlUtils::FindFirstByTagName(node, wxT("cols"));
-    if(propertynode) { SetPropertyString(PROP_COLS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_COLS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("rows"));
-    if(propertynode) { SetPropertyString(PROP_ROWS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_ROWS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("vgap"));
-    if(propertynode) { SetPropertyString(PROP_VGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_VGAP, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("hgap"));
-    if(propertynode) { SetPropertyString(PROP_HGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_HGAP, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("growablecols"));
-    if(propertynode) { SetPropertyString(PROP_GROW_COLS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_GROW_COLS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("growablerows"));
-    if(propertynode) { SetPropertyString(PROP_GROW_ROWS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_GROW_ROWS, propertynode->GetNodeContent());
+    }
 }
 
 void FlexGridSizerWrapper::LoadPropertiesFromwxFB(const wxXmlNode* node)
@@ -113,20 +130,32 @@ void FlexGridSizerWrapper::LoadPropertiesFromwxFB(const wxXmlNode* node)
     wxcWidget::LoadPropertiesFromwxFB(node);
 
     wxXmlNode* propertynode = XmlUtils::FindNodeByName(node, "property", "cols");
-    if(propertynode) { SetPropertyString(PROP_COLS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_COLS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "rows");
-    if(propertynode) { SetPropertyString(PROP_ROWS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_ROWS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "vgap");
-    if(propertynode) { SetPropertyString(PROP_VGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_VGAP, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "hgap");
-    if(propertynode) { SetPropertyString(PROP_HGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_HGAP, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "growablecols");
-    if(propertynode) { SetPropertyString(PROP_GROW_COLS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_GROW_COLS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "growablerows");
-    if(propertynode) { SetPropertyString(PROP_GROW_ROWS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_GROW_ROWS, propertynode->GetNodeContent());
+    }
 }

--- a/wxcrafter/grid_bag_sizer_wrapper.cpp
+++ b/wxcrafter/grid_bag_sizer_wrapper.cpp
@@ -1,5 +1,7 @@
 #include "grid_bag_sizer_wrapper.h"
+
 #include "allocator_mgr.h"
+#include "wxc_project_metadata.h"
 #include "wxgui_helpers.h"
 #include "xmlutils.h"
 
@@ -10,15 +12,17 @@ GridBagSizerWrapper::GridBagSizerWrapper()
     SetPropertyString(_("Common Settings"), "wxGridBagSizer");
     AddProperty(
         new StringProperty(PROP_GROW_COLS, wxT(""), _("Which columns are allowed to grow. Comma separated list")));
-    AddProperty(
-        new StringProperty(PROP_GROW_ROWS, wxT(""), _("Which rows are allowed to grow. Comma separated list")));
+    AddProperty(new StringProperty(PROP_GROW_ROWS, wxT(""), _("Which rows are allowed to grow. Comma separated list")));
     AddProperty(new StringProperty(PROP_HGAP, wxT("0"), _("The horizontal gap between grid cells")));
     AddProperty(new StringProperty(PROP_VGAP, wxT("0"), _("The vertical gap between grid cells")));
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);
 
-    m_namePattern = wxT("gridBagSizer");
+    m_namePattern = "gridBagSizer";
+    if(wxcProjectMetadata::Get().IsKeepSizers()) {
+        m_namePattern.Prepend("m_");
+    }
     SetName(GenerateName());
 }
 
@@ -28,7 +32,8 @@ wxString GridBagSizerWrapper::CppCtorCode() const
 {
     wxString code;
 
-    if(!wxcSettings::Get().HasFlag(wxcSettings::SIZERS_AS_MEMBERS)) code << "wxGridBagSizer* ";
+    if(!wxcProjectMetadata::Get().IsKeepSizers())
+        code << "wxGridBagSizer* ";
 
     code << GetName() << " = new wxGridBagSizer(" << PropertyString(PROP_VGAP) << wxT(", ") << PropertyString(PROP_HGAP)
          << wxT(");\n");
@@ -78,16 +83,24 @@ void GridBagSizerWrapper::LoadPropertiesFromwxSmith(const wxXmlNode* node)
 void GridBagSizerWrapper::DoLoadXRCProperties(const wxXmlNode* node)
 {
     wxXmlNode* propertynode = XmlUtils::FindFirstByTagName(node, wxT("vgap"));
-    if(propertynode) { SetPropertyString(PROP_VGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_VGAP, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("hgap"));
-    if(propertynode) { SetPropertyString(PROP_HGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_HGAP, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("growablecols"));
-    if(propertynode) { SetPropertyString(PROP_GROW_COLS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_GROW_COLS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("growablerows"));
-    if(propertynode) { SetPropertyString(PROP_GROW_ROWS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_GROW_ROWS, propertynode->GetNodeContent());
+    }
 }
 
 void GridBagSizerWrapper::LoadPropertiesFromwxFB(const wxXmlNode* node)
@@ -96,16 +109,24 @@ void GridBagSizerWrapper::LoadPropertiesFromwxFB(const wxXmlNode* node)
     wxcWidget::LoadPropertiesFromwxFB(node);
 
     wxXmlNode* propertynode = XmlUtils::FindNodeByName(node, "property", "vgap");
-    if(propertynode) { SetPropertyString(PROP_VGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_VGAP, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "hgap");
-    if(propertynode) { SetPropertyString(PROP_HGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_HGAP, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "growablecols");
-    if(propertynode) { SetPropertyString(PROP_GROW_COLS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_GROW_COLS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "growablerows");
-    if(propertynode) { SetPropertyString(PROP_GROW_ROWS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_GROW_ROWS, propertynode->GetNodeContent());
+    }
 }
 
 wxString GridBagSizerWrapper::DoGenerateCppCtorCode_End() const

--- a/wxcrafter/grid_sizer_wrapper.cpp
+++ b/wxcrafter/grid_sizer_wrapper.cpp
@@ -1,5 +1,7 @@
 #include "grid_sizer_wrapper.h"
+
 #include "allocator_mgr.h"
+#include "wxc_project_metadata.h"
 #include "wxgui_helpers.h"
 #include "xmlutils.h"
 
@@ -17,7 +19,10 @@ GridSizerWrapper::GridSizerWrapper()
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);
 
-    m_namePattern = wxT("gridSizer");
+    m_namePattern = "gridSizer";
+    if(wxcProjectMetadata::Get().IsKeepSizers()) {
+        m_namePattern.Prepend("m_");
+    }
     SetName(GenerateName());
 }
 
@@ -27,7 +32,8 @@ wxString GridSizerWrapper::CppCtorCode() const
 {
     wxString code;
 
-    if(!wxcSettings::Get().HasFlag(wxcSettings::SIZERS_AS_MEMBERS)) code << "wxGridSizer* ";
+    if(!wxcProjectMetadata::Get().IsKeepSizers())
+        code << "wxGridSizer* ";
 
     code << GetName() << " = new wxGridSizer(" << PropertyString(PROP_ROWS) << wxT(", ") << PropertyString(PROP_COLS)
          << wxT(", ") << PropertyString(PROP_VGAP) << wxT(", ") << PropertyString(PROP_HGAP) << wxT(");\n");
@@ -72,16 +78,24 @@ void GridSizerWrapper::LoadPropertiesFromwxSmith(const wxXmlNode* node)
 void GridSizerWrapper::DoLoadXRCProperties(const wxXmlNode* node)
 {
     wxXmlNode* propertynode = XmlUtils::FindFirstByTagName(node, wxT("cols"));
-    if(propertynode) { SetPropertyString(PROP_COLS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_COLS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("rows"));
-    if(propertynode) { SetPropertyString(PROP_ROWS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_ROWS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("vgap"));
-    if(propertynode) { SetPropertyString(PROP_VGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_VGAP, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindFirstByTagName(node, wxT("hgap"));
-    if(propertynode) { SetPropertyString(PROP_HGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_HGAP, propertynode->GetNodeContent());
+    }
 }
 
 void GridSizerWrapper::LoadPropertiesFromwxFB(const wxXmlNode* node)
@@ -90,14 +104,22 @@ void GridSizerWrapper::LoadPropertiesFromwxFB(const wxXmlNode* node)
     wxcWidget::LoadPropertiesFromwxFB(node);
 
     wxXmlNode* propertynode = XmlUtils::FindNodeByName(node, "property", "cols");
-    if(propertynode) { SetPropertyString(PROP_COLS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_COLS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "rows");
-    if(propertynode) { SetPropertyString(PROP_ROWS, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_ROWS, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "vgap");
-    if(propertynode) { SetPropertyString(PROP_VGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_VGAP, propertynode->GetNodeContent());
+    }
 
     propertynode = XmlUtils::FindNodeByName(node, "property", "hgap");
-    if(propertynode) { SetPropertyString(PROP_HGAP, propertynode->GetNodeContent()); }
+    if(propertynode) {
+        SetPropertyString(PROP_HGAP, propertynode->GetNodeContent());
+    }
 }

--- a/wxcrafter/gui.cpp
+++ b/wxcrafter/gui.cpp
@@ -93,7 +93,7 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
     m_menuFile->AppendSeparator();
 
     m_menuItemBackToCodelite =
-        new wxMenuItem(m_menuFile, wxID_BACKWARD, _("Back to codelite\tCtrl-Shift-F12"), wxT(""), wxITEM_NORMAL);
+        new wxMenuItem(m_menuFile, wxID_BACKWARD, _("Back to CodeLite\tCtrl-Shift-F12"), wxT(""), wxITEM_NORMAL);
     m_menuFile->Append(m_menuItemBackToCodelite);
 
     m_menuView = new wxMenu();
@@ -227,6 +227,8 @@ MainFrameBase::MainFrameBase(wxWindow* parent, wxWindowID id, const wxString& ti
                   wxUpdateUIEventHandler(MainFrameBase::OnBatchGenerateCodeUI), NULL, this);
     this->Connect(m_menuItemBackToCodelite->GetId(), wxEVT_UPDATE_UI,
                   wxUpdateUIEventHandler(MainFrameBase::OnSwitchToCodeliteUI), NULL, this);
+    this->Connect(m_menuItemBackToCodelite->GetId(), wxEVT_COMMAND_MENU_SELECTED,
+                  wxCommandEventHandler(MainFrameBase::OnSwitchToCodelite), NULL, this);
     this->Connect(m_menuItemPreview->GetId(), wxEVT_COMMAND_MENU_SELECTED,
                   wxCommandEventHandler(MainFrameBase::OnPreview), NULL, this);
     this->Connect(m_menuItemPreview->GetId(), wxEVT_UPDATE_UI, wxUpdateUIEventHandler(MainFrameBase::OnPreviewUI), NULL,
@@ -302,6 +304,8 @@ MainFrameBase::~MainFrameBase()
                      wxUpdateUIEventHandler(MainFrameBase::OnBatchGenerateCodeUI), NULL, this);
     this->Disconnect(m_menuItemBackToCodelite->GetId(), wxEVT_UPDATE_UI,
                      wxUpdateUIEventHandler(MainFrameBase::OnSwitchToCodeliteUI), NULL, this);
+    this->Disconnect(m_menuItemBackToCodelite->GetId(), wxEVT_COMMAND_MENU_SELECTED,
+                     wxCommandEventHandler(MainFrameBase::OnSwitchToCodelite), NULL, this);
     this->Disconnect(m_menuItemPreview->GetId(), wxEVT_COMMAND_MENU_SELECTED,
                      wxCommandEventHandler(MainFrameBase::OnPreview), NULL, this);
     this->Disconnect(m_menuItemPreview->GetId(), wxEVT_UPDATE_UI, wxUpdateUIEventHandler(MainFrameBase::OnPreviewUI),

--- a/wxcrafter/gui.cpp
+++ b/wxcrafter/gui.cpp
@@ -970,38 +970,38 @@ ColourPickerDlgbase::ColourPickerDlgbase(wxWindow* parent, wxWindowID id, const 
     bSizer21->Add(bSizer25, 1, wxEXPAND, WXC_FROM_DIP(5));
 
     wxArrayString m_choiceStandardColorsArr;
-    m_choiceStandardColorsArr.Add(wxT("<Default>"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_SCROLLBAR"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_DESKTOP"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_ACTIVECAPTION"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_INACTIVECAPTION"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_MENU"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_WINDOW"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_WINDOWFRAME"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_MENUTEXT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_WINDOWTEXT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_CAPTIONTEXT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_ACTIVEBORDER"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_INACTIVEBORDER"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_APPWORKSPACE"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_HIGHLIGHT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_HIGHLIGHTTEXT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_BTNFACE"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_BTNSHADOW"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_GRAYTEXT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_BTNTEXT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_INACTIVECAPTIONTEXT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_BTNHIGHLIGHT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_3DDKSHADOW"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_3DLIGHT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_INFOTEXT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_INFOBK"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_LISTBOX"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_HOTLIGHT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_GRADIENTACTIVECAPTION"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_GRADIENTINACTIVECAPTION"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_MENUHILIGHT"));
-    m_choiceStandardColorsArr.Add(wxT("wxSYS_COLOUR_MENUBAR"));
+    m_choiceStandardColorsArr.Add(_("<Default>"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_SCROLLBAR"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_DESKTOP"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_ACTIVECAPTION"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_INACTIVECAPTION"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_MENU"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_WINDOW"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_WINDOWFRAME"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_MENUTEXT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_WINDOWTEXT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_CAPTIONTEXT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_ACTIVEBORDER"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_INACTIVEBORDER"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_APPWORKSPACE"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_HIGHLIGHT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_HIGHLIGHTTEXT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_BTNFACE"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_BTNSHADOW"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_GRAYTEXT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_BTNTEXT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_INACTIVECAPTIONTEXT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_BTNHIGHLIGHT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_3DDKSHADOW"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_3DLIGHT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_INFOTEXT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_INFOBK"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_LISTBOX"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_HOTLIGHT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_GRADIENTACTIVECAPTION"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_GRADIENTINACTIVECAPTION"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_MENUHILIGHT"));
+    m_choiceStandardColorsArr.Add(_("wxSYS_COLOUR_MENUBAR"));
     m_choiceStandardColors =
         new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, -1)), m_choiceStandardColorsArr, 0);
     m_choiceStandardColors->SetToolTip(_("Select a standard color from the list below"));
@@ -1107,12 +1107,6 @@ wxcSettingsDlgBase::wxcSettingsDlgBase(wxWindow* parent, wxWindowID id, const wx
         new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, _("Code Generation:")), wxVERTICAL);
 
     boxSizer145->Add(staticBoxSizer152, 0, wxALL | wxEXPAND, WXC_FROM_DIP(5));
-
-    m_checkBoxSizersAsMembers = new wxCheckBox(this, wxID_ANY, _("Keep wxSizers as class members"), wxDefaultPosition,
-                                               wxDLG_UNIT(this, wxSize(-1, -1)), 0);
-    m_checkBoxSizersAsMembers->SetValue(false);
-
-    staticBoxSizer152->Add(m_checkBoxSizersAsMembers, 0, wxALL, WXC_FROM_DIP(5));
 
     m_checkBoxFormatInheritedFiles = new wxCheckBox(this, wxID_ANY, _("Format inherited files"), wxDefaultPosition,
                                                     wxDLG_UNIT(this, wxSize(-1, -1)), 0);

--- a/wxcrafter/gui.h
+++ b/wxcrafter/gui.h
@@ -65,9 +65,9 @@ class MainFrameBase : public wxFrame
 public:
     enum {
         ID_CUSTOM_CONTROL_DELETE = 1001,
-        ID_CUSTOM_CONTROL_NEW = 1002,
-        ID_BATCH_GENERATE_CODE = 1003,
-        ID_CUSTOM_CONTROL_EDIT = 1004,
+        ID_CUSTOM_CONTROL_EDIT = 1002,
+        ID_CUSTOM_CONTROL_NEW = 1003,
+        ID_BATCH_GENERATE_CODE = 1004,
         ID_GENERATE_CODE = 1005,
     };
 
@@ -331,7 +331,6 @@ class wxcSettingsDlgBase : public wxDialog
 {
 protected:
     wxCheckBox* m_checkBoxUseTRay;
-    wxCheckBox* m_checkBoxSizersAsMembers;
     wxCheckBox* m_checkBoxFormatInheritedFiles;
     wxStaticText* m_staticText215;
     wxCheckBox* m_checkBoxKeepAllUsersetNames;
@@ -347,7 +346,6 @@ protected:
 
 public:
     wxCheckBox* GetCheckBoxUseTRay() { return m_checkBoxUseTRay; }
-    wxCheckBox* GetCheckBoxSizersAsMembers() { return m_checkBoxSizersAsMembers; }
     wxCheckBox* GetCheckBoxFormatInheritedFiles() { return m_checkBoxFormatInheritedFiles; }
     wxStaticText* GetStaticText215() { return m_staticText215; }
     wxCheckBox* GetCheckBoxKeepAllUsersetNames() { return m_checkBoxKeepAllUsersetNames; }

--- a/wxcrafter/gui.h
+++ b/wxcrafter/gui.h
@@ -131,6 +131,7 @@ protected:
     virtual void OnBatchGenerateCode(wxCommandEvent& event) { event.Skip(); }
     virtual void OnBatchGenerateCodeUI(wxUpdateUIEvent& event) { event.Skip(); }
     virtual void OnSwitchToCodeliteUI(wxUpdateUIEvent& event) { event.Skip(); }
+    virtual void OnSwitchToCodelite(wxCommandEvent& event) { event.Skip(); }
     virtual void OnPreview(wxCommandEvent& event) { event.Skip(); }
     virtual void OnPreviewUI(wxUpdateUIEvent& event) { event.Skip(); }
     virtual void OnDeleteItem(wxCommandEvent& event) { event.Skip(); }
@@ -158,13 +159,13 @@ protected:
     virtual void OnAbout(wxCommandEvent& event) { event.Skip(); }
 
 public:
-    clToolBar* GetMainToolbar() { return m_mainToolbar; }
-    wxPanel* GetSplitterPageTreeView() { return m_splitterPageTreeView; }
-    wxPanel* GetSplitterPageDesigner() { return m_splitterPageDesigner; }
-    wxSplitterWindow* GetSplitterMain() { return m_splitterMain; }
-    wxPanel* GetMainPanel() { return m_MainPanel; }
-    wxStatusBar* GetStatusBar() { return m_statusBar; }
-    wxMenuBar* GetMenuBar() { return m_menuBar; }
+    clToolBar* GetMainToolbar() noexcept { return m_mainToolbar; }
+    wxPanel* GetSplitterPageTreeView() noexcept { return m_splitterPageTreeView; }
+    wxPanel* GetSplitterPageDesigner() noexcept { return m_splitterPageDesigner; }
+    wxSplitterWindow* GetSplitterMain() noexcept { return m_splitterMain; }
+    wxPanel* GetMainPanel() noexcept { return m_MainPanel; }
+    wxStatusBar* GetStatusBar() noexcept { return m_statusBar; }
+    wxMenuBar* GetMenuBar() noexcept { return m_menuBar; }
     MainFrameBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("wxCrafter"),
                   const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(-1, -1),
                   long style = wxDEFAULT_FRAME_STYLE | wxFRAME_FLOAT_ON_PARENT | wxTAB_TRAVERSAL);
@@ -218,33 +219,33 @@ protected:
     virtual void OnAuiPaneInfoChanged(wxPropertyGridEvent& event) { event.Skip(); }
 
 public:
-    wxPanel* GetPanelToolBox() { return m_panelToolBox; }
-    wxAuiToolBar* GetToolbar() { return m_toolbar; }
-    DesignerPanel* GetDp() { return m_dp; }
-    wxPanel* GetDesignerNBPage() { return m_designerNBPage; }
-    wxStyledTextCtrl* GetTextCtrlCppSource() { return m_textCtrlCppSource; }
-    wxPanel* GetCppPage() { return m_cppPage; }
-    wxStyledTextCtrl* GetTextCtrlHeaderSource() { return m_textCtrlHeaderSource; }
-    wxPanel* GetHeaderPage() { return m_headerPage; }
-    wxNotebook* GetNotebookCpp() { return m_notebookCpp; }
-    wxPanel* GetCppNBPage() { return m_cppNBPage; }
-    wxStyledTextCtrl* GetTextCtrlXrc() { return m_textCtrlXrc; }
-    wxPanel* GetXrcNBPage() { return m_xrcNBPage; }
-    OutputNBook* GetMainBook() { return m_mainBook; }
-    wxInfoBar* GetInfobarLicense() { return m_infobarLicense; }
-    wxPanel* GetPanelDesigner() { return m_panelDesigner; }
-    wxPanel* GetPanelProperties() { return m_panelProperties; }
-    wxPanel* GetPageProps() { return m_pageProps; }
-    wxPropertyGridManager* GetPgMgrStyles() { return m_pgMgrStyles; }
-    wxPanel* GetPanelStyles() { return m_panelStyles; }
-    wxPropertyGridManager* GetPgMgrSizerFlags() { return m_pgMgrSizerFlags; }
-    wxPanel* GetPanelSizerFlags() { return m_panelSizerFlags; }
-    wxPropertyGridManager* GetPgMgrAuiProperties() { return m_pgMgrAuiProperties; }
-    wxPanel* GetPanelAuiPaneInfo() { return m_panelAuiPaneInfo; }
-    wxNotebook* GetNotebook2() { return m_notebook2; }
-    wxPanel* GetPanel10() { return m_panel10; }
-    wxSplitterWindow* GetMainSplitter() { return m_mainSplitter; }
-    wxPanel* GetPanelRightSidebar() { return m_panelRightSidebar; }
+    wxPanel* GetPanelToolBox() noexcept { return m_panelToolBox; }
+    wxAuiToolBar* GetToolbar() noexcept { return m_toolbar; }
+    DesignerPanel* GetDp() noexcept { return m_dp; }
+    wxPanel* GetDesignerNBPage() noexcept { return m_designerNBPage; }
+    wxStyledTextCtrl* GetTextCtrlCppSource() noexcept { return m_textCtrlCppSource; }
+    wxPanel* GetCppPage() noexcept { return m_cppPage; }
+    wxStyledTextCtrl* GetTextCtrlHeaderSource() noexcept { return m_textCtrlHeaderSource; }
+    wxPanel* GetHeaderPage() noexcept { return m_headerPage; }
+    wxNotebook* GetNotebookCpp() noexcept { return m_notebookCpp; }
+    wxPanel* GetCppNBPage() noexcept { return m_cppNBPage; }
+    wxStyledTextCtrl* GetTextCtrlXrc() noexcept { return m_textCtrlXrc; }
+    wxPanel* GetXrcNBPage() noexcept { return m_xrcNBPage; }
+    OutputNBook* GetMainBook() noexcept { return m_mainBook; }
+    wxInfoBar* GetInfobarLicense() noexcept { return m_infobarLicense; }
+    wxPanel* GetPanelDesigner() noexcept { return m_panelDesigner; }
+    wxPanel* GetPanelProperties() noexcept { return m_panelProperties; }
+    wxPanel* GetPageProps() noexcept { return m_pageProps; }
+    wxPropertyGridManager* GetPgMgrStyles() noexcept { return m_pgMgrStyles; }
+    wxPanel* GetPanelStyles() noexcept { return m_panelStyles; }
+    wxPropertyGridManager* GetPgMgrSizerFlags() noexcept { return m_pgMgrSizerFlags; }
+    wxPanel* GetPanelSizerFlags() noexcept { return m_panelSizerFlags; }
+    wxPropertyGridManager* GetPgMgrAuiProperties() noexcept { return m_pgMgrAuiProperties; }
+    wxPanel* GetPanelAuiPaneInfo() noexcept { return m_panelAuiPaneInfo; }
+    wxNotebook* GetNotebook2() noexcept { return m_notebook2; }
+    wxPanel* GetPanel10() noexcept { return m_panel10; }
+    wxSplitterWindow* GetMainSplitter() noexcept { return m_mainSplitter; }
+    wxPanel* GetPanelRightSidebar() noexcept { return m_panelRightSidebar; }
     GUICraftMainPanelBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition,
                           const wxSize& size = wxSize(-1, -1), long style = wxTAB_TRAVERSAL);
     virtual ~GUICraftMainPanelBase();
@@ -257,7 +258,7 @@ protected:
 
 protected:
 public:
-    wxScrolledWindow* GetMainPanel() { return m_mainPanel; }
+    wxScrolledWindow* GetMainPanel() noexcept { return m_mainPanel; }
     PropertiesSheetBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition,
                         const wxSize& size = wxSize(-1, -1), long style = wxTAB_TRAVERSAL);
     virtual ~PropertiesSheetBase();
@@ -274,8 +275,8 @@ protected:
 
 protected:
 public:
-    wxStaticText* GetStaticTextMessage() { return m_staticTextMessage; }
-    wxStyledTextCtrl* GetStc() { return m_stc; }
+    wxStaticText* GetStaticTextMessage() noexcept { return m_staticTextMessage; }
+    wxStyledTextCtrl* GetStc() noexcept { return m_stc; }
     EnterStringsDlgBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("Enter Text"),
                         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(-1, -1),
                         long style = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
@@ -291,9 +292,9 @@ protected:
 
 protected:
 public:
-    wxPanel* GetPanel11() { return m_panel11; }
-    wxButton* GetButton6() { return m_button6; }
-    wxButton* GetButton7() { return m_button7; }
+    wxPanel* GetPanel11() noexcept { return m_panel11; }
+    wxButton* GetButton6() noexcept { return m_button6; }
+    wxButton* GetButton7() noexcept { return m_button7; }
     ColorPaletteDlgBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("Select Color"),
                         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(-1, -1),
                         long style = wxDEFAULT_DIALOG_STYLE);
@@ -316,11 +317,11 @@ protected:
     virtual void OnPaintPreviewColor(wxPaintEvent& event) { event.Skip(); }
 
 public:
-    wxChoice* GetChoiceStandardColors() { return m_choiceStandardColors; }
-    wxButton* GetButton5() { return m_button5; }
-    wxPanel* GetPanelColorPreview() { return m_panelColorPreview; }
-    wxButton* GetButton8() { return m_button8; }
-    wxButton* GetButton11() { return m_button11; }
+    wxChoice* GetChoiceStandardColors() noexcept { return m_choiceStandardColors; }
+    wxButton* GetButton5() noexcept { return m_button5; }
+    wxPanel* GetPanelColorPreview() noexcept { return m_panelColorPreview; }
+    wxButton* GetButton8() noexcept { return m_button8; }
+    wxButton* GetButton11() noexcept { return m_button11; }
     ColourPickerDlgbase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("Select Colour..."),
                         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(-1, -1),
                         long style = wxDEFAULT_DIALOG_STYLE);
@@ -345,12 +346,12 @@ protected:
     virtual void OnOk(wxCommandEvent& event) { event.Skip(); }
 
 public:
-    wxCheckBox* GetCheckBoxUseTRay() { return m_checkBoxUseTRay; }
-    wxCheckBox* GetCheckBoxFormatInheritedFiles() { return m_checkBoxFormatInheritedFiles; }
-    wxStaticText* GetStaticText215() { return m_staticText215; }
-    wxCheckBox* GetCheckBoxKeepAllUsersetNames() { return m_checkBoxKeepAllUsersetNames; }
-    wxCheckBox* GetCheckBoxKeepAllPossibleNames() { return m_checkBoxKeepAllPossibleNames; }
-    wxCheckBox* GetCheckBoxCopyEventhandlerToo() { return m_checkBoxCopyEventhandlerToo; }
+    wxCheckBox* GetCheckBoxUseTRay() noexcept { return m_checkBoxUseTRay; }
+    wxCheckBox* GetCheckBoxFormatInheritedFiles() noexcept { return m_checkBoxFormatInheritedFiles; }
+    wxStaticText* GetStaticText215() noexcept { return m_staticText215; }
+    wxCheckBox* GetCheckBoxKeepAllUsersetNames() noexcept { return m_checkBoxKeepAllUsersetNames; }
+    wxCheckBox* GetCheckBoxKeepAllPossibleNames() noexcept { return m_checkBoxKeepAllPossibleNames; }
+    wxCheckBox* GetCheckBoxCopyEventhandlerToo() noexcept { return m_checkBoxCopyEventhandlerToo; }
     wxcSettingsDlgBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("wxCrafter Settings"),
                        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(-1, -1),
                        long style = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
@@ -408,9 +409,9 @@ protected:
     virtual void OnTrial(wxCommandEvent& event) { event.Skip(); }
 
 public:
-    wxStaticText* GetStaticText270() { return m_staticText270; }
-    wxCommandLinkButton* GetCmdLnkBtnPurchase() { return m_cmdLnkBtnPurchase; }
-    wxCommandLinkButton* GetCmdLnkBtnCancel() { return m_cmdLnkBtnCancel; }
+    wxStaticText* GetStaticText270() noexcept { return m_staticText270; }
+    wxCommandLinkButton* GetCmdLnkBtnPurchase() noexcept { return m_cmdLnkBtnPurchase; }
+    wxCommandLinkButton* GetCmdLnkBtnCancel() noexcept { return m_cmdLnkBtnCancel; }
     FreeTrialVersionDlgBase(wxWindow* parent, wxWindowID id = wxID_ANY,
                             const wxString& title = _("This is an unregistered copy of wxCrafter"),
                             const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(-1, -1),

--- a/wxcrafter/gui.wxcp
+++ b/wxcrafter/gui.wxcp
@@ -1171,7 +1171,7 @@
 										}, {
 											"type":	"string",
 											"m_label":	"Label:",
-											"m_value":	"Back to codelite"
+											"m_value":	"Back to CodeLite"
 										}, {
 											"type":	"string",
 											"m_label":	"Shortcut:",
@@ -1200,6 +1200,13 @@
 											"m_eventHandler":	"wxUpdateUIEventHandler",
 											"m_functionNameAndSignature":	"OnSwitchToCodeliteUI(wxUpdateUIEvent& event)",
 											"m_description":	"Process a wxEVT_UPDATE_UI event",
+											"m_noBody":	false
+										}, {
+											"m_eventName":	"wxEVT_COMMAND_MENU_SELECTED",
+											"m_eventClass":	"wxCommandEvent",
+											"m_eventHandler":	"wxCommandEventHandler",
+											"m_functionNameAndSignature":	"OnSwitchToCodelite(wxCommandEvent& event)",
+											"m_description":	"Menu item has been clicked",
 											"m_noBody":	false
 										}],
 									"m_children":	[]

--- a/wxcrafter/gui.wxcp
+++ b/wxcrafter/gui.wxcp
@@ -11,6 +11,7 @@
 		"m_useEnum":	true,
 		"m_useUnderscoreMacro":	true,
 		"m_addHandlers":	true,
+		"m_keepSizers":	false,
 		"m_templateClasses":	[]
 	},
 	"windows":	[{
@@ -7382,81 +7383,6 @@
 										}],
 									"m_events":	[],
 									"m_children":	[{
-											"m_type":	4415,
-											"proportion":	0,
-											"border":	5,
-											"gbSpan":	"1,1",
-											"gbPosition":	"0,0",
-											"m_styles":	[],
-											"m_sizerFlags":	["wxALL", "wxLEFT", "wxRIGHT", "wxTOP", "wxBOTTOM"],
-											"m_properties":	[{
-													"type":	"winid",
-													"m_label":	"ID:",
-													"m_winid":	"wxID_ANY"
-												}, {
-													"type":	"string",
-													"m_label":	"Size:",
-													"m_value":	"-1,-1"
-												}, {
-													"type":	"string",
-													"m_label":	"Minimum Size:",
-													"m_value":	"-1,-1"
-												}, {
-													"type":	"string",
-													"m_label":	"Name:",
-													"m_value":	"m_checkBoxSizersAsMembers"
-												}, {
-													"type":	"multi-string",
-													"m_label":	"Tooltip:",
-													"m_value":	""
-												}, {
-													"type":	"colour",
-													"m_label":	"Bg Colour:",
-													"colour":	"<Default>"
-												}, {
-													"type":	"colour",
-													"m_label":	"Fg Colour:",
-													"colour":	"<Default>"
-												}, {
-													"type":	"font",
-													"m_label":	"Font:",
-													"m_value":	""
-												}, {
-													"type":	"bool",
-													"m_label":	"Hidden",
-													"m_value":	false
-												}, {
-													"type":	"bool",
-													"m_label":	"Disabled",
-													"m_value":	false
-												}, {
-													"type":	"bool",
-													"m_label":	"Focused",
-													"m_value":	false
-												}, {
-													"type":	"string",
-													"m_label":	"Class Name:",
-													"m_value":	""
-												}, {
-													"type":	"string",
-													"m_label":	"Include File:",
-													"m_value":	""
-												}, {
-													"type":	"string",
-													"m_label":	"Style:",
-													"m_value":	""
-												}, {
-													"type":	"string",
-													"m_label":	"Label:",
-													"m_value":	"Keep wxSizers as class members"
-												}, {
-													"type":	"bool",
-													"m_label":	"Value:",
-													"m_value":	false
-												}],
-											"m_events":	[],
-											"m_children":	[]
-										}, {
 											"m_type":	4415,
 											"proportion":	0,
 											"border":	5,

--- a/wxcrafter/main.h
+++ b/wxcrafter/main.h
@@ -6,6 +6,7 @@
 #include "wxcEvent.h"
 #include "wxcTreeView.h"
 #include "wxguicraft_main_view.h"
+
 #include <wx/cmdline.h>
 #include <wx/fdrepdlg.h>
 #include <wx/stc/stc.h>
@@ -45,7 +46,6 @@ protected:
     virtual void OnSettings(wxCommandEvent& event);
     virtual void OnProjectClosed(wxCommandEvent& event);
     virtual void OnHide(wxCommandEvent& event);
-    virtual void OnRestoreFrame(wxCommandEvent& event);
     virtual void OnAbout(wxCommandEvent& event);
     virtual void OnImportFB(wxCommandEvent& event);
     virtual void OnImportSmith(wxCommandEvent& event);
@@ -107,6 +107,9 @@ public:
     wxWindow* GetDesignerParent() { return m_splitterPageDesigner; }
 
     void DisplayDesigner();
+    void MinimizeDesigner();
+    void HideDesigner();
+
     void SetStatusMessage(const wxString& message);
 
 protected:

--- a/wxcrafter/properties_list_view.cpp
+++ b/wxcrafter/properties_list_view.cpp
@@ -65,11 +65,15 @@ void PropertiesListView::ConstructProjectSettings()
           "the XRCID macro\nWhen left unchecked it is up to the user to provide a header file with the wxWindow IDs"));
     AddIntegerProp(_("First Window ID"), wxcProjectMetadata::Get().GetFirstWindowId(),
                    _("When 'Generate Window ID' is checked, use this as the first enumerator value"));
+
+    m_pg->Append(new wxPropertyCategory(_("Code Generation")));
     AddBoolProp(_("Generate Translatable Strings"), wxcProjectMetadata::Get().IsUseUnderscoreMacro(),
                 _("When enabled, all generated strings are wrapped with the \"_\" macro, otherwise allow users to "
                   "directly enter native text string encapsulated by wxT() macro"));
     AddBoolProp(_("Add wxWidgets Handlers if missing"), wxcProjectMetadata::Get().IsAddHandlers(),
                 _("When enabled, wxCrafter will add missing handlers (e.g. wxBitmapXmlHandler)"));
+    AddBoolProp(_("Keep wxSizers as class members"), wxcProjectMetadata::Get().IsKeepSizers(),
+                _("When enabled, wxSizers are kept as class members and become accessible"));
 }
 
 void PropertiesListView::Construct(wxcWidget* wb)
@@ -299,6 +303,11 @@ void PropertiesListView::OnCellChanged(wxPropertyGridEvent& e)
         p = m_pg->GetProperty(_("Add wxWidgets Handlers if missing"));
         if(p) {
             wxcProjectMetadata::Get().SetAddHandlers(p->GetValue().GetBool());
+        }
+
+        p = m_pg->GetProperty(_("Keep wxSizers as class members"));
+        if(p) {
+            wxcProjectMetadata::Get().SetKeepSizers(p->GetValue().GetBool());
         }
 
         wxCommandEvent evt(wxEVT_PROJECT_METADATA_MODIFIED);

--- a/wxcrafter/static_box_sizer_wrapper.cpp
+++ b/wxcrafter/static_box_sizer_wrapper.cpp
@@ -1,7 +1,9 @@
 #include "static_box_sizer_wrapper.h"
+
 #include "allocator_mgr.h"
 #include "choice_property.h"
 #include "string_property.h"
+#include "wxc_project_metadata.h"
 #include "wxgui_helpers.h"
 #include "xmlutils.h"
 
@@ -18,7 +20,10 @@ StaticBoxSizerWrapper::StaticBoxSizerWrapper()
     AddProperty(new ChoiceProperty(PROP_ORIENTATION, arr, 0, _("Sizer orientation")));
     AddProperty(new StringProperty(PROP_LABEL, _("My Label"), _("Label")));
 
-    m_namePattern = wxT("staticBoxSizer");
+    m_namePattern = "staticBoxSizer";
+    if(wxcProjectMetadata::Get().IsKeepSizers()) {
+        m_namePattern.Prepend("m_");
+    }
     SetName(GenerateName());
 }
 
@@ -35,7 +40,8 @@ wxString StaticBoxSizerWrapper::CppCtorCode() const
     wxString staticBox;
     staticBox << wxT(" new wxStaticBox(") << GetWindowParent() << wxT(", wxID_ANY, ") << Label() << wxT(")");
 
-    if(!wxcSettings::Get().HasFlag(wxcSettings::SIZERS_AS_MEMBERS)) code << "wxStaticBoxSizer* ";
+    if(!wxcProjectMetadata::Get().IsKeepSizers())
+        code << "wxStaticBoxSizer* ";
 
     code << GetName() << wxT(" = new wxStaticBoxSizer(") << staticBox << wxT(", ") << orient << wxT(");\n");
     code << GenerateMinSizeCode();

--- a/wxcrafter/wxcSettingsDlg.cpp
+++ b/wxcrafter/wxcSettingsDlg.cpp
@@ -8,7 +8,6 @@ wxcSettingsDlg::wxcSettingsDlg(wxWindow* parent)
 
 {
     m_useTabModeStart = m_useTabModeEnd = wxcSettings::Get().HasFlag(wxcSettings::USE_TABBED_MODE);
-    m_checkBoxSizersAsMembers->SetValue(wxcSettings::Get().HasFlag(wxcSettings::SIZERS_AS_MEMBERS));
     m_checkBoxFormatInheritedFiles->SetValue(wxcSettings::Get().HasFlag(wxcSettings::FORMAT_INHERITED_FILES));
     m_checkBoxKeepAllPossibleNames->SetValue(wxcSettings::Get().HasFlag(wxcSettings::DUPLICATE_KEEPS_ALL_NAMES));
     m_checkBoxKeepAllUsersetNames->SetValue(wxcSettings::Get().HasFlag(wxcSettings::DUPLICATE_KEEPS_USERSET_NAMES));
@@ -20,7 +19,6 @@ wxcSettingsDlg::~wxcSettingsDlg() {}
 
 void wxcSettingsDlg::OnOk(wxCommandEvent& event)
 {
-    wxcSettings::Get().EnableFlag(wxcSettings::SIZERS_AS_MEMBERS, m_checkBoxSizersAsMembers->IsChecked());
     wxcSettings::Get().EnableFlag(wxcSettings::FORMAT_INHERITED_FILES, m_checkBoxFormatInheritedFiles->IsChecked());
     wxcSettings::Get().EnableFlag(wxcSettings::DUPLICATE_KEEPS_ALL_NAMES, m_checkBoxKeepAllPossibleNames->IsChecked());
     wxcSettings::Get().EnableFlag(wxcSettings::DUPLICATE_KEEPS_USERSET_NAMES,

--- a/wxcrafter/wxcTreeView.cpp
+++ b/wxcrafter/wxcTreeView.cpp
@@ -1,15 +1,17 @@
+#include "wxcTreeView.h"
+
 #include "EventsEditorDlg.h"
 #include "allocator_mgr.h"
 #include "drawingutils.h"
-#include "wxcTreeView.h"
+#include "event_notifier.h"
+#include "globals.h"
+#include "plugin.h"
+#include "workspace.h"
 #include "wxcrafter.h"
 #include "wxgui_bitmaploader.h"
 #include "wxgui_defs.h"
 #include "wxguicraft_main_view.h"
-#include <event_notifier.h>
-#include <globals.h>
-#include <plugin.h>
-#include <workspace.h>
+
 #include <wx/aui/auibar.h>
 
 const wxEventType wxEVT_SHOW_WXCRAFTER_DESIGNER = wxNewEventType();
@@ -236,11 +238,12 @@ void wxcTreeView::OnSashPositionChanged(wxSplitterEvent& event)
 
 void wxcTreeView::OnChar(wxKeyEvent& event)
 {
-    event.Skip();
     if(event.GetKeyCode() == WXK_DELETE) {
         // Fake the corresponding menu event and throw it at the tree, which is Connect()ed to GUICraftMainPanel
         wxCommandEvent e(wxEVT_COMMAND_MENU_SELECTED, ID_DELETE_NODE);
         wxPostEvent(m_treeControls, e);
+    } else {
+        event.Skip();
     }
 }
 

--- a/wxcrafter/wxc_project_metadata.cpp
+++ b/wxcrafter/wxc_project_metadata.cpp
@@ -15,6 +15,7 @@ wxcProjectMetadata::wxcProjectMetadata()
     , m_useEnum(true)
     , m_useUnderscoreMacro(true)
     , m_addHandlers(true)
+    , m_keepSizers(false)
 {
     SetGenerateCPPCode(true);
     SetGenerateXRC(false);
@@ -35,6 +36,7 @@ void wxcProjectMetadata::FromJSON(const JSONElement& json)
     m_useEnum = json.namedObject("m_useEnum").toBool(true);
     m_useUnderscoreMacro = json.namedObject("m_useUnderscoreMacro").toBool(true);
     m_addHandlers = json.namedObject("m_addHandlers").toBool(m_addHandlers);
+    m_keepSizers = json.namedObject("m_keepSizers").toBool(false);
 
     wxcSettings::Get().MergeCustomControl(json.namedObject("m_templateClasses"));
     if(m_bitmapFunction.IsEmpty()) {
@@ -66,6 +68,7 @@ JSONElement wxcProjectMetadata::ToJSON()
     metadata.addProperty("m_useEnum", m_useEnum);
     metadata.addProperty("m_useUnderscoreMacro", m_useUnderscoreMacro);
     metadata.addProperty("m_addHandlers", m_addHandlers);
+    metadata.addProperty("m_keepSizers", m_keepSizers);
     return metadata;
 }
 
@@ -157,6 +160,7 @@ void wxcProjectMetadata::Reset()
     m_useUnderscoreMacro = true;
     m_firstWindowId = 10000;
     m_addHandlers = true;
+    m_keepSizers = false;
 }
 
 void wxcProjectMetadata::DoGenerateBitmapFunctionName()
@@ -232,10 +236,7 @@ wxString wxcProjectMetadata::GetOutputFileName() const
     return m_outputFileName;
 }
 
-wxString wxcProjectMetadata::GetHeaderFileExt() const
-{
-    return m_useHpp ? "hpp" : "h";
-}
+wxString wxcProjectMetadata::GetHeaderFileExt() const { return m_useHpp ? "hpp" : "h"; }
 
 void wxcProjectMetadata::SetProjectFile(const wxString& filename)
 {

--- a/wxcrafter/wxc_project_metadata.h
+++ b/wxcrafter/wxc_project_metadata.h
@@ -35,6 +35,7 @@ protected:
     bool m_useEnum;
     bool m_useUnderscoreMacro;
     bool m_addHandlers;
+    bool m_keepSizers;
 
 private:
     wxcProjectMetadata();
@@ -106,6 +107,8 @@ public:
 
     void SetUseUnderscoreMacro(bool useUnderscoreMacro) { this->m_useUnderscoreMacro = useUnderscoreMacro; }
     bool IsUseUnderscoreMacro() const { return m_useUnderscoreMacro; }
+    void SetKeepSizers(bool keepSizers) { this->m_keepSizers = keepSizers; }
+    bool IsKeepSizers() const { return m_keepSizers; }
 
     void GenerateBitmapFunctionName() { DoGenerateBitmapFunctionName(); }
 

--- a/wxcrafter/wxc_settings.h
+++ b/wxcrafter/wxc_settings.h
@@ -50,7 +50,6 @@ public:
     enum {
         DLG_CODE_GENERATED = (1 << 0),
         USE_TABBED_MODE = (1 << 1),
-        SIZERS_AS_MEMBERS = (1 << 2),
         LAYOUT_RESET_DONE = (1 << 3),
         LICENSE_ACTIVATED = (1 << 4),
         DONT_PROMPT_ABOUT_MISSING_SUBCLASS = (1 << 5),

--- a/wxcrafter/wxc_widget.cpp
+++ b/wxcrafter/wxc_widget.cpp
@@ -2711,7 +2711,8 @@ void wxcWidget::DoGenerateGetters(wxString& decl) const
                 firstChar.MakeUpper();
                 memberName.replace(0, 1, firstChar);
 
-                code << "    " << GetRealClassName() << "* Get" << memberName << "() { return " << GetName() << "; }\n";
+                code << "    " << GetRealClassName() << "* Get" << memberName << "() noexcept { return " << GetName()
+                     << "; }\n";
                 decl << code;
             }
         } break;

--- a/wxcrafter/wxc_widget.cpp
+++ b/wxcrafter/wxc_widget.cpp
@@ -18,6 +18,7 @@
 #include "winid_property.h"
 #include "wx_collapsible_pane_pane_wrapper.h"
 #include "wxc_bitmap_code_generator.h"
+#include "wxc_project_metadata.h"
 #include "wxc_settings.h"
 #include "wxgui_defs.h"
 #include "wxgui_helpers.h"
@@ -2654,11 +2655,7 @@ wxString wxcWidget::BaseDoGenerateClassMember() const
     wxString classname = GetRealClassName();
     if(!IsTopWindow() && !classname.IsEmpty()) {
 
-        bool sizersAsMembers = wxcSettings::Get().HasFlag(wxcSettings::SIZERS_AS_MEMBERS);
-        if(IsSizer() && sizersAsMembers) {
-            memberCode << wxT("    ") << classname << wxT("* ") << GetName() << wxT(";");
-
-        } else if(!IsSizer()) {
+        if(!IsSizer() || wxcProjectMetadata::Get().IsKeepSizers()) {
 
             memberCode << wxT("    ") << classname << wxT("* ") << GetName() << wxT(";");
             WrapInIfBlockIfNeeded(memberCode);


### PR DESCRIPTION
* Make `Keep wxSizers as class members` as a project-specific option.
This option directly affects the project which relies on them, so it is more logical to make it project-specific.

* Generate all getters as `noexcept` method.

* Window close button (the X button) now hides wxCrafter rather than minimizing it.
I personally find it is more intuitive (`File` -> `Close` menu already does like this).

* Fix `File` -> `Back to CodeLite` menu (not a toolbar button) does not take any actions.

* wxGTK port: Fix awkward window restoration (occurs after 'show -> hide -> show' action).
This [video](https://user-images.githubusercontent.com/32811754/148957054-a65a0055-698d-47bb-87e5-707d07fa7cc0.mp4) describes this issue (the one running on VM is an unpatched version, whereas the one from Cinnamon is patched).
As you see, it needs so many clicks to bring the wxCrafter window to the front. I'm not sure why GTK behaves like that, but calling [wxWindow::SetCanFocus()](https://docs.wxwidgets.org/trunk/classwx_window.html#a2b8b2e99231a0ec1a05f5066f1b7f3d8) and [wxWindow::SetFocus()](https://docs.wxwidgets.org/trunk/classwx_window.html#a697f9f8d3ff389790f1c74b59bcb1d75) works for now.

* wxGTK port: Prevent `Delete` key from rapidly deleting multiple tree nodes with just one short-stroke.
This [video](https://user-images.githubusercontent.com/32811754/148957050-112d378f-473d-4299-ad5e-4c74b27246e9.mp4) describes this issue (the left-side unpatched vs. the right-side patched).