### PR TITLE
Revert "wxCrafter: Generate all getters as `noexcept` method"

### DIFF
--- a/Runtime/templates/projects/executable-wxcrafter-dialog/wxcrafter.hpp
+++ b/Runtime/templates/projects/executable-wxcrafter-dialog/wxcrafter.hpp
@@ -44,9 +44,9 @@ protected:
 
 protected:
 public:
-    wxStaticLine* GetStaticLine15() noexcept { return m_staticLine15; }
-    wxButton* GetButtonOK() noexcept { return m_buttonOK; }
-    wxButton* GetButtonCancel() noexcept { return m_buttonCancel; }
+    wxStaticLine* GetStaticLine15() { return m_staticLine15; }
+    wxButton* GetButtonOK() { return m_buttonOK; }
+    wxButton* GetButtonCancel() { return m_buttonCancel; }
     MainDialogBaseClass(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("My Dialog"),
                         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(500, 300),
                         long style = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);

--- a/Runtime/templates/projects/executable-wxcrafter-frame/wxcrafter.hpp
+++ b/Runtime/templates/projects/executable-wxcrafter-frame/wxcrafter.hpp
@@ -52,9 +52,9 @@ protected:
     virtual void OnAbout(wxCommandEvent& event) { event.Skip(); }
 
 public:
-    wxPanel* GetMainPanel() noexcept { return m_mainPanel; }
-    wxMenuBar* GetMainMenuBar() noexcept { return m_mainMenuBar; }
-    wxToolBar* GetMainToolbar() noexcept { return m_mainToolbar; }
+    wxPanel* GetMainPanel() { return m_mainPanel; }
+    wxMenuBar* GetMainMenuBar() { return m_mainMenuBar; }
+    wxToolBar* GetMainToolbar() { return m_mainToolbar; }
     MainFrameBaseClass(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("My Frame"),
                        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(500, 300),
                        long style = wxCAPTION | wxRESIZE_BORDER | wxMAXIMIZE_BOX | wxMINIMIZE_BOX | wxSYSTEM_MENU |

--- a/wxcrafter/wxc_widget.cpp
+++ b/wxcrafter/wxc_widget.cpp
@@ -2735,8 +2735,7 @@ void wxcWidget::DoGenerateGetters(wxString& decl) const
                 firstChar.MakeUpper();
                 memberName.replace(0, 1, firstChar);
 
-                code << "    " << GetRealClassName() << "* Get" << memberName << "() noexcept { return " << GetName()
-                     << "; }\n";
+                code << "    " << GetRealClassName() << "* Get" << memberName << "() { return " << GetName() << "; }\n";
                 decl << code;
             }
         } break;

--- a/wxcrafter/wxc_widget.cpp
+++ b/wxcrafter/wxc_widget.cpp
@@ -2696,7 +2696,7 @@ bool wxcWidget::IsParentAuiToolbar() const
 
 void wxcWidget::DoGenerateGetters(wxString& decl) const
 {
-    if(wxcSettings::Get().IsLicensed2()) {
+    if(KeepAsClassMember()) {
         switch(GetWidgetType()) {
         case TYPE_CONTROL:
         case TYPE_LIST_CTRL:


### PR DESCRIPTION
1. The introduction of `noexcept` keyword was a bit early, so revert 1966fbe.
fixes #2925.

2. Check `wxcWidget::KeepAsClassMember()` when generating getters.
This fix does nothing at the moment, but is also harmless and prevents an error from future wxCrafter changes.