### PR TITLE
Several bug fixes 5

### DIFF
--- a/CodeLite/CxxCodeCompletion.hpp
+++ b/CodeLite/CxxCodeCompletion.hpp
@@ -37,7 +37,7 @@ struct LookupTable {
     unordered_map<wxString, TagEntryPtr> tests_db; // test database, for unit testings
     explicit LookupTable(ITagsStoragePtr real_db, const unordered_map<wxString, TagEntryPtr>& unit_tests_db)
     {
-        pdb = pdb;
+        pdb = real_db;
         tests_db = unit_tests_db;
     }
     explicit LookupTable(ITagsStoragePtr real_db) { pdb = real_db; }

--- a/CodeLite/tags_options_data.cpp
+++ b/CodeLite/tags_options_data.cpp
@@ -47,11 +47,11 @@ static bool _IsValidCppIndetifier(const wxString& id)
     }
     // first char can be only _A-Za-z
     wxString first(id.Mid(0, 1));
-    if(first.find_first_not_of(wxT("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")) != wxString::npos) {
+    if(first.find_first_not_of("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") != wxString::npos) {
         return false;
     }
     // make sure that rest of the id contains only a-zA-Z0-9_
-    if(id.find_first_not_of(wxT("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")) != wxString::npos) {
+    if(id.find_first_not_of("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") != wxString::npos) {
         return false;
     }
     return true;
@@ -70,28 +70,28 @@ static bool _IsCppKeyword(const wxString& word)
 
 TagsOptionsData::TagsOptionsData()
     : clConfigItem("code-completion")
-    , m_ccFlags(CC_DISP_FUNC_CALLTIP | CC_CPP_KEYWORD_ASISST | CC_COLOUR_VARS | CC_ACCURATE_SCOPE_RESOLVING |
-                CC_DEEP_SCAN_USING_NAMESPACE_RESOLVING | CC_WORD_ASSIST)
+    , m_ccFlags(CC_DISP_TYPE_INFO | CC_DISP_FUNC_CALLTIP | CC_CPP_KEYWORD_ASISST | CC_COLOUR_VARS |
+                CC_ACCURATE_SCOPE_RESOLVING | CC_DEEP_SCAN_USING_NAMESPACE_RESOLVING | CC_WORD_ASSIST)
     , m_ccColourFlags(CC_COLOUR_DEFAULT)
-    , m_fileSpec(wxT("*.cpp;*.cc;*.cxx;*.h;*.hpp;*.c;*.c++;*.tcc;*.hxx;*.h++"))
+    , m_fileSpec("*.cpp;*.cc;*.cxx;*.h;*.hpp;*.c;*.c++;*.tcc;*.hxx;*.h++")
     , m_minWordLen(3)
     , m_parserEnabled(true)
     , m_maxItemToColour(1000)
 #ifdef __WXMSW__
-    , m_macrosFiles(wxT("_mingw.h bits/c++config.h"))
+    , m_macrosFiles("_mingw.h bits/c++config.h")
 #elif defined(__WXMAC__)
-    , m_macrosFiles(wxT("sys/cdefs.h bits/c++config.h AvailabilityMacros.h"))
+    , m_macrosFiles("sys/cdefs.h bits/c++config.h AvailabilityMacros.h")
 #else
-    , m_macrosFiles(wxT("sys/cdefs.h bits/c++config.h"))
+    , m_macrosFiles("sys/cdefs.h bits/c++config.h")
 #endif
     , m_clangOptions(0)
-    , m_clangBinary(wxT(""))
+    , m_clangBinary("")
     , m_clangCachePolicy(TagsOptionsData::CLANG_CACHE_ON_FILE_LOAD)
     , m_ccNumberOfDisplayItems(250)
     , m_version(0)
 {
     // Initialize defaults
-    m_languages.Add(wxT("C++"));
+    m_languages.Add("C++");
     AddDefaultTokens();
     AddDefaultTypes();
 
@@ -102,339 +102,339 @@ TagsOptionsData::~TagsOptionsData() {}
 
 void TagsOptionsData::AddDefaultTokens()
 {
-    m_tokens.Add(wxT("ATTRIBUTE_PRINTF_1"));
-    m_tokens.Add(wxT("ATTRIBUTE_PRINTF_2"));
-    m_tokens.Add(wxT("BEGIN_DECLARE_EVENT_TYPES()=enum {"));
-    m_tokens.Add(wxT("BOOST_FOREACH(%0, %1)=%0;"));
-    m_tokens.Add(wxT("DECLARE_EVENT_TYPE"));
-    m_tokens.Add(wxT("DECLARE_EVENT_TYPE(%0,%1)=int %0;"));
-    m_tokens.Add(wxT("DECLARE_EXPORTED_EVENT_TYPE"));
-    m_tokens.Add(wxT("DECLARE_INSTANCE_TYPE"));
-    m_tokens.Add(wxT("DLLIMPORT"));
-    m_tokens.Add(wxT("END_DECLARE_EVENT_TYPES()=};"));
-    m_tokens.Add(wxT("EXPORT"));
-    m_tokens.Add(wxT("LLDB_API"));
-    m_tokens.Add(wxT("PYTHON_API"));
-    m_tokens.Add(wxT("QT_BEGIN_HEADER"));
-    m_tokens.Add(wxT("QT_BEGIN_NAMESPACE"));
-    m_tokens.Add(wxT("QT_END_HEADER"));
-    m_tokens.Add(wxT("QT_END_NAMESPACE"));
-    m_tokens.Add(wxT("Q_GADGET"));
-    m_tokens.Add(wxT("Q_INLINE_TEMPLATE"));
-    m_tokens.Add(wxT("Q_OBJECT"));
-    m_tokens.Add(wxT("Q_OUTOFLINE_TEMPLATE"));
-    m_tokens.Add(wxT("Q_PACKED"));
-    m_tokens.Add(wxT("Q_REQUIRED_RESULT"));
-    m_tokens.Add(wxT("SCI_SCOPE(%0)=%0"));
-    m_tokens.Add(wxT("UNALIGNED"));
-    m_tokens.Add(wxT("WINAPI"));
-    m_tokens.Add(wxT("WINBASEAPI"));
-    m_tokens.Add(wxT("WXDLLEXPORT"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_ADV"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_AUI"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_BASE"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_CL"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_CORE"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_FWD_ADV"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_FWD_AUI"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_FWD_BASE"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_FWD_CORE"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_FWD_PROPGRID"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_FWD_XML"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_LE_SDK"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_SCI"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_SQLITE3"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_XML"));
-    m_tokens.Add(wxT("WXDLLIMPEXP_XRC"));
-    m_tokens.Add(wxT("WXDLLIMPORT"));
-    m_tokens.Add(wxT("WXMAKINGDLL"));
-    m_tokens.Add(wxT("WXUNUSED(%0)=%0"));
-    m_tokens.Add(wxT("WXUSINGDLL"));
-    m_tokens.Add(wxT("_ALIGNAS(%0)=alignas(%0)"));
-    m_tokens.Add(wxT("_ALIGNAS_TYPE(%0)=alignas(%0)"));
-    m_tokens.Add(wxT("_ANONYMOUS_STRUCT"));
-    m_tokens.Add(wxT("_ANONYMOUS_UNION"));
-    m_tokens.Add(wxT("_ATTRIBUTE(%0)"));
-    m_tokens.Add(wxT("_CRTIMP"));
-    m_tokens.Add(wxT("_CRTIMP2"));
-    m_tokens.Add(wxT("_CRTIMP2_PURE"));
-    m_tokens.Add(wxT("_CRTIMP_ALTERNATIVE"));
-    m_tokens.Add(wxT("_CRTIMP_NOIA64"));
-    m_tokens.Add(wxT("_CRTIMP_PURE"));
-    m_tokens.Add(wxT("_CRT_ALIGN(%0)"));
-    m_tokens.Add(wxT("_CRT_DEPRECATE_TEXT(%0)"));
-    m_tokens.Add(wxT("_CRT_INSECURE_DEPRECATE_GLOBALS(%0)"));
-    m_tokens.Add(wxT("_CRT_INSECURE_DEPRECATE_MEMORY(%0)"));
-    m_tokens.Add(wxT("_CRT_OBSOLETE(%0)"));
-    m_tokens.Add(wxT("_CRT_STRINGIZE(%0)=\"%0\""));
-    m_tokens.Add(wxT("_CRT_UNUSED(%0)=%0"));
-    m_tokens.Add(wxT("_CRT_WIDE(%0)=L\"%0\""));
-    m_tokens.Add(wxT("_GLIBCXX14_CONSTEXPR"));
-    m_tokens.Add(wxT("_GLIBCXX17_CONSTEXPR"));
-    m_tokens.Add(wxT("_GLIBCXX17_DEPRECATED"));
-    m_tokens.Add(wxT("_GLIBCXX17_INLINE"));
-    m_tokens.Add(wxT("_GLIBCXX20_CONSTEXPR"));
-    m_tokens.Add(wxT("_GLIBCXX20_DEPRECATED(%0)"));
-    m_tokens.Add(wxT("_GLIBCXX_BEGIN_EXTERN_C=extern \"C\" {"));
-    m_tokens.Add(wxT("_GLIBCXX_BEGIN_NAMESPACE(%0)=namespace %0{"));
-    m_tokens.Add(wxT("_GLIBCXX_BEGIN_NAMESPACE_ALGO"));
-    m_tokens.Add(wxT("_GLIBCXX_BEGIN_NAMESPACE_CONTAINER"));
-    m_tokens.Add(wxT("_GLIBCXX_BEGIN_NAMESPACE_CXX11"));
-    m_tokens.Add(wxT("_GLIBCXX_BEGIN_NAMESPACE_LDBL"));
-    m_tokens.Add(wxT("_GLIBCXX_BEGIN_NAMESPACE_LDBL_OR_CXX11"));
-    m_tokens.Add(wxT("_GLIBCXX_BEGIN_NAMESPACE_TR1=namespace tr1{"));
-    m_tokens.Add(wxT("_GLIBCXX_BEGIN_NAMESPACE_VERSION"));
-    m_tokens.Add(wxT("_GLIBCXX_BEGIN_NESTED_NAMESPACE(%0, %1)=namespace %0{"));
-    m_tokens.Add(wxT("_GLIBCXX_CONST"));
-    m_tokens.Add(wxT("_GLIBCXX_CONSTEXPR"));
-    m_tokens.Add(wxT("_GLIBCXX_DEPRECATED"));
-    m_tokens.Add(wxT("_GLIBCXX_DEPRECATED_SUGGEST(%0)"));
-    m_tokens.Add(wxT("_GLIBCXX_END_EXTERN_C=}"));
-    m_tokens.Add(wxT("_GLIBCXX_END_NAMESPACE=}"));
-    m_tokens.Add(wxT("_GLIBCXX_END_NAMESPACE_ALGO"));
-    m_tokens.Add(wxT("_GLIBCXX_END_NAMESPACE_CONTAINER"));
-    m_tokens.Add(wxT("_GLIBCXX_END_NAMESPACE_CXX11"));
-    m_tokens.Add(wxT("_GLIBCXX_END_NAMESPACE_LDBL"));
-    m_tokens.Add(wxT("_GLIBCXX_END_NAMESPACE_LDBL_OR_CXX11"));
-    m_tokens.Add(wxT("_GLIBCXX_END_NAMESPACE_TR1=}"));
-    m_tokens.Add(wxT("_GLIBCXX_END_NAMESPACE_VERSION"));
-    m_tokens.Add(wxT("_GLIBCXX_END_NESTED_NAMESPACE=}"));
-    m_tokens.Add(wxT("_GLIBCXX_NAMESPACE_CXX11"));
-    m_tokens.Add(wxT("_GLIBCXX_NAMESPACE_LDBL"));
-    m_tokens.Add(wxT("_GLIBCXX_NAMESPACE_LDBL_OR_CXX11"));
-    m_tokens.Add(wxT("_GLIBCXX_NODISCARD"));
-    m_tokens.Add(wxT("_GLIBCXX_NOEXCEPT"));
-    m_tokens.Add(wxT("_GLIBCXX_NOEXCEPT_IF(%0)"));
-    m_tokens.Add(wxT("_GLIBCXX_NOEXCEPT_PARM"));
-    m_tokens.Add(wxT("_GLIBCXX_NOEXCEPT_QUAL"));
-    m_tokens.Add(wxT("_GLIBCXX_NORETURN"));
-    m_tokens.Add(wxT("_GLIBCXX_NOTHROW"));
-    m_tokens.Add(wxT("_GLIBCXX_PSEUDO_VISIBILITY(%0)"));
-    m_tokens.Add(wxT("_GLIBCXX_PURE"));
-    m_tokens.Add(wxT("_GLIBCXX_STD=std"));
-    m_tokens.Add(wxT("_GLIBCXX_SYNCHRONIZATION_HAPPENS_AFTER(%0)"));
-    m_tokens.Add(wxT("_GLIBCXX_SYNCHRONIZATION_HAPPENS_BEFORE(%0)"));
-    m_tokens.Add(wxT("_GLIBCXX_THROW(%0)"));
-    m_tokens.Add(wxT("_GLIBCXX_THROW_OR_ABORT(%0)"));
-    m_tokens.Add(wxT("_GLIBCXX_TXN_SAFE"));
-    m_tokens.Add(wxT("_GLIBCXX_TXN_SAFE_DYN"));
-    m_tokens.Add(wxT("_GLIBCXX_USE_CONSTEXPR"));
-    m_tokens.Add(wxT("_GLIBCXX_USE_NOEXCEPT"));
-    m_tokens.Add(wxT("_GLIBCXX_VISIBILITY(%0)"));
-    m_tokens.Add(wxT("_LIBCPP_ALWAYS_INLINE"));
-    m_tokens.Add(wxT("_LIBCPP_BEGIN_NAMESPACE_FILESYSTEM=namespace std { namespace filesystem {"));
-    m_tokens.Add(wxT("_LIBCPP_BEGIN_NAMESPACE_STD=namespace std{"));
-    m_tokens.Add(wxT("_LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS"));
-    m_tokens.Add(wxT("_LIBCPP_CONCAT(%0,%1)=%0%1"));
-    m_tokens.Add(wxT("_LIBCPP_CONCAT1(%0,%1)=%0%1"));
-    m_tokens.Add(wxT("_LIBCPP_CONSTEVAL"));
-    m_tokens.Add(wxT("_LIBCPP_CONSTEXPR"));
-    m_tokens.Add(wxT("_LIBCPP_CONSTEXPR_AFTER_CXX11"));
-    m_tokens.Add(wxT("_LIBCPP_CONSTEXPR_AFTER_CXX14"));
-    m_tokens.Add(wxT("_LIBCPP_CONSTEXPR_AFTER_CXX17"));
-    m_tokens.Add(wxT("_LIBCPP_CONSTEXPR_IF_NODEBUG"));
-    m_tokens.Add(wxT("_LIBCPP_CRT_FUNC"));
-    m_tokens.Add(wxT("_LIBCPP_DECLARE_STRONG_ENUM(%0)=enum class %0"));
-    m_tokens.Add(wxT("_LIBCPP_DECLARE_STRONG_ENUM_EPILOG(%0)"));
-    m_tokens.Add(wxT("_LIBCPP_DECLSPEC_EMPTY_BASES"));
-    m_tokens.Add(wxT("_LIBCPP_DEFAULT"));
-    m_tokens.Add(wxT("_LIBCPP_DEPRECATED"));
-    m_tokens.Add(wxT("_LIBCPP_DEPRECATED_IN_CXX11"));
-    m_tokens.Add(wxT("_LIBCPP_DEPRECATED_IN_CXX14"));
-    m_tokens.Add(wxT("_LIBCPP_DEPRECATED_IN_CXX17"));
-    m_tokens.Add(wxT("_LIBCPP_DEPRECATED_IN_CXX20"));
-    m_tokens.Add(wxT("_LIBCPP_DEPRECATED_WITH_CHAR8_T"));
-    m_tokens.Add(wxT("_LIBCPP_DIAGNOSE_ERROR(%0)"));
-    m_tokens.Add(wxT("_LIBCPP_DIAGNOSE_WARNING(%0)"));
-    m_tokens.Add(wxT("_LIBCPP_DISABLE_EXTENSION_WARNING"));
-    m_tokens.Add(wxT("_LIBCPP_DLL_VIS"));
-    m_tokens.Add(wxT("_LIBCPP_END_NAMESPACE_FILESYSTEM=} }"));
-    m_tokens.Add(wxT("_LIBCPP_END_NAMESPACE_STD=}"));
-    m_tokens.Add(wxT("_LIBCPP_EQUAL_DELETE"));
-    m_tokens.Add(wxT("_LIBCPP_EXCEPTION_ABI"));
-    m_tokens.Add(wxT("_LIBCPP_EXCLUDE_FROM_EXPLICIT_INSTANTIATION"));
-    m_tokens.Add(wxT("_LIBCPP_EXPLICIT"));
-    m_tokens.Add(wxT("_LIBCPP_EXPLICIT_AFTER_CXX11"));
-    m_tokens.Add(wxT("_LIBCPP_EXPORTED_FROM_ABI"));
-    m_tokens.Add(wxT("_LIBCPP_EXTERN_TEMPLATE(%0)"));
-    m_tokens.Add(wxT("_LIBCPP_EXTERN_TEMPLATE_DEFINE(%0)"));
-    m_tokens.Add(wxT("_LIBCPP_EXTERN_TEMPLATE_EVEN_IN_DEBUG_MODE(%0)"));
-    m_tokens.Add(wxT("_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS"));
-    m_tokens.Add(wxT("_LIBCPP_FALLTHROUGH(%0)"));
-    m_tokens.Add(wxT("_LIBCPP_FORMAT_PRINTF(%0,%1)"));
-    m_tokens.Add(wxT("_LIBCPP_FUNC_VIS"));
-    m_tokens.Add(wxT("_LIBCPP_INIT_PRIORITY_MAX"));
-    m_tokens.Add(wxT("_LIBCPP_INLINE_VAR"));
-    m_tokens.Add(wxT("_LIBCPP_INLINE_VISIBILITY"));
-    m_tokens.Add(wxT("_LIBCPP_INTERNAL_LINKAGE"));
-    m_tokens.Add(wxT("_LIBCPP_NOALIAS"));
-    m_tokens.Add(wxT("_LIBCPP_NODEBUG"));
-    m_tokens.Add(wxT("_LIBCPP_NODEBUG_TYPE"));
-    m_tokens.Add(wxT("_LIBCPP_NODISCARD_AFTER_CXX17"));
-    m_tokens.Add(wxT("_LIBCPP_NODISCARD_ATTRIBUTE"));
-    m_tokens.Add(wxT("_LIBCPP_NODISCARD_EXT"));
-    m_tokens.Add(wxT("_LIBCPP_NORETURN"));
-    m_tokens.Add(wxT("_LIBCPP_NO_DESTROY"));
-    m_tokens.Add(wxT("_LIBCPP_OVERRIDABLE_FUNC_VIS"));
-    m_tokens.Add(wxT("_LIBCPP_PREFERRED_NAME(%0)"));
-    m_tokens.Add(wxT("_LIBCPP_SAFE_STATIC"));
-    m_tokens.Add(wxT("_LIBCPP_THREAD_SAFETY_ANNOTATION(%0)"));
-    m_tokens.Add(wxT("_LIBCPP_TOSTRING(%0)=\"%0\""));
-    m_tokens.Add(wxT("_LIBCPP_TOSTRING2(%0)=\"%0\""));
-    m_tokens.Add(wxT("_LIBCPP_TYPE_VIS"));
-    m_tokens.Add(wxT("_LIBCPP_TYPE_VIS_ONLY"));
-    m_tokens.Add(wxT("_LIBCPP_UNUSED_VAR(%0)=%0"));
-    m_tokens.Add(wxT("_LIBCPP_WEAK"));
-    m_tokens.Add(wxT("_MCRTIMP"));
-    m_tokens.Add(wxT("_MRTIMP2"));
-    m_tokens.Add(wxT("_NOEXCEPT"));
-    m_tokens.Add(wxT("noexcept"));
-    m_tokens.Add(wxT("_NOEXCEPT_(%0)"));
-    m_tokens.Add(wxT("_Noreturn"));
-    m_tokens.Add(wxT("_PSTL_ASSERT(%0)"));
-    m_tokens.Add(wxT("_PSTL_ASSERT_MSG(%0,%1)"));
-    m_tokens.Add(wxT("_STD_BEGIN=namespace std{"));
-    m_tokens.Add(wxT("_STD_END=}"));
-    m_tokens.Add(wxT("_STRUCT_NAME(%0)"));
-    m_tokens.Add(wxT("_Static_assert(%0,%1)"));
-    m_tokens.Add(wxT("_T"));
-    m_tokens.Add(wxT("_UNION_NAME(%0)"));
-    m_tokens.Add(wxT("_VSTD=std"));
-    m_tokens.Add(wxT("_VSTD_FS=std::filesystem"));
-    m_tokens.Add(wxT("__BEGIN_DECLS=extern \"C\" {"));
-    m_tokens.Add(wxT("__CLRCALL_OR_CDECL"));
-    m_tokens.Add(wxT("__CONCAT(%0,%1)=%0%1"));
-    m_tokens.Add(wxT("__CRTDECL"));
-    m_tokens.Add(wxT("__CRT_INLINE"));
-    m_tokens.Add(wxT("__CRT_STRINGIZE(%0)=\"%0\""));
-    m_tokens.Add(wxT("__CRT_UUID_DECL(%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,%11)"));
-    m_tokens.Add(wxT("__CRT_WIDE(%0)=L\"%0\""));
-    m_tokens.Add(wxT("__END_DECLS=}"));
-    m_tokens.Add(wxT("__GOMP_NOTHROW"));
-    m_tokens.Add(wxT("__LEAF"));
-    m_tokens.Add(wxT("__LEAF_ATTR"));
-    m_tokens.Add(wxT("__MINGW_ATTRIB_CONST"));
-    m_tokens.Add(wxT("__MINGW_ATTRIB_DEPRECATED"));
-    m_tokens.Add(wxT("__MINGW_ATTRIB_DEPRECATED_MSG(%0)"));
-    m_tokens.Add(wxT("__MINGW_ATTRIB_MALLOC"));
-    m_tokens.Add(wxT("__MINGW_ATTRIB_NONNULL(%0)"));
-    m_tokens.Add(wxT("__MINGW_ATTRIB_NORETURN"));
-    m_tokens.Add(wxT("__MINGW_ATTRIB_NO_OPTIMIZE"));
-    m_tokens.Add(wxT("__MINGW_ATTRIB_PURE"));
-    m_tokens.Add(wxT("__MINGW_ATTRIB_UNUSED"));
-    m_tokens.Add(wxT("__MINGW_ATTRIB_USED"));
-    m_tokens.Add(wxT("__MINGW_BROKEN_INTERFACE(%0)"));
-    m_tokens.Add(wxT("__MINGW_IMPORT"));
-    m_tokens.Add(wxT("__MINGW_INTRIN_INLINE=extern"));
-    m_tokens.Add(wxT("__MINGW_NOTHROW"));
-    m_tokens.Add(wxT("__MINGW_PRAGMA_PARAM(%0)"));
-    m_tokens.Add(wxT("__N(%0)=%0"));
-    m_tokens.Add(wxT("__NTH(%0)=%0"));
-    m_tokens.Add(wxT("__NTHNL(%0)=%0"));
-    m_tokens.Add(wxT("__P(%0)=%0"));
-    m_tokens.Add(wxT("__PMT(%0)=%0"));
-    m_tokens.Add(wxT("__PSTL_ASSERT(%0)"));
-    m_tokens.Add(wxT("__PSTL_ASSERT_MSG(%0,%1)"));
-    m_tokens.Add(wxT("__STRING(%0)=\"%0\""));
-    m_tokens.Add(wxT("__THROW"));
-    m_tokens.Add(wxT("__THROWNL"));
-    m_tokens.Add(wxT("__UNUSED_PARAM(%0)=%0"));
-    m_tokens.Add(wxT("__always_inline"));
-    m_tokens.Add(wxT("__attribute__(%0)"));
-    m_tokens.Add(wxT("__attribute_alloc_size__(%0)"));
-    m_tokens.Add(wxT("__attribute_artificial__"));
-    m_tokens.Add(wxT("__attribute_const__"));
-    m_tokens.Add(wxT("__attribute_copy__(%0)"));
-    m_tokens.Add(wxT("__attribute_deprecated__"));
-    m_tokens.Add(wxT("__attribute_deprecated_msg__(%0)"));
-    m_tokens.Add(wxT("__attribute_format_arg__(%0)"));
-    m_tokens.Add(wxT("__attribute_format_strfmon__(%0,%1)"));
-    m_tokens.Add(wxT("__attribute_malloc__"));
-    m_tokens.Add(wxT("__attribute_noinline__"));
-    m_tokens.Add(wxT("__attribute_nonstring__"));
-    m_tokens.Add(wxT("__attribute_pure__"));
-    m_tokens.Add(wxT("__attribute_used__"));
-    m_tokens.Add(wxT("__attribute_warn_unused_result__"));
-    m_tokens.Add(wxT("__cdecl"));
-    m_tokens.Add(wxT("__const=const"));
-    m_tokens.Add(wxT("__cpp_deduction_guides=0"));
-    m_tokens.Add(wxT("__errordecl(%0,%1)=extern void %0 (void)"));
-    m_tokens.Add(wxT("__extension__"));
-    m_tokens.Add(wxT("__extern_always_inline=extern"));
-    m_tokens.Add(wxT("__extern_inline=extern"));
-    m_tokens.Add(wxT("__flexarr=[]"));
-    m_tokens.Add(wxT("__forceinline"));
-    m_tokens.Add(wxT("__fortify_function=extern"));
-    m_tokens.Add(wxT("__glibc_likely(%0)=(%0)"));
-    m_tokens.Add(wxT("__glibc_macro_warning(%0)"));
-    m_tokens.Add(wxT("__glibc_macro_warning1(%0)"));
-    m_tokens.Add(wxT("__glibc_unlikely(%0)=(%0)"));
-    m_tokens.Add(wxT("__glibcxx_assert(%0)"));
-    m_tokens.Add(wxT("__glibcxx_assert_impl(%0)"));
-    m_tokens.Add(wxT("__inline"));
-    m_tokens.Add(wxT("__nonnull(%0)"));
-    m_tokens.Add(wxT("__nothrow"));
-    m_tokens.Add(wxT("__restrict"));
-    m_tokens.Add(wxT("__restrict__"));
-    m_tokens.Add(wxT("__restrict_arr"));
-    m_tokens.Add(wxT("__stdcall"));
-    m_tokens.Add(wxT("__warnattr(%0)"));
-    m_tokens.Add(wxT("__warndecl(%0,%1)=extern void %0 (void)"));
-    m_tokens.Add(wxT("__wur"));
-    m_tokens.Add(wxT("_inline"));
-    m_tokens.Add(wxT("emit"));
-    m_tokens.Add(wxT("static_assert(%0)"));
-    m_tokens.Add(wxT("wxDECLARE_EVENT(%0,%1)=int %0;"));
-    m_tokens.Add(wxT("wxDECLARE_EXPORTED_EVENT(%0,%1,%2)=int %1;"));
-    m_tokens.Add(wxT("wxDEPRECATED(%0)=%0"));
-    m_tokens.Add(wxT("wxMSVC_FWD_MULTIPLE_BASES"));
-    m_tokens.Add(wxT("wxOVERRIDE"));
-    m_tokens.Add(wxT("wxStatusBar=wxStatusBarBase"));
-    m_tokens.Add(wxT("wxT"));
-    m_tokens.Add(wxT("wxWindowNative=wxWindowBase"));
+    m_tokens.Add("ATTRIBUTE_PRINTF_1");
+    m_tokens.Add("ATTRIBUTE_PRINTF_2");
+    m_tokens.Add("BEGIN_DECLARE_EVENT_TYPES()=enum {");
+    m_tokens.Add("BOOST_FOREACH(%0, %1)=%0;");
+    m_tokens.Add("DECLARE_EVENT_TYPE");
+    m_tokens.Add("DECLARE_EVENT_TYPE(%0,%1)=int %0;");
+    m_tokens.Add("DECLARE_EXPORTED_EVENT_TYPE");
+    m_tokens.Add("DECLARE_INSTANCE_TYPE");
+    m_tokens.Add("DLLIMPORT");
+    m_tokens.Add("END_DECLARE_EVENT_TYPES()=};");
+    m_tokens.Add("EXPORT");
+    m_tokens.Add("LLDB_API");
+    m_tokens.Add("PYTHON_API");
+    m_tokens.Add("QT_BEGIN_HEADER");
+    m_tokens.Add("QT_BEGIN_NAMESPACE");
+    m_tokens.Add("QT_END_HEADER");
+    m_tokens.Add("QT_END_NAMESPACE");
+    m_tokens.Add("Q_GADGET");
+    m_tokens.Add("Q_INLINE_TEMPLATE");
+    m_tokens.Add("Q_OBJECT");
+    m_tokens.Add("Q_OUTOFLINE_TEMPLATE");
+    m_tokens.Add("Q_PACKED");
+    m_tokens.Add("Q_REQUIRED_RESULT");
+    m_tokens.Add("SCI_SCOPE(%0)=%0");
+    m_tokens.Add("UNALIGNED");
+    m_tokens.Add("WINAPI");
+    m_tokens.Add("WINBASEAPI");
+    m_tokens.Add("WXDLLEXPORT");
+    m_tokens.Add("WXDLLIMPEXP_ADV");
+    m_tokens.Add("WXDLLIMPEXP_AUI");
+    m_tokens.Add("WXDLLIMPEXP_BASE");
+    m_tokens.Add("WXDLLIMPEXP_CL");
+    m_tokens.Add("WXDLLIMPEXP_CORE");
+    m_tokens.Add("WXDLLIMPEXP_FWD_ADV");
+    m_tokens.Add("WXDLLIMPEXP_FWD_AUI");
+    m_tokens.Add("WXDLLIMPEXP_FWD_BASE");
+    m_tokens.Add("WXDLLIMPEXP_FWD_CORE");
+    m_tokens.Add("WXDLLIMPEXP_FWD_PROPGRID");
+    m_tokens.Add("WXDLLIMPEXP_FWD_XML");
+    m_tokens.Add("WXDLLIMPEXP_LE_SDK");
+    m_tokens.Add("WXDLLIMPEXP_SCI");
+    m_tokens.Add("WXDLLIMPEXP_SQLITE3");
+    m_tokens.Add("WXDLLIMPEXP_XML");
+    m_tokens.Add("WXDLLIMPEXP_XRC");
+    m_tokens.Add("WXDLLIMPORT");
+    m_tokens.Add("WXMAKINGDLL");
+    m_tokens.Add("WXUNUSED(%0)=%0");
+    m_tokens.Add("WXUSINGDLL");
+    m_tokens.Add("_ALIGNAS(%0)=alignas(%0)");
+    m_tokens.Add("_ALIGNAS_TYPE(%0)=alignas(%0)");
+    m_tokens.Add("_ANONYMOUS_STRUCT");
+    m_tokens.Add("_ANONYMOUS_UNION");
+    m_tokens.Add("_ATTRIBUTE(%0)");
+    m_tokens.Add("_CRTIMP");
+    m_tokens.Add("_CRTIMP2");
+    m_tokens.Add("_CRTIMP2_PURE");
+    m_tokens.Add("_CRTIMP_ALTERNATIVE");
+    m_tokens.Add("_CRTIMP_NOIA64");
+    m_tokens.Add("_CRTIMP_PURE");
+    m_tokens.Add("_CRT_ALIGN(%0)");
+    m_tokens.Add("_CRT_DEPRECATE_TEXT(%0)");
+    m_tokens.Add("_CRT_INSECURE_DEPRECATE_GLOBALS(%0)");
+    m_tokens.Add("_CRT_INSECURE_DEPRECATE_MEMORY(%0)");
+    m_tokens.Add("_CRT_OBSOLETE(%0)");
+    m_tokens.Add("_CRT_STRINGIZE(%0)=\"%0\"");
+    m_tokens.Add("_CRT_UNUSED(%0)=%0");
+    m_tokens.Add("_CRT_WIDE(%0)=L\"%0\"");
+    m_tokens.Add("_GLIBCXX14_CONSTEXPR");
+    m_tokens.Add("_GLIBCXX17_CONSTEXPR");
+    m_tokens.Add("_GLIBCXX17_DEPRECATED");
+    m_tokens.Add("_GLIBCXX17_INLINE");
+    m_tokens.Add("_GLIBCXX20_CONSTEXPR");
+    m_tokens.Add("_GLIBCXX20_DEPRECATED(%0)");
+    m_tokens.Add("_GLIBCXX_BEGIN_EXTERN_C=extern \"C\" {");
+    m_tokens.Add("_GLIBCXX_BEGIN_NAMESPACE(%0)=namespace %0{");
+    m_tokens.Add("_GLIBCXX_BEGIN_NAMESPACE_ALGO");
+    m_tokens.Add("_GLIBCXX_BEGIN_NAMESPACE_CONTAINER");
+    m_tokens.Add("_GLIBCXX_BEGIN_NAMESPACE_CXX11");
+    m_tokens.Add("_GLIBCXX_BEGIN_NAMESPACE_LDBL");
+    m_tokens.Add("_GLIBCXX_BEGIN_NAMESPACE_LDBL_OR_CXX11");
+    m_tokens.Add("_GLIBCXX_BEGIN_NAMESPACE_TR1=namespace tr1{");
+    m_tokens.Add("_GLIBCXX_BEGIN_NAMESPACE_VERSION");
+    m_tokens.Add("_GLIBCXX_BEGIN_NESTED_NAMESPACE(%0, %1)=namespace %0{");
+    m_tokens.Add("_GLIBCXX_CONST");
+    m_tokens.Add("_GLIBCXX_CONSTEXPR");
+    m_tokens.Add("_GLIBCXX_DEPRECATED");
+    m_tokens.Add("_GLIBCXX_DEPRECATED_SUGGEST(%0)");
+    m_tokens.Add("_GLIBCXX_END_EXTERN_C=}");
+    m_tokens.Add("_GLIBCXX_END_NAMESPACE=}");
+    m_tokens.Add("_GLIBCXX_END_NAMESPACE_ALGO");
+    m_tokens.Add("_GLIBCXX_END_NAMESPACE_CONTAINER");
+    m_tokens.Add("_GLIBCXX_END_NAMESPACE_CXX11");
+    m_tokens.Add("_GLIBCXX_END_NAMESPACE_LDBL");
+    m_tokens.Add("_GLIBCXX_END_NAMESPACE_LDBL_OR_CXX11");
+    m_tokens.Add("_GLIBCXX_END_NAMESPACE_TR1=}");
+    m_tokens.Add("_GLIBCXX_END_NAMESPACE_VERSION");
+    m_tokens.Add("_GLIBCXX_END_NESTED_NAMESPACE=}");
+    m_tokens.Add("_GLIBCXX_NAMESPACE_CXX11");
+    m_tokens.Add("_GLIBCXX_NAMESPACE_LDBL");
+    m_tokens.Add("_GLIBCXX_NAMESPACE_LDBL_OR_CXX11");
+    m_tokens.Add("_GLIBCXX_NODISCARD");
+    m_tokens.Add("_GLIBCXX_NOEXCEPT");
+    m_tokens.Add("_GLIBCXX_NOEXCEPT_IF(%0)");
+    m_tokens.Add("_GLIBCXX_NOEXCEPT_PARM");
+    m_tokens.Add("_GLIBCXX_NOEXCEPT_QUAL");
+    m_tokens.Add("_GLIBCXX_NORETURN");
+    m_tokens.Add("_GLIBCXX_NOTHROW");
+    m_tokens.Add("_GLIBCXX_PSEUDO_VISIBILITY(%0)");
+    m_tokens.Add("_GLIBCXX_PURE");
+    m_tokens.Add("_GLIBCXX_STD=std");
+    m_tokens.Add("_GLIBCXX_SYNCHRONIZATION_HAPPENS_AFTER(%0)");
+    m_tokens.Add("_GLIBCXX_SYNCHRONIZATION_HAPPENS_BEFORE(%0)");
+    m_tokens.Add("_GLIBCXX_THROW(%0)");
+    m_tokens.Add("_GLIBCXX_THROW_OR_ABORT(%0)");
+    m_tokens.Add("_GLIBCXX_TXN_SAFE");
+    m_tokens.Add("_GLIBCXX_TXN_SAFE_DYN");
+    m_tokens.Add("_GLIBCXX_USE_CONSTEXPR");
+    m_tokens.Add("_GLIBCXX_USE_NOEXCEPT");
+    m_tokens.Add("_GLIBCXX_VISIBILITY(%0)");
+    m_tokens.Add("_LIBCPP_ALWAYS_INLINE");
+    m_tokens.Add("_LIBCPP_BEGIN_NAMESPACE_FILESYSTEM=namespace std { namespace filesystem {");
+    m_tokens.Add("_LIBCPP_BEGIN_NAMESPACE_STD=namespace std{");
+    m_tokens.Add("_LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS");
+    m_tokens.Add("_LIBCPP_CONCAT(%0,%1)=%0%1");
+    m_tokens.Add("_LIBCPP_CONCAT1(%0,%1)=%0%1");
+    m_tokens.Add("_LIBCPP_CONSTEVAL");
+    m_tokens.Add("_LIBCPP_CONSTEXPR");
+    m_tokens.Add("_LIBCPP_CONSTEXPR_AFTER_CXX11");
+    m_tokens.Add("_LIBCPP_CONSTEXPR_AFTER_CXX14");
+    m_tokens.Add("_LIBCPP_CONSTEXPR_AFTER_CXX17");
+    m_tokens.Add("_LIBCPP_CONSTEXPR_IF_NODEBUG");
+    m_tokens.Add("_LIBCPP_CRT_FUNC");
+    m_tokens.Add("_LIBCPP_DECLARE_STRONG_ENUM(%0)=enum class %0");
+    m_tokens.Add("_LIBCPP_DECLARE_STRONG_ENUM_EPILOG(%0)");
+    m_tokens.Add("_LIBCPP_DECLSPEC_EMPTY_BASES");
+    m_tokens.Add("_LIBCPP_DEFAULT");
+    m_tokens.Add("_LIBCPP_DEPRECATED");
+    m_tokens.Add("_LIBCPP_DEPRECATED_IN_CXX11");
+    m_tokens.Add("_LIBCPP_DEPRECATED_IN_CXX14");
+    m_tokens.Add("_LIBCPP_DEPRECATED_IN_CXX17");
+    m_tokens.Add("_LIBCPP_DEPRECATED_IN_CXX20");
+    m_tokens.Add("_LIBCPP_DEPRECATED_WITH_CHAR8_T");
+    m_tokens.Add("_LIBCPP_DIAGNOSE_ERROR(%0)");
+    m_tokens.Add("_LIBCPP_DIAGNOSE_WARNING(%0)");
+    m_tokens.Add("_LIBCPP_DISABLE_EXTENSION_WARNING");
+    m_tokens.Add("_LIBCPP_DLL_VIS");
+    m_tokens.Add("_LIBCPP_END_NAMESPACE_FILESYSTEM=} }");
+    m_tokens.Add("_LIBCPP_END_NAMESPACE_STD=}");
+    m_tokens.Add("_LIBCPP_EQUAL_DELETE");
+    m_tokens.Add("_LIBCPP_EXCEPTION_ABI");
+    m_tokens.Add("_LIBCPP_EXCLUDE_FROM_EXPLICIT_INSTANTIATION");
+    m_tokens.Add("_LIBCPP_EXPLICIT");
+    m_tokens.Add("_LIBCPP_EXPLICIT_AFTER_CXX11");
+    m_tokens.Add("_LIBCPP_EXPORTED_FROM_ABI");
+    m_tokens.Add("_LIBCPP_EXTERN_TEMPLATE(%0)");
+    m_tokens.Add("_LIBCPP_EXTERN_TEMPLATE_DEFINE(%0)");
+    m_tokens.Add("_LIBCPP_EXTERN_TEMPLATE_EVEN_IN_DEBUG_MODE(%0)");
+    m_tokens.Add("_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS");
+    m_tokens.Add("_LIBCPP_FALLTHROUGH(%0)");
+    m_tokens.Add("_LIBCPP_FORMAT_PRINTF(%0,%1)");
+    m_tokens.Add("_LIBCPP_FUNC_VIS");
+    m_tokens.Add("_LIBCPP_INIT_PRIORITY_MAX");
+    m_tokens.Add("_LIBCPP_INLINE_VAR");
+    m_tokens.Add("_LIBCPP_INLINE_VISIBILITY");
+    m_tokens.Add("_LIBCPP_INTERNAL_LINKAGE");
+    m_tokens.Add("_LIBCPP_NOALIAS");
+    m_tokens.Add("_LIBCPP_NODEBUG");
+    m_tokens.Add("_LIBCPP_NODEBUG_TYPE");
+    m_tokens.Add("_LIBCPP_NODISCARD_AFTER_CXX17");
+    m_tokens.Add("_LIBCPP_NODISCARD_ATTRIBUTE");
+    m_tokens.Add("_LIBCPP_NODISCARD_EXT");
+    m_tokens.Add("_LIBCPP_NORETURN");
+    m_tokens.Add("_LIBCPP_NO_DESTROY");
+    m_tokens.Add("_LIBCPP_OVERRIDABLE_FUNC_VIS");
+    m_tokens.Add("_LIBCPP_PREFERRED_NAME(%0)");
+    m_tokens.Add("_LIBCPP_SAFE_STATIC");
+    m_tokens.Add("_LIBCPP_THREAD_SAFETY_ANNOTATION(%0)");
+    m_tokens.Add("_LIBCPP_TOSTRING(%0)=\"%0\"");
+    m_tokens.Add("_LIBCPP_TOSTRING2(%0)=\"%0\"");
+    m_tokens.Add("_LIBCPP_TYPE_VIS");
+    m_tokens.Add("_LIBCPP_TYPE_VIS_ONLY");
+    m_tokens.Add("_LIBCPP_UNUSED_VAR(%0)=%0");
+    m_tokens.Add("_LIBCPP_WEAK");
+    m_tokens.Add("_MCRTIMP");
+    m_tokens.Add("_MRTIMP2");
+    m_tokens.Add("_NOEXCEPT");
+    m_tokens.Add("noexcept");
+    m_tokens.Add("_NOEXCEPT_(%0)");
+    m_tokens.Add("_Noreturn");
+    m_tokens.Add("_PSTL_ASSERT(%0)");
+    m_tokens.Add("_PSTL_ASSERT_MSG(%0,%1)");
+    m_tokens.Add("_STD_BEGIN=namespace std{");
+    m_tokens.Add("_STD_END=}");
+    m_tokens.Add("_STRUCT_NAME(%0)");
+    m_tokens.Add("_Static_assert(%0,%1)");
+    m_tokens.Add("_T");
+    m_tokens.Add("_UNION_NAME(%0)");
+    m_tokens.Add("_VSTD=std");
+    m_tokens.Add("_VSTD_FS=std::filesystem");
+    m_tokens.Add("__BEGIN_DECLS=extern \"C\" {");
+    m_tokens.Add("__CLRCALL_OR_CDECL");
+    m_tokens.Add("__CONCAT(%0,%1)=%0%1");
+    m_tokens.Add("__CRTDECL");
+    m_tokens.Add("__CRT_INLINE");
+    m_tokens.Add("__CRT_STRINGIZE(%0)=\"%0\"");
+    m_tokens.Add("__CRT_UUID_DECL(%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,%11)");
+    m_tokens.Add("__CRT_WIDE(%0)=L\"%0\"");
+    m_tokens.Add("__END_DECLS=}");
+    m_tokens.Add("__GOMP_NOTHROW");
+    m_tokens.Add("__LEAF");
+    m_tokens.Add("__LEAF_ATTR");
+    m_tokens.Add("__MINGW_ATTRIB_CONST");
+    m_tokens.Add("__MINGW_ATTRIB_DEPRECATED");
+    m_tokens.Add("__MINGW_ATTRIB_DEPRECATED_MSG(%0)");
+    m_tokens.Add("__MINGW_ATTRIB_MALLOC");
+    m_tokens.Add("__MINGW_ATTRIB_NONNULL(%0)");
+    m_tokens.Add("__MINGW_ATTRIB_NORETURN");
+    m_tokens.Add("__MINGW_ATTRIB_NO_OPTIMIZE");
+    m_tokens.Add("__MINGW_ATTRIB_PURE");
+    m_tokens.Add("__MINGW_ATTRIB_UNUSED");
+    m_tokens.Add("__MINGW_ATTRIB_USED");
+    m_tokens.Add("__MINGW_BROKEN_INTERFACE(%0)");
+    m_tokens.Add("__MINGW_IMPORT");
+    m_tokens.Add("__MINGW_INTRIN_INLINE=extern");
+    m_tokens.Add("__MINGW_NOTHROW");
+    m_tokens.Add("__MINGW_PRAGMA_PARAM(%0)");
+    m_tokens.Add("__N(%0)=%0");
+    m_tokens.Add("__NTH(%0)=%0");
+    m_tokens.Add("__NTHNL(%0)=%0");
+    m_tokens.Add("__P(%0)=%0");
+    m_tokens.Add("__PMT(%0)=%0");
+    m_tokens.Add("__PSTL_ASSERT(%0)");
+    m_tokens.Add("__PSTL_ASSERT_MSG(%0,%1)");
+    m_tokens.Add("__STRING(%0)=\"%0\"");
+    m_tokens.Add("__THROW");
+    m_tokens.Add("__THROWNL");
+    m_tokens.Add("__UNUSED_PARAM(%0)=%0");
+    m_tokens.Add("__always_inline");
+    m_tokens.Add("__attribute__(%0)");
+    m_tokens.Add("__attribute_alloc_size__(%0)");
+    m_tokens.Add("__attribute_artificial__");
+    m_tokens.Add("__attribute_const__");
+    m_tokens.Add("__attribute_copy__(%0)");
+    m_tokens.Add("__attribute_deprecated__");
+    m_tokens.Add("__attribute_deprecated_msg__(%0)");
+    m_tokens.Add("__attribute_format_arg__(%0)");
+    m_tokens.Add("__attribute_format_strfmon__(%0,%1)");
+    m_tokens.Add("__attribute_malloc__");
+    m_tokens.Add("__attribute_noinline__");
+    m_tokens.Add("__attribute_nonstring__");
+    m_tokens.Add("__attribute_pure__");
+    m_tokens.Add("__attribute_used__");
+    m_tokens.Add("__attribute_warn_unused_result__");
+    m_tokens.Add("__cdecl");
+    m_tokens.Add("__const=const");
+    m_tokens.Add("__cpp_deduction_guides=0");
+    m_tokens.Add("__errordecl(%0,%1)=extern void %0 (void)");
+    m_tokens.Add("__extension__");
+    m_tokens.Add("__extern_always_inline=extern");
+    m_tokens.Add("__extern_inline=extern");
+    m_tokens.Add("__flexarr=[]");
+    m_tokens.Add("__forceinline");
+    m_tokens.Add("__fortify_function=extern");
+    m_tokens.Add("__glibc_likely(%0)=(%0)");
+    m_tokens.Add("__glibc_macro_warning(%0)");
+    m_tokens.Add("__glibc_macro_warning1(%0)");
+    m_tokens.Add("__glibc_unlikely(%0)=(%0)");
+    m_tokens.Add("__glibcxx_assert(%0)");
+    m_tokens.Add("__glibcxx_assert_impl(%0)");
+    m_tokens.Add("__inline");
+    m_tokens.Add("__nonnull(%0)");
+    m_tokens.Add("__nothrow");
+    m_tokens.Add("__restrict");
+    m_tokens.Add("__restrict__");
+    m_tokens.Add("__restrict_arr");
+    m_tokens.Add("__stdcall");
+    m_tokens.Add("__warnattr(%0)");
+    m_tokens.Add("__warndecl(%0,%1)=extern void %0 (void)");
+    m_tokens.Add("__wur");
+    m_tokens.Add("_inline");
+    m_tokens.Add("emit");
+    m_tokens.Add("static_assert(%0)");
+    m_tokens.Add("wxDECLARE_EVENT(%0,%1)=int %0;");
+    m_tokens.Add("wxDECLARE_EXPORTED_EVENT(%0,%1,%2)=int %1;");
+    m_tokens.Add("wxDEPRECATED(%0)=%0");
+    m_tokens.Add("wxMSVC_FWD_MULTIPLE_BASES");
+    m_tokens.Add("wxOVERRIDE");
+    m_tokens.Add("wxStatusBar=wxStatusBarBase");
+    m_tokens.Add("wxT");
+    m_tokens.Add("wxWindowNative=wxWindowBase");
 
 #if defined(__WXGTK__)
-    m_tokens.Add(wxT("wxTopLevelWindowNative=wxTopLevelWindowGTK"));
-    m_tokens.Add(wxT("wxWindow=wxWindowGTK"));
+    m_tokens.Add("wxTopLevelWindowNative=wxTopLevelWindowGTK");
+    m_tokens.Add("wxWindow=wxWindowGTK");
 #elif defined(__WXMSW__)
-    m_tokens.Add(wxT("wxTopLevelWindowNative=wxTopLevelWindowMSW"));
-    m_tokens.Add(wxT("wxWindow=wxWindowMSW"));
+    m_tokens.Add("wxTopLevelWindowNative=wxTopLevelWindowMSW");
+    m_tokens.Add("wxWindow=wxWindowMSW");
 #else
-    m_tokens.Add(wxT("wxTopLevelWindowNative=wxTopLevelWindowMac"));
-    m_tokens.Add(wxT("wxWindow=wxWindowMac"));
+    m_tokens.Add("wxTopLevelWindowNative=wxTopLevelWindowMac");
+    m_tokens.Add("wxWindow=wxWindowMac");
 #endif
 }
 
 void TagsOptionsData::AddDefaultTypes()
 {
-    // m_types.Add(wxT("std::vector::reference=_Tp"));
-    // m_types.Add(wxT("std::vector::const_reference=_Tp"));
-    // m_types.Add(wxT("std::vector::iterator=_Tp"));
-    // m_types.Add(wxT("std::vector::const_iterator=_Tp"));
-    // m_types.Add(wxT("std::queue::reference=_Tp"));
-    // m_types.Add(wxT("std::queue::const_reference=_Tp"));
-    // m_types.Add(wxT("std::priority_queue::reference=_Tp"));
-    // m_types.Add(wxT("std::priority_queue::const_reference=_Tp"));
-    // m_types.Add(wxT("std::set::const_iterator=_Key"));
-    // m_types.Add(wxT("std::set::iterator=_Key"));
-    // m_types.Add(wxT("std::unordered_set::const_iterator=_Key"));
-    // m_types.Add(wxT("std::unordered_set::iterator=_Key"));
-    // m_types.Add(wxT("std::deque::reference=_Tp"));
-    // m_types.Add(wxT("std::deque::const_reference=_Tp"));
-    // m_types.Add(wxT("std::map::iterator=std::pair<_Key, _Tp>"));
-    // m_types.Add(wxT("std::map::const_iterator=std::pair<_Key,_Tp>"));
-    // m_types.Add(wxT("std::unordered_map::iterator=std::pair<_Key, _Tp>"));
-    // m_types.Add(wxT("std::unordered_map::mapped_type=_Tp"));
-    // m_types.Add(wxT("std::unordered_map::const_iterator=std::pair<_Key,_Tp>"));
-    // m_types.Add(wxT("std::unordered_map::value_type=std::pair<_Key,_Tp>"));
-    // m_types.Add(wxT("std::multimap::iterator=std::pair<_Key,_Tp>"));
-    // m_types.Add(wxT("std::multimap::const_iterator=std::pair<_Key,_Tp>"));
-    // m_types.Add(wxT("wxOrderedMap::iterator=std::pair<Key,Value>"));
-    // m_types.Add(wxT("wxOrderedMap::const_iterator=std::pair<Key,Value>"));
-    // m_types.Add(wxT("boost::shared_ptr::type=T"));
-    // m_types.Add(wxT("std::unique_ptr::pointer=_Tp"));
-    // m_types.Add(wxT("_Ptr<_Tp,_Dp>::type=_Tp"));
-    // m_types.Add(wxT("std::shared_ptr::element_type=_Tp"));
+    // m_types.Add("std::vector::reference=_Tp");
+    // m_types.Add("std::vector::const_reference=_Tp");
+    // m_types.Add("std::vector::iterator=_Tp");
+    // m_types.Add("std::vector::const_iterator=_Tp");
+    // m_types.Add("std::queue::reference=_Tp");
+    // m_types.Add("std::queue::const_reference=_Tp");
+    // m_types.Add("std::priority_queue::reference=_Tp");
+    // m_types.Add("std::priority_queue::const_reference=_Tp");
+    // m_types.Add("std::set::const_iterator=_Key");
+    // m_types.Add("std::set::iterator=_Key");
+    // m_types.Add("std::unordered_set::const_iterator=_Key");
+    // m_types.Add("std::unordered_set::iterator=_Key");
+    // m_types.Add("std::deque::reference=_Tp");
+    // m_types.Add("std::deque::const_reference=_Tp");
+    // m_types.Add("std::map::iterator=std::pair<_Key, _Tp>");
+    // m_types.Add("std::map::const_iterator=std::pair<_Key,_Tp>");
+    // m_types.Add("std::unordered_map::iterator=std::pair<_Key, _Tp>");
+    // m_types.Add("std::unordered_map::mapped_type=_Tp");
+    // m_types.Add("std::unordered_map::const_iterator=std::pair<_Key,_Tp>");
+    // m_types.Add("std::unordered_map::value_type=std::pair<_Key,_Tp>");
+    // m_types.Add("std::multimap::iterator=std::pair<_Key,_Tp>");
+    // m_types.Add("std::multimap::const_iterator=std::pair<_Key,_Tp>");
+    // m_types.Add("wxOrderedMap::iterator=std::pair<Key,Value>");
+    // m_types.Add("wxOrderedMap::const_iterator=std::pair<Key,Value>");
+    // m_types.Add("boost::shared_ptr::type=T");
+    // m_types.Add("std::unique_ptr::pointer=_Tp");
+    // m_types.Add("_Ptr<_Tp,_Dp>::type=_Tp");
+    // m_types.Add("std::shared_ptr::element_type=_Tp");
 }
 
 wxString TagsOptionsData::ToString() const
@@ -456,28 +456,30 @@ wxString TagsOptionsData::ToString() const
 
     if(tokensMap.empty() == false) {
         for(; iter != tokensMap.end(); ++iter) {
-            if(!iter->second.IsEmpty() || (iter->second.IsEmpty() && iter->first.Find(wxT("%0")) != wxNOT_FOUND)) {
+            if(!iter->second.IsEmpty() || (iter->second.IsEmpty() && iter->first.Find("%0") != wxNOT_FOUND)) {
                 // Key = Value pair. Place this one in the output file
-                file_content << iter->first << wxT("=") << iter->second << wxT("\n");
+                file_content << iter->first << "=" << iter->second << "\n";
             } else {
 
-                if(options.IsEmpty())
-                    options = wxT(" -I");
+                if(options.IsEmpty()) {
+                    options = " -I";
+                }
 
                 options << iter->first;
-                options << wxT(",");
+                options << ",";
             }
         }
 
-        if(options.IsEmpty() == false)
+        if(options.IsEmpty() == false) {
             options.RemoveLast();
+        }
 
-        options += wxT(" ");
+        options += " ";
     }
 
     // write the file content
     if(file_name.IsEmpty() == false) {
-        wxFFile fp(file_name, wxT("w+b"));
+        wxFFile fp(file_name, "w+b");
         if(fp.IsOpened()) {
             fp.Write(file_content);
             fp.Close();
@@ -485,9 +487,9 @@ wxString TagsOptionsData::ToString() const
     }
 
     //    if(GetLanguages().IsEmpty() == false) {
-    //        options += wxT(" --language-force=");
+    //        options += " --language-force=";
     //        options += GetLanguages().Item(0);
-    //        options += wxT(" ");
+    //        options += " ";
     //    }
     return options;
 }
@@ -508,8 +510,8 @@ std::map<std::string, std::string> TagsOptionsData::GetTokensMap() const
         // const wxCharBuffer bufKey = _C(
         wxString item = m_tokens.Item(i);
         item.Trim().Trim(false);
-        wxString k = item.BeforeFirst(wxT('='));
-        wxString v = item.AfterFirst(wxT('='));
+        wxString k = item.BeforeFirst('=');
+        wxString v = item.AfterFirst('=');
 
         const wxCharBuffer bufKey = _C(k);
         std::string key = bufKey.data();
@@ -531,8 +533,8 @@ wxStringTable_t TagsOptionsData::GetTypesMap() const
     for(size_t i = 0; i < m_types.GetCount(); i++) {
         wxString item = m_types.Item(i);
         item.Trim().Trim(false);
-        wxString k = item.BeforeFirst(wxT('='));
-        wxString v = item.AfterFirst(wxT('='));
+        wxString k = item.BeforeFirst('=');
+        wxString v = item.AfterFirst('=');
         tokens[k] = v;
     }
     return tokens;
@@ -550,8 +552,8 @@ void TagsOptionsData::DoUpdateTokensWxMap()
     m_tokensWxMap.clear();
     for(size_t i = 0; i < m_tokens.GetCount(); i++) {
         wxString item = m_tokens.Item(i).Trim().Trim(false);
-        wxString k = item.BeforeFirst(wxT('='));
-        wxString v = item.AfterFirst(wxT('='));
+        wxString k = item.BeforeFirst('=');
+        wxString v = item.AfterFirst('=');
         m_tokensWxMap[k] = v;
     }
 }
@@ -561,8 +563,8 @@ void TagsOptionsData::DoUpdateTokensWxMapReversed()
     m_tokensWxMapReversed.clear();
     for(size_t i = 0; i < m_tokens.GetCount(); i++) {
         wxString item = m_tokens.Item(i).Trim().Trim(false);
-        wxString k = item.AfterFirst(wxT('='));
-        wxString v = item.BeforeFirst(wxT('='));
+        wxString k = item.AfterFirst('=');
+        wxString v = item.BeforeFirst('=');
         if(_IsValidCppIndetifier(k) && !_IsCppKeyword(k)) {
             m_tokensWxMapReversed[k] = v;
         }
@@ -574,25 +576,25 @@ const wxStringTable_t& TagsOptionsData::GetTokensReversedWxMap() const { return 
 void TagsOptionsData::FromJSON(const JSONItem& json)
 {
     m_version = json.namedObject("version").toSize_t();
-    m_ccFlags = json.namedObject(wxT("m_ccFlags")).toSize_t(m_ccFlags);
-    m_ccColourFlags = json.namedObject(wxT("m_ccColourFlags")).toSize_t(m_ccColourFlags);
-    m_tokens = json.namedObject(wxT("m_tokens")).toArrayString();
-    m_types = json.namedObject(wxT("m_types")).toArrayString();
-    m_fileSpec = json.namedObject(wxT("m_fileSpec")).toString(m_fileSpec);
-    m_languages = json.namedObject(wxT("m_languages")).toArrayString();
-    m_minWordLen = json.namedObject(wxT("m_minWordLen")).toInt(m_minWordLen);
-    m_parserSearchPaths = json.namedObject(wxT("m_parserSearchPaths")).toArrayString();
-    m_parserEnabled = json.namedObject(wxT("m_parserEnabled")).toBool();
-    m_parserExcludePaths = json.namedObject(wxT("m_parserExcludePaths")).toArrayString();
-    m_maxItemToColour = json.namedObject(wxT("m_maxItemToColour")).toInt();
-    m_macrosFiles = json.namedObject(wxT("m_macrosFiles")).toString();
-    m_clangOptions = json.namedObject(wxT("m_clangOptions")).toSize_t();
-    m_clangBinary = json.namedObject(wxT("m_clangBinary")).toString();
-    m_clangCmpOptions = json.namedObject(wxT("m_clangCmpOptions")).toString();
-    m_clangSearchPaths = json.namedObject(wxT("m_clangSearchPaths")).toArrayString();
-    m_clangMacros = json.namedObject(wxT("m_clangMacros")).toString();
-    m_clangCachePolicy = json.namedObject(wxT("m_clangCachePolicy")).toString();
-    m_ccNumberOfDisplayItems = json.namedObject(wxT("m_ccNumberOfDisplayItems")).toSize_t(m_ccNumberOfDisplayItems);
+    m_ccFlags = json.namedObject("m_ccFlags").toSize_t(m_ccFlags);
+    m_ccColourFlags = json.namedObject("m_ccColourFlags").toSize_t(m_ccColourFlags);
+    m_tokens = json.namedObject("m_tokens").toArrayString();
+    m_types = json.namedObject("m_types").toArrayString();
+    m_fileSpec = json.namedObject("m_fileSpec").toString(m_fileSpec);
+    m_languages = json.namedObject("m_languages").toArrayString();
+    m_minWordLen = json.namedObject("m_minWordLen").toInt(m_minWordLen);
+    m_parserSearchPaths = json.namedObject("m_parserSearchPaths").toArrayString();
+    m_parserEnabled = json.namedObject("m_parserEnabled").toBool();
+    m_parserExcludePaths = json.namedObject("m_parserExcludePaths").toArrayString();
+    m_maxItemToColour = json.namedObject("m_maxItemToColour").toInt();
+    m_macrosFiles = json.namedObject("m_macrosFiles").toString();
+    m_clangOptions = json.namedObject("m_clangOptions").toSize_t();
+    m_clangBinary = json.namedObject("m_clangBinary").toString();
+    m_clangCmpOptions = json.namedObject("m_clangCmpOptions").toString();
+    m_clangSearchPaths = json.namedObject("m_clangSearchPaths").toArrayString();
+    m_clangMacros = json.namedObject("m_clangMacros").toString();
+    m_clangCachePolicy = json.namedObject("m_clangCachePolicy").toString();
+    m_ccNumberOfDisplayItems = json.namedObject("m_ccNumberOfDisplayItems").toSize_t(m_ccNumberOfDisplayItems);
 
     if(!m_fileSpec.Contains("*.hxx")) {
         m_fileSpec = "*.cpp;*.cc;*.cxx;*.h;*.hpp;*.c;*.c++;*.tcc;*.hxx;*.h++";
@@ -635,8 +637,9 @@ wxString TagsOptionsData::DoJoinArray(const wxArrayString& arr) const
     for(size_t i = 0; i < arr.GetCount(); ++i)
         s << arr.Item(i) << "\n";
 
-    if(s.IsEmpty() == false)
+    if(s.IsEmpty() == false) {
         s.RemoveLast();
+    }
 
     return s;
 }

--- a/LiteEditor/editorsettingsmiscpanel.cpp
+++ b/LiteEditor/editorsettingsmiscpanel.cpp
@@ -23,18 +23,20 @@
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
+#include "editorsettingsmiscpanel.h"
+
 #include "cl_config.h"
 #include "ctags_manager.h"
-#include "editorsettingsmiscpanel.h"
 #include "file_logger.h"
 #include "frame.h"
 #include "generalinfo.h"
 #include "globals.h"
 #include "manager.h"
 #include "pluginmanager.h"
-#include "wx/wxprec.h"
+
 #include <wx/fontmap.h>
 #include <wx/intl.h>
+#include <wx/wxprec.h>
 
 #ifdef __WXMSW__
 #include <wx/msw/uxtheme.h>
@@ -58,7 +60,9 @@ EditorSettingsMiscPanel::EditorSettingsMiscPanel(wxWindow* parent)
     m_oldpreferredLocale = options->GetPreferredLocale();
     // Load the available locales and feed them to the wxchoice
     int select = FindAvailableLocales();
-    if(select != wxNOT_FOUND) { m_AvailableLocales->SetSelection(select); }
+    if(select != wxNOT_FOUND) {
+        m_AvailableLocales->SetSelection(select);
+    }
 
     wxArrayString astrEncodings;
     wxFontEncoding fontEnc;
@@ -70,7 +74,9 @@ EditorSettingsMiscPanel::EditorSettingsMiscPanel(wxWindow* parent)
             continue;
         }
         astrEncodings.Add(wxFontMapper::GetEncodingName(fontEnc));
-        if(fontEnc == options->GetFileFontEncoding()) { iCurrSelId = i; }
+        if(fontEnc == options->GetFileFontEncoding()) {
+            iCurrSelId = i;
+        }
     }
 
     m_fileEncoding->Append(astrEncodings);
@@ -123,30 +129,36 @@ void EditorSettingsMiscPanel::Save(OptionsConfigPtr options)
     int oldIconSize(24);
 
     OptionsConfigPtr oldOptions = EditorConfigST::Get()->GetOptions();
-    if(oldOptions) { oldIconSize = oldOptions->GetIconsSize(); }
+    if(oldOptions) {
+        oldIconSize = oldOptions->GetIconsSize();
+    }
 
     int iconSize(24);
-    if(m_toolbarIconSize->GetSelection() == 0) { iconSize = 16; }
+    if(m_toolbarIconSize->GetSelection() == 0) {
+        iconSize = 16;
+    }
     options->SetIconsSize(iconSize);
 
     bool setlocale = m_SetLocale->IsChecked();
     options->SetUseLocale(setlocale);
     wxString newLocaleString = m_AvailableLocales->GetStringSelection();
     // I don't think we should check if newLocaleString is empty; that's still useful information
-    newLocaleString = newLocaleString.BeforeFirst(wxT(':')); // Store it as "fr_FR", not "fr_FR: French"
+    newLocaleString = newLocaleString.BeforeFirst(':'); // Store it as "fr_FR", not "fr_FR: French"
     options->SetPreferredLocale(newLocaleString);
-    if((setlocale != m_oldSetLocale) || (newLocaleString != m_oldpreferredLocale)) { m_restartRequired = true; }
+    if((setlocale != m_oldSetLocale) || (newLocaleString != m_oldpreferredLocale)) {
+        m_restartRequired = true;
+    }
 
     // save file font encoding
     options->SetFileFontEncoding(m_fileEncoding->GetStringSelection());
     TagsManagerST::Get()->SetEncoding(options->GetFileFontEncoding());
 
     if(oldIconSize != iconSize) {
-        EditorConfigST::Get()->SetInteger(wxT("LoadSavedPrespective"), 0);
+        EditorConfigST::Get()->SetInteger("LoadSavedPrespective", 0);
         // notify the user
         m_restartRequired = true;
     } else {
-        EditorConfigST::Get()->SetInteger(wxT("LoadSavedPrespective"), 1);
+        EditorConfigST::Get()->SetInteger("LoadSavedPrespective", 1);
     }
 
     size_t flags = options->GetOptions();
@@ -156,14 +168,16 @@ void EditorSettingsMiscPanel::Save(OptionsConfigPtr options)
     flags &= ~(OptionsConfig::Opt_IconSet_FreshFarm);
     flags &= ~(OptionsConfig::Opt_IconSet_Classic_Dark);
     flags |= OptionsConfig::Opt_IconSet_Classic;
-    
+
     clConfig::Get().Write("RedirectLogOutput", m_redirectLogOutput->IsChecked());
     clConfig::Get().Write("PromptForNewReleaseOnly", m_checkBoxPromptReleaseOnly->IsChecked());
     options->SetOptions(flags);
     options->SetWebSearchPrefix(GetWebSearchPrefix()->GetValue());
     bool useDirect2D_Old = clConfig::Get().Read("Editor/UseDirect2D", true);
     clConfig::Get().Write("Editor/UseDirect2D", m_checkBoxDirect2D->IsChecked());
-    m_restartRequired = (useDirect2D_Old != m_checkBoxDirect2D->IsChecked());
+    if(useDirect2D_Old != m_checkBoxDirect2D->IsChecked()) {
+        m_restartRequired = true;
+    }
 }
 
 void EditorSettingsMiscPanel::OnClearUI(wxUpdateUIEvent& e)
@@ -205,7 +219,7 @@ int EditorSettingsMiscPanel::FindAvailableLocales()
             // Check we haven't already seen this item: we may find the system default twice
             if(canonicalNames.Index(info->CanonicalName) == wxNOT_FOUND) {
                 // Display the name as e.g. "en_GB: English (U.K.)"
-                m_AvailableLocales->Append(info->CanonicalName + wxT(": ") + info->Description);
+                m_AvailableLocales->Append(info->CanonicalName + ": " + info->Description);
                 canonicalNames.Add(info->CanonicalName);
 
                 if(info->CanonicalName == m_oldpreferredLocale) {
@@ -234,7 +248,7 @@ void EditorSettingsMiscPanel::OnShowLogFile(wxCommandEvent& event)
 {
     wxUnusedVar(event);
     wxString logfile;
-    logfile << clStandardPaths::Get().GetUserDataDir() << wxFileName::GetPathSeparator() << wxT("codelite.log");
+    logfile << clStandardPaths::Get().GetUserDataDir() << wxFileName::GetPathSeparator() << "codelite.log";
 
     clMainFrame::Get()->GetMainBook()->OpenFile(logfile);
 }

--- a/LiteEditor/fileview.cpp
+++ b/LiteEditor/fileview.cpp
@@ -23,6 +23,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 #include "fileview.h"
+
 #include "BuildOrderDialog.h"
 #include "ICompilerLocator.h"
 #include "ImportFilesDialogNew.h"
@@ -60,14 +61,15 @@
 #include "tree.h"
 #include "workspacesettingsdlg.h"
 #include "workspacetab.h"
-#include "wx/imaglist.h"
 #include "wxStringHash.h"
+
 #include <algorithm>
 #include <deque>
-#include <project.h>
 #include <queue>
+#include <tuple>
 #include <wx/colordlg.h>
 #include <wx/filedlg.h>
+#include <wx/imaglist.h>
 #include <wx/mimetype.h>
 #include <wx/msgdlg.h>
 #include <wx/progdlg.h>
@@ -77,7 +79,7 @@
 #include <wx/treectrl.h>
 #include <wx/xrc/xmlres.h>
 
-static const wxString gsCustomTargetsMenu(wxT("Custom Build Targets"));
+static const wxString gsCustomTargetsMenu("Custom Build Targets");
 
 BEGIN_EVENT_TABLE(FileViewTree, clThemedTreeCtrl)
 EVT_TREE_BEGIN_DRAG(wxID_ANY, FileViewTree::OnItemBeginDrag)
@@ -177,10 +179,11 @@ FileViewTree::FileViewTree(wxWindow* parent, const wxWindowID id, const wxPoint&
                                                                                  const wxTreeItemId& itemB) {
         FilewViewTreeItemData* a = static_cast<FilewViewTreeItemData*>(GetItemData(itemA));
         FilewViewTreeItemData* b = static_cast<FilewViewTreeItemData*>(GetItemData(itemB));
-        if(a->GetData().IsVirtualFolder() && b->GetData().IsFile())
+        if(a->GetData().IsVirtualFolder() && b->GetData().IsFile()) {
             return true;
-        else if(a->GetData().IsFile() && b->GetData().IsVirtualFolder())
+        } else if(a->GetData().IsFile() && b->GetData().IsVirtualFolder()) {
             return false;
+        }
         // same kind
         return (a->GetData().GetDisplayName().CmpNoCase(b->GetData().GetDisplayName()) < 0);
     };
@@ -303,8 +306,9 @@ int FileViewTree::GetIconIndex(const ProjectItem& item)
     case ProjectItem::TypeFile: {
         wxFileName filename(item.GetFile());
         icondIndex = bmpLoader->GetMimeImageId(filename.GetFullName());
-        if(icondIndex == wxNOT_FOUND)
+        if(icondIndex == wxNOT_FOUND) {
             icondIndex = bmpLoader->GetMimeImageId(FileExtManager::TypeText);
+        }
     } break;
     case ProjectItem::TypeWorkspaceFolder:
         icondIndex = WORKSPACE_FOLDER_IMG_IDX;
@@ -370,10 +374,11 @@ void FileViewTree::ShowFileContextMenu()
 {
     wxArrayTreeItemIds items;
     GetSelections(items);
-    if(items.IsEmpty())
+    if(items.IsEmpty()) {
         return;
+    }
 
-    wxMenu* menu = wxXmlResource::Get()->LoadMenu(wxT("file_tree_file"));
+    wxMenu* menu = wxXmlResource::Get()->LoadMenu("file_tree_file");
     if(!ManagerST::Get()->IsBuildInProgress()) {
         // Let the plugins alter it
         clContextMenuEvent event(wxEVT_CONTEXT_MENU_FILE);
@@ -435,7 +440,7 @@ void FileViewTree::ShowProjectContextMenu(const wxString& projectName)
 void FileViewTree::ShowWorkspaceContextMenu()
 {
     // Load the basic menu
-    wxMenu* menu = wxXmlResource::Get()->LoadMenu(wxT("workspace_popup_menu"));
+    wxMenu* menu = wxXmlResource::Get()->LoadMenu("workspace_popup_menu");
     if(!ManagerST::Get()->IsBuildInProgress()) {
         // Let the plugins alter it
         clContextMenuEvent event(wxEVT_CONTEXT_MENU_WORKSPACE);
@@ -478,7 +483,7 @@ void FileViewTree::OnPopupMenu(wxTreeEvent& event)
             }
         }
     } else {
-        PopupMenu(wxXmlResource::Get()->LoadMenu(wxT("file_view_empty")));
+        PopupMenu(wxXmlResource::Get()->LoadMenu("file_view_empty"));
     }
 }
 
@@ -498,7 +503,7 @@ TreeItemInfo FileViewTree::GetSelectedItemInfo()
             // in-case of virtual directories, set the file name to be the directory of
             // the project
             wxString path = GetItemPath(item);
-            wxString project = path.BeforeFirst(wxT(':'));
+            wxString project = path.BeforeFirst(':');
             info.m_fileName = wxFileName(ManagerST::Get()->GetProjectCwd(project), wxEmptyString);
         }
     }
@@ -512,8 +517,9 @@ void FileViewTree::DoItemActivated(wxTreeItemId& item, wxEvent& event)
     // holds the key for searching the its corresponding
     // node in the m_tree data structure
     //-----------------------------------------------------
-    if(item.IsOk() == false)
+    if(item.IsOk() == false) {
         return;
+    }
     FilewViewTreeItemData* itemData = static_cast<FilewViewTreeItemData*>(GetItemData(item));
     if(!itemData) {
         event.Skip();
@@ -528,9 +534,9 @@ void FileViewTree::DoItemActivated(wxTreeItemId& item, wxEvent& event)
         wxString project;
         if(key.GetChar(0) == ':') {
             // All the entries I've tested have started with a : so exclude this one, otherwise the project is always ""
-            project = key.AfterFirst(':').BeforeFirst(wxT(':'));
+            project = key.AfterFirst(':').BeforeFirst(':');
         } else {
-            project = key.BeforeFirst(wxT(':'));
+            project = key.BeforeFirst(':');
         }
 
         // Convert the file name to be in absolute path
@@ -541,8 +547,9 @@ void FileViewTree::DoItemActivated(wxTreeItemId& item, wxEvent& event)
         wxString file_path = fn.GetFullPath();
         clCommandEvent activateEvent(wxEVT_TREE_ITEM_FILE_ACTIVATED);
         activateEvent.SetFileName(file_path);
-        if(EventNotifier::Get()->ProcessEvent(activateEvent))
+        if(EventNotifier::Get()->ProcessEvent(activateEvent)) {
             return;
+        }
 
         clMainFrame::Get()->GetMainBook()->OpenFile(fn.GetFullPath(), project, -1);
 
@@ -563,7 +570,7 @@ void FileViewTree::OnOpenInEditor(wxCommandEvent& event)
         FilewViewTreeItemData* itemData = static_cast<FilewViewTreeItemData*>(GetItemData(item));
         if(itemData && itemData->GetData().GetKind() == ProjectItem::TypeFile) {
             wxString filename = itemData->GetData().GetFile();
-            wxString project = itemData->GetData().Key().BeforeFirst(wxT(':'));
+            wxString project = itemData->GetData().Key().BeforeFirst(':');
 
             // Convert the file name to an absolute path
             wxFileName fn(filename);
@@ -601,7 +608,7 @@ bool FileViewTree::AddFilesToVirtualFolder(const wxString& vdFullPath, wxArraySt
             // Add the tree node
             wxFileName fnFileName(actualAdded.Item(i));
             wxString path(vdFullPath);
-            path += wxT(":");
+            path += ":";
             path += fnFileName.GetFullName();
             ProjectItem projItem(path, fnFileName.GetFullName(), fnFileName.GetFullPath(), ProjectItem::TypeFile);
 
@@ -629,8 +636,8 @@ bool FileViewTree::AddFilesToVirtualFolderIntelligently(const wxString& vdFullPa
 
     // Check first for vdFullPath being one of the subdirs:
     wxString basename, srcname, includename;
-    if(!vdFullPath.EndsWith(wxT(":src"), &basename)) {
-        vdFullPath.EndsWith(wxT(":include"), &basename);
+    if(!vdFullPath.EndsWith(":src", &basename)) {
+        vdFullPath.EndsWith(":include", &basename);
     }
     if(basename.empty()) {
         basename = vdFullPath; // If not, assume that we were passed the parent folder
@@ -642,8 +649,8 @@ bool FileViewTree::AddFilesToVirtualFolderIntelligently(const wxString& vdFullPa
     if(!parentitem.IsOk()) {
         return false;
     }
-    wxTreeItemId srcitem = DoGetItemByText(parentitem, wxT("src"));
-    wxTreeItemId includeitem = DoGetItemByText(parentitem, wxT("include"));
+    wxTreeItemId srcitem = DoGetItemByText(parentitem, "src");
+    wxTreeItemId includeitem = DoGetItemByText(parentitem, "include");
     if(!(srcitem.IsOk() && includeitem.IsOk())) {
         return false; // The alleged parent folder doesn't have a relevant matching pair of children
     }
@@ -652,17 +659,17 @@ bool FileViewTree::AddFilesToVirtualFolderIntelligently(const wxString& vdFullPa
     wxArrayString cppfiles, hfiles;
     for(int c = (int)paths.GetCount() - 1; c >= 0; --c) {
         wxString file = paths.Item(c);
-        if(file.Right(4) == wxT(".cpp")) {
+        if(file.Right(4) == ".cpp") {
             cppfiles.Add(file);
             paths.RemoveAt(c);
-        } else if((file.Right(2) == wxT(".h")) || (file.Right(4) == wxT(".hpp"))) {
+        } else if((file.Right(2) == ".h") || (file.Right(4) == ".hpp")) {
             hfiles.Add(file);
             paths.RemoveAt(c);
         }
     }
     // Finally do the Adds
-    AddFilesToVirtualFolder(basename + wxT(":src"), cppfiles);
-    AddFilesToVirtualFolder(basename + wxT(":include"), hfiles);
+    AddFilesToVirtualFolder(basename + ":src", cppfiles);
+    AddFilesToVirtualFolder(basename + ":include", hfiles);
     // There shouldn't have been any other files passed; but if there were, add them to the selected folder
     if(paths.GetCount()) {
         AddFilesToVirtualFolder(vdFullPath, paths);
@@ -673,8 +680,9 @@ bool FileViewTree::AddFilesToVirtualFolderIntelligently(const wxString& vdFullPa
 
 bool FileViewTree::AddFilesToVirtualFolder(wxTreeItemId& item, wxArrayString& paths)
 {
-    if(item.IsOk() == false)
+    if(item.IsOk() == false) {
         return false;
+    }
 
     FilewViewTreeItemData* data = static_cast<FilewViewTreeItemData*>(GetItemData(item));
     switch(data->GetData().GetKind()) {
@@ -688,14 +696,14 @@ bool FileViewTree::AddFilesToVirtualFolder(wxTreeItemId& item, wxArrayString& pa
     wxArrayString actualAdded;
     wxString vdPath = GetItemPath(item);
     wxString project;
-    project = vdPath.BeforeFirst(wxT(':'));
+    project = vdPath.BeforeFirst(':');
     ManagerST::Get()->AddFilesToProject(paths, vdPath, actualAdded);
     for(size_t i = 0; i < actualAdded.Count(); i++) {
 
         // Add the tree node
         wxFileName fnFileName(actualAdded.Item(i));
         wxString path(vdPath);
-        path += wxT(":");
+        path += ":";
         path += fnFileName.GetFullName();
         ProjectItem projItem(path, fnFileName.GetFullName(), fnFileName.GetFullPath(), ProjectItem::TypeFile);
 
@@ -720,14 +728,14 @@ void FileViewTree::OnAddExistingItem(wxCommandEvent& WXUNUSED(event))
         return;
     }
 
-    const wxString ALL(
-        wxT("All Files (*)|*|") wxT("C/C++ Source Files (*.c;*.cpp;*.cxx;*.cc)|*.c;*.cpp;*.cxx;*.cc|")
-            wxT("C/C++ Header Files (*.h;*.hpp;*.hxx;*.hh;*.inl;*.inc)|*.h;*.hpp;*.hxx;*.hh;*.inl;*.inc"));
+    const wxString ALL("All Files (*)|*|"
+                       "C/C++ Source Files (*.c;*.cpp;*.cxx;*.cc)|*.c;*.cpp;*.cxx;*.cc|"
+                       "C/C++ Header Files (*.h;*.hpp;*.hxx;*.hh;*.inl;*.inc)|*.h;*.hpp;*.hxx;*.hh;*.inl;*.inc");
 
     wxString vdPath = GetItemPath(item);
     wxString project, vd;
-    project = vdPath.BeforeFirst(wxT(':'));
-    vd = vdPath.AfterFirst(wxT(':'));
+    project = vdPath.BeforeFirst(':');
+    vd = vdPath.AfterFirst(':');
 
     ProjectPtr proj = ManagerST::Get()->GetProject(project);
     start_path = proj->GetBestPathForVD(vd);
@@ -757,8 +765,8 @@ void FileViewTree::OnNewItem(wxCommandEvent& WXUNUSED(event))
     wxString path = GetItemPath(item);
 
     // Project name
-    wxString projName = path.BeforeFirst(wxT(':'));
-    wxString vd = path.AfterFirst(wxT(':'));
+    wxString projName = path.BeforeFirst(':');
+    wxString vd = path.AfterFirst(':');
     wxString projCwd;
     ProjectPtr project = ManagerST::Get()->GetProject(projName);
     if(project) {
@@ -802,8 +810,8 @@ void FileViewTree::OnRemoveItem(wxCommandEvent& WXUNUSED(event)) { DoRemoveItems
 
 void FileViewTree::DoRemoveItems()
 {
-    wxArrayTreeItemIds items;
-    size_t num = GetMultiSelection(items);
+    wxArrayTreeItemIds sels;
+    size_t num = GetMultiSelection(sels);
     if(!num) {
         return;
     }
@@ -815,137 +823,140 @@ void FileViewTree::DoRemoveItems()
     // We need to get the item names and data first. Why? Because if they're projects and multiple,
     // removing the second one segs in GetItemText(item) or data->GetData() as 'item' is no longer valid.
     // Why doesn't this happen for files and VDs too? Good question :/
-    wxArrayString namearray;
-    wxArrayInt kindarray;
-    std::vector<FilewViewTreeItemData*> itemdata;
-    for(size_t i = 0; i < num; i++) {
-        wxTreeItemId item = items.Item(i);
-        if(item.IsOk()) {
-            namearray.Add(GetItemText(item));
-            FilewViewTreeItemData* data = static_cast<FilewViewTreeItemData*>(GetItemData(item));
-            itemdata.push_back(data);
-            // Store the kind too, as this would become an invalid value
-            kindarray.Add(data->GetData().GetKind());
+    std::deque<std::tuple<wxTreeItemId, wxString, ProjectItem>> items;
+    for(size_t i = 0; i < num; ++i) {
+        wxTreeItemId sel = sels.Item(i);
+        if(sel.IsOk()) {
+            FilewViewTreeItemData* data = static_cast<FilewViewTreeItemData*>(GetItemData(sel));
+            items.emplace_back(sel, GetItemText(sel), data->GetData());
         }
     }
 
     wxArrayString filesRemoved;
     wxString affectedProject;
-    for(size_t i = 0; i < num; i++) {
-        wxTreeItemId item = items.Item(i);
-        if(!item.IsOk()) {
-            continue;
-        }
+    while(!items.empty()) {
+        std::tuple<wxTreeItemId, wxString, ProjectItem> item = items.front();
+        items.pop_front();
 
-        wxString name = namearray.Item(i);
-        FilewViewTreeItemData* data = itemdata.at(i);
+        const wxTreeItemId& itemId = std::get<0>(item);
+        const wxString& name = std::get<1>(item);
+        const ProjectItem& projectItem = std::get<2>(item);
+        bool eraseChildren = false;
 
-        if(data) {
-            switch(kindarray.Item(i)) {
-            case ProjectItem::TypeFile: {
-                int result = wxID_YES;
-                if(ApplyToEachFileRemoval == false) {
-                    wxString message;
-                    message << _("Are you sure you want remove '") << name << wxT("' ?");
-                    if((num > 1) && ((i + 1) < num)) {
+        switch(projectItem.GetKind()) {
+        case ProjectItem::TypeFile: {
+            int result = wxID_YES;
+            if(ApplyToEachFileRemoval == false) {
+                wxString message;
+                message << _("Are you sure you want remove '") << name << "' ?";
+                if(!items.empty()) {
 
-                        // For multiple selections, use a YesToAll dialog
-                        wxRichMessageDialog dlg(wxTheApp->GetTopWindow(), message, _("Confirm"),
-                                                wxYES_NO | wxYES_DEFAULT | wxCANCEL | wxCENTER | wxICON_QUESTION);
-                        dlg.ShowCheckBox(_("Remember my answer and apply it all files"), false);
-                        result = dlg.ShowModal();
-                        ApplyToEachFileRemoval = dlg.IsCheckBoxChecked();
+                    // For multiple selections, use a YesToAll dialog
+                    wxRichMessageDialog dlg(wxTheApp->GetTopWindow(), message, _("Confirm"),
+                                            wxYES_NO | wxYES_DEFAULT | wxCANCEL | wxCENTER | wxICON_QUESTION);
+                    dlg.ShowCheckBox(_("Remember my answer and apply it all files"), false);
+                    result = dlg.ShowModal();
+                    ApplyToEachFileRemoval = dlg.IsCheckBoxChecked();
 
-                    } else {
-                        result = wxMessageBox(message, _("Are you sure?"), wxYES_NO | wxICON_QUESTION, this);
+                } else {
+                    result = wxMessageBox(message, _("Are you sure?"), wxYES_NO | wxICON_QUESTION, this);
+                }
+            }
+            if(result == wxID_CANCEL || (result == wxID_NO && ApplyToEachFileRemoval == true)) {
+                return; // Assume Cancel or No+ApplyToEachFileRemoval means for folders etc too, not just files
+            }
+            if(result == wxID_YES || result == wxYES) {
+                wxTreeItemId parent = GetItemParent(itemId);
+                if(parent.IsOk()) {
+                    wxString path = GetItemPath(parent);
+
+                    // Remove the file. Do not fire an event here, we will send a "bulk" event
+                    // with a list of all files removed
+                    wxString fullpathOfFileRemoved;
+                    CL_DEBUG("File removed %s", path);
+                    if(affectedProject.IsEmpty()) {
+                        affectedProject = path.BeforeFirst(':');
                     }
-                }
-                if(result == wxID_CANCEL || (result == wxID_NO && ApplyToEachFileRemoval == true)) {
-                    return; // Assume Cancel or No+ApplyToEachFileRemoval means for folders etc too, not just files
-                }
-                if(result == wxID_YES || result == wxYES) {
-                    wxTreeItemId parent = GetItemParent(item);
-                    if(parent.IsOk()) {
-                        wxString path = GetItemPath(parent);
 
-                        // Remove the file. Do not fire an event here, we will send a "bulk" event
-                        // with a list of all files removed
-                        wxString fullpathOfFileRemoved;
-                        CL_DEBUG("File removed %s", path);
-                        if(affectedProject.IsEmpty()) {
-                            affectedProject = path.BeforeFirst(wxT(':'));
+                    if(ManagerST::Get()->RemoveFile(projectItem.GetFile(), path, fullpathOfFileRemoved, false)) {
+                        filesRemoved.Add(fullpathOfFileRemoved);
+                    }
+
+                    wxString file_name(projectItem.GetFile());
+                    Delete(itemId);
+                    SendCmdEvent(wxEVT_FILE_VIEW_REFRESHED);
+
+                    int DeleteThisItemFromDisc = false;
+                    if(ApplyToEachFileDeletion == false) {
+                        wxString message;
+                        message << _("Do you also want to delete the file '") << name << _("' from disc?");
+                        if(!items.empty()) {
+                            // For multiple selections, use a YesToAll dialog
+                            wxRichMessageDialog dlg(EventNotifier::Get()->TopFrame(), message, _("Confirm"),
+                                                    wxYES_NO | wxNO_DEFAULT | wxCANCEL | wxCENTER | wxICON_QUESTION);
+                            dlg.ShowCheckBox(_("Remember my answer and apply it all files"), false);
+                            DeleteThisItemFromDisc = dlg.ShowModal();
+                            ApplyToEachFileDeletion = dlg.IsCheckBoxChecked();
+                        } else {
+                            DeleteThisItemFromDisc = ::PromptForYesNoCancelDialogWithCheckbox(
+                                message, "fileview_del_file_from_disc", _("Yes"), _("No"), _("Cancel"),
+                                _("Remember my answer and don't ask me again"),
+                                wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
                         }
+                    }
 
-                        if(ManagerST::Get()->RemoveFile(data->GetData().GetFile(), path, fullpathOfFileRemoved,
-                                                        false)) {
-                            filesRemoved.Add(fullpathOfFileRemoved);
-                        }
+                    if((DeleteThisItemFromDisc == wxID_YES || DeleteThisItemFromDisc == wxYES) || AlsoDeleteFromDisc) {
+                        AlsoDeleteFromDisc = ApplyToEachFileDeletion; // If we're here, ApplyToAll means delete all
 
-                        wxString file_name(data->GetData().GetFile());
-                        Delete(item);
-                        SendCmdEvent(wxEVT_FILE_VIEW_REFRESHED);
-
-                        int DeleteThisItemFromDisc = false;
-                        if(ApplyToEachFileDeletion == false) {
-                            wxString message;
-                            message << _("Do you also want to delete the file '") << name << _("' from disc?");
-                            if((num > 1) && ((i + 1) < num)) {
-                                // For multiple selections, use a YesToAll dialog
-                                wxRichMessageDialog dlg(EventNotifier::Get()->TopFrame(), message, _("Confirm"),
-                                                        wxYES_NO | wxNO_DEFAULT | wxCANCEL | wxCENTER |
-                                                            wxICON_QUESTION);
-                                dlg.ShowCheckBox(_("Remember my answer and apply it all files"), false);
-                                DeleteThisItemFromDisc = dlg.ShowModal();
-                                ApplyToEachFileDeletion = dlg.IsCheckBoxChecked();
+                        wxString message(_("An error occurred during file removal. Maybe it has been already "
+                                           "deleted or you don't have the necessary permissions"));
+                        if(wxDirExists(name)) {
+                            if(!wxFileName::Rmdir(name, wxPATH_RMDIR_RECURSIVE)) {
+                                wxMessageBox(message, _("Error"), wxOK | wxICON_ERROR, this);
                             } else {
-                                DeleteThisItemFromDisc = ::PromptForYesNoCancelDialogWithCheckbox(
-                                    message, "fileview_del_file_from_disc", _("Yes"), _("No"), _("Cancel"),
-                                    _("Remember my answer and don't ask me again"),
-                                    wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
+                                // Folder was removed from the disc, notify about it
+                                clFileSystemEvent rmEvent(wxEVT_FOLDER_DELETED);
+                                rmEvent.GetPaths().Add(name);
+                                rmEvent.SetEventObject(this);
+                                EventNotifier::Get()->AddPendingEvent(rmEvent);
                             }
-                        }
-
-                        if((DeleteThisItemFromDisc == wxID_YES || DeleteThisItemFromDisc == wxYES) ||
-                           AlsoDeleteFromDisc) {
-                            AlsoDeleteFromDisc = ApplyToEachFileDeletion; // If we're here, ApplyToAll means delete all
-
-                            wxString message(_("An error occurred during file removal. Maybe it has been already "
-                                               "deleted or you don't have the necessary permissions"));
-                            if(wxDirExists(name)) {
-                                if(!wxFileName::Rmdir(name, wxPATH_RMDIR_RECURSIVE)) {
+                        } else {
+                            if(wxFileName::FileExists(file_name)) {
+                                if(!clRemoveFile(file_name)) {
                                     wxMessageBox(message, _("Error"), wxOK | wxICON_ERROR, this);
                                 } else {
-                                    // Folder was removed from the disc, notify about it
-                                    clFileSystemEvent rmEvent(wxEVT_FOLDER_DELETED);
-                                    rmEvent.GetPaths().Add(name);
+                                    // File was removed from the disc, notify about it
+                                    clFileSystemEvent rmEvent(wxEVT_FILE_DELETED);
+                                    rmEvent.GetPaths().Add(file_name);
                                     rmEvent.SetEventObject(this);
                                     EventNotifier::Get()->AddPendingEvent(rmEvent);
                                 }
-                            } else {
-                                if(wxFileName::FileExists(file_name)) {
-                                    if(!clRemoveFile(file_name)) {
-                                        wxMessageBox(message, _("Error"), wxOK | wxICON_ERROR, this);
-                                    } else {
-                                        // File was removed from the disc, notify about it
-                                        clFileSystemEvent rmEvent(wxEVT_FILE_DELETED);
-                                        rmEvent.GetPaths().Add(file_name);
-                                        rmEvent.SetEventObject(this);
-                                        EventNotifier::Get()->AddPendingEvent(rmEvent);
-                                    }
-                                }
                             }
                         }
                     }
                 }
-            } break;
-            case ProjectItem::TypeVirtualDirectory:
-                DoRemoveVirtualFolder(item);
-                break;
-            case ProjectItem::TypeProject:
-                DoRemoveProject(name);
-                break;
-            default:
-                break;
+            }
+        } break;
+        case ProjectItem::TypeVirtualDirectory:
+            eraseChildren = DoRemoveVirtualFolder(itemId);
+            break;
+        case ProjectItem::TypeProject:
+            eraseChildren = DoRemoveProject(name);
+            break;
+        default:
+            break;
+        }
+
+        // Removing a VD or project will remove its children as well
+        // We need to erase those children from this iteration too (if any)
+        if(eraseChildren) {
+            std::deque<std::tuple<wxTreeItemId, wxString, ProjectItem>>::iterator iter = items.begin();
+            while(iter != items.end()) {
+                if(std::get<2>(*iter).Key().StartsWith(projectItem.Key())) {
+                    iter = items.erase(iter);
+                } else {
+                    ++iter;
+                }
             }
         }
     }
@@ -960,26 +971,28 @@ void FileViewTree::DoRemoveItems()
     }
 }
 
-void FileViewTree::DoRemoveVirtualFolder(wxTreeItemId& item)
+bool FileViewTree::DoRemoveVirtualFolder(const wxTreeItemId& item)
 {
     wxString name = GetItemText(item);
-    wxString message(wxT("'") + name + wxT("'"));
+    wxString message("'" + name + "'");
     message << _(" and all its contents will be removed from the project.");
-
-    if(wxMessageBox(message, _("CodeLite"), wxYES_NO | wxICON_WARNING) == wxYES) {
-        wxString path = GetItemPath(item);
-        ManagerST::Get()->RemoveVirtualDirectory(path);
-
-        DeleteChildren(item);
-        Delete(item);
-        SendCmdEvent(wxEVT_FILE_VIEW_REFRESHED);
+    if(wxMessageBox(message, _("CodeLite"), wxYES_NO | wxICON_WARNING) != wxYES) {
+        return false;
     }
+
+    wxString path = GetItemPath(item);
+    ManagerST::Get()->RemoveVirtualDirectory(path);
+
+    DeleteChildren(item);
+    Delete(item);
+    SendCmdEvent(wxEVT_FILE_VIEW_REFRESHED);
+    return true;
 }
 
 void FileViewTree::OnNewVirtualFolder(wxCommandEvent& WXUNUSED(event))
 {
     static int count = 0;
-    wxString defaultName(wxT("NewDirectory"));
+    wxString defaultName("NewDirectory");
     defaultName << count++;
 
     wxTreeItemId item = GetSingleSelection();
@@ -995,11 +1008,12 @@ void FileViewTree::OnNewVirtualFolder(wxCommandEvent& WXUNUSED(event))
 
 wxTreeItemId FileViewTree::DoAddVirtualFolder(wxTreeItemId& parent, const wxString& text)
 {
-    wxString path = GetItemPath(parent) + wxT(":") + text;
+    wxString path = GetItemPath(parent) + ":" + text;
 
     // Virtual directory already exists?
-    if(ManagerST::Get()->AddVirtualDirectory(path, true) == Manager::VD_EXISTS)
+    if(ManagerST::Get()->AddVirtualDirectory(path, true) == Manager::VD_EXISTS) {
         return wxTreeItemId();
+    }
 
     wxTreeItemId item;
     ProjectItem itemData(path, text, wxEmptyString, ProjectItem::TypeVirtualDirectory);
@@ -1023,12 +1037,14 @@ wxString FileViewTree::GetItemPath(const wxTreeItemId& item, const wxChar& sep) 
     wxTreeItemId p = GetItemParent(item);
     while(true) {
 
-        if(!p.IsOk() || p == GetRootItem())
+        if(!p.IsOk() || p == GetRootItem()) {
             break;
+        }
 
         FilewViewTreeItemData* data = static_cast<FilewViewTreeItemData*>(GetItemData(p));
-        if(!data)
+        if(!data) {
             break;
+        }
 
         if(data->GetData().GetKind() == ProjectItem::TypeWorkspaceFolder) {
             // We reached the top level
@@ -1109,19 +1125,22 @@ void FileViewTree::OnProjectProperties(wxCommandEvent& WXUNUSED(event))
     }
 }
 
-void FileViewTree::DoRemoveProject(const wxString& name)
+bool FileViewTree::DoRemoveProject(const wxString& name)
 {
     wxString message(_("You are about to remove project '"));
-    message << name << wxT("' ");
+    message << name << "' ";
     message << _(" from the workspace, click 'Yes' to proceed or 'No' to abort.");
-    if(wxMessageBox(message, _("Confirm"), wxYES_NO) == wxYES) {
-        ManagerST::Get()->RemoveProject(name, true);
-
-        // Remove the project from the cache
-        if(m_projectsMap.count(name)) {
-            m_projectsMap.erase(name);
-        }
+    if(wxMessageBox(message, _("Confirm"), wxYES_NO) != wxYES) {
+        return false;
     }
+
+    ManagerST::Get()->RemoveProject(name, true);
+
+    // Remove the project from the cache
+    if(m_projectsMap.count(name)) {
+        m_projectsMap.erase(name);
+    }
+    return true;
 }
 
 int FileViewTree::OnCompareItems(const wxTreeItemId& item1, const wxTreeItemId& item2)
@@ -1129,21 +1148,21 @@ int FileViewTree::OnCompareItems(const wxTreeItemId& item1, const wxTreeItemId& 
     // used for SortChildren, reroute to our sort routine
     FilewViewTreeItemData *a = (FilewViewTreeItemData*)GetItemData(item1),
                           *b = (FilewViewTreeItemData*)GetItemData(item2);
-    if(a && b)
+    if(a && b) {
         return OnCompareItems(a, b);
-
+    }
     return 0;
 }
 
 int FileViewTree::OnCompareItems(const FilewViewTreeItemData* a, const FilewViewTreeItemData* b)
 {
     // if dir and other is not, dir has preference
-    if(a->GetData().GetKind() == ProjectItem::TypeVirtualDirectory && b->GetData().GetKind() == ProjectItem::TypeFile)
+    if(a->GetData().GetKind() == ProjectItem::TypeVirtualDirectory && b->GetData().GetKind() == ProjectItem::TypeFile) {
         return -1;
-    else if(b->GetData().GetKind() == ProjectItem::TypeVirtualDirectory &&
-            a->GetData().GetKind() == ProjectItem::TypeFile)
+    } else if(b->GetData().GetKind() == ProjectItem::TypeVirtualDirectory &&
+              a->GetData().GetKind() == ProjectItem::TypeFile) {
         return 1;
-
+    }
     // else let ascii fight it out
     return a->GetData().GetDisplayName().CmpNoCase(b->GetData().GetDisplayName());
 }
@@ -1208,7 +1227,7 @@ void FileViewTree::OnClean(wxCommandEvent& event)
 
         if(bldConf && bldConf->IsCustomBuild()) {
             buildInfo.SetKind(QueueCommand::kCustomBuild);
-            buildInfo.SetCustomBuildTarget(wxT("Clean"));
+            buildInfo.SetCustomBuildTarget("Clean");
         }
         ManagerST::Get()->PushQueueCommand(buildInfo);
         ManagerST::Get()->ProcessCommandQueue();
@@ -1232,7 +1251,7 @@ void FileViewTree::OnBuild(wxCommandEvent& event)
         QueueCommand buildInfo(projectName, conf, false, QueueCommand::kBuild);
         if(bldConf && bldConf->IsCustomBuild()) {
             buildInfo.SetKind(QueueCommand::kCustomBuild);
-            buildInfo.SetCustomBuildTarget(wxT("Build"));
+            buildInfo.SetCustomBuildTarget("Build");
         }
         ManagerST::Get()->PushQueueCommand(buildInfo);
         ManagerST::Get()->ProcessCommandQueue();
@@ -1251,8 +1270,8 @@ void FileViewTree::OnCompileItem(wxCommandEvent& e)
             if(parent.IsOk()) {
                 wxString logmsg;
                 wxString path = GetItemPath(parent);
-                wxString proj = path.BeforeFirst(wxT(':'));
-                logmsg << _("Compiling file: ") << data->GetData().GetFile() << _(" of project ") << proj << wxT("\n");
+                wxString proj = path.BeforeFirst(':');
+                logmsg << _("Compiling file: ") << data->GetData().GetFile() << _(" of project ") << proj << "\n";
                 mgr->CompileFile(proj, data->GetData().GetFile());
             }
         }
@@ -1271,9 +1290,8 @@ void FileViewTree::OnPreprocessItem(wxCommandEvent& e)
             if(parent.IsOk()) {
                 wxString logmsg;
                 wxString path = GetItemPath(parent);
-                wxString proj = path.BeforeFirst(wxT(':'));
-                logmsg << _("Preprocessing file: ") << data->GetData().GetFile() << _(" of project ") << proj
-                       << wxT("\n");
+                wxString proj = path.BeforeFirst(':');
+                logmsg << _("Preprocessing file: ") << data->GetData().GetFile() << _(" of project ") << proj << "\n";
                 mgr->CompileFile(proj, data->GetData().GetFile(), true);
             }
         }
@@ -1443,12 +1461,14 @@ wxTreeItemId FileViewTree::FindItemByPath(wxTreeItemId& projectHTI, const wxStri
         return wxTreeItemId();
     }
 
-    if(!ItemHasChildren(projectHTI))
+    if(!ItemHasChildren(projectHTI)) {
         return wxTreeItemId();
+    }
     wxString projectName = clCxxWorkspaceST::Get()->GetProjectFromFile(fileName);
     ProjectPtr proj = clCxxWorkspaceST::Get()->GetProject(projectName);
-    if(!proj)
+    if(!proj) {
         return wxTreeItemId();
+    }
 
     wxString vdFullPath = proj->GetVDByFileName(fileName);
 
@@ -1510,16 +1530,18 @@ wxTreeItemId FileViewTree::FindItemByPath(wxTreeItemId& projectHTI, const wxStri
 
 wxTreeItemId FileViewTree::ItemByFullPath(const wxString& fullPath)
 {
-    if(!ItemHasChildren(GetRootItem()))
+    if(!ItemHasChildren(GetRootItem())) {
         return wxTreeItemId();
+    }
 
     // Locate the project item
     wxString projname = fullPath.BeforeFirst(':');
-    if(m_projectsMap.count(projname) == 0)
+    if(m_projectsMap.count(projname) == 0) {
         return wxTreeItemId();
+    }
 
     wxTreeItemId parent = GetItemParent(m_projectsMap[projname]);
-    wxArrayString texts = wxStringTokenize(fullPath, wxT(":"), wxTOKEN_STRTOK);
+    wxArrayString texts = wxStringTokenize(fullPath, ":", wxTOKEN_STRTOK);
     for(size_t i = 0; i < texts.GetCount(); i++) {
         parent = DoGetItemByText(parent, texts.Item(i));
         if(parent.IsOk() == false) {
@@ -1539,7 +1561,7 @@ void FileViewTree::OnImportDirectory(wxCommandEvent& e)
 
     wxString vdPath = GetItemPath(item);
     wxString project;
-    project = vdPath.BeforeFirst(wxT(':'));
+    project = vdPath.BeforeFirst(':');
     ProjectPtr proj = ManagerST::Get()->GetProject(project);
 
     bool extlessFiles(false);
@@ -1549,8 +1571,9 @@ void FileViewTree::OnImportDirectory(wxCommandEvent& e)
     wxString filespec;
 
     ImportFilesDialogNew dlg(clMainFrame::Get());
-    if(dlg.ShowModal() != wxID_OK)
+    if(dlg.ShowModal() != wxID_OK) {
         return;
+    }
 
     extlessFiles = dlg.ExtlessFiles();
     dlg.GetDirectories(dirs);
@@ -1569,18 +1592,18 @@ void FileViewTree::OnImportDirectory(wxCommandEvent& e)
 void FileViewTree::DoImportFolder(ProjectPtr proj, const wxString& baseDir, const wxArrayString& all_files,
                                   const wxString& filespec, bool extlessFiles)
 {
-    wxStringTokenizer tok(filespec, wxT(";"));
+    wxStringTokenizer tok(filespec, ";");
     wxStringSet_t specMap;
     while(tok.HasMoreTokens()) {
         wxString v = tok.GetNextToken();
         // Cater for *.*, and also for idiots asking for *.foo;*.*
-        if(v == wxT("*.*")) {
+        if(v == "*.*") {
             // Remove any previous entries, and stop looking for more: an empty specMap signals *.*
             specMap.clear();
             break;
         }
-        v = v.AfterLast(wxT('*'));
-        v = v.AfterLast(wxT('.')).MakeLower();
+        v = v.AfterLast('*');
+        v = v.AfterLast('.').MakeLower();
         specMap.insert(v);
     }
 
@@ -1594,21 +1617,22 @@ void FileViewTree::DoImportFolder(ProjectPtr proj, const wxString& baseDir, cons
         bool cont = true;
         for(size_t j = 0; j < dirs.GetCount() && cont; j++) {
             wxString filepath = fn.GetPath();
-            if(dirs.Item(j) == wxT(".svn") || dirs.Item(j) == wxT(".cvs") || dirs.Item(j) == wxT(".arch-ids") ||
-               dirs.Item(j) == wxT("arch-inventory") || dirs.Item(j) == wxT("autom4te.cache") ||
-               dirs.Item(j) == wxT("BitKeeper") || dirs.Item(j) == wxT(".bzr") || dirs.Item(j) == wxT(".bzrignore") ||
-               dirs.Item(j) == wxT("CVS") || dirs.Item(j) == wxT(".cvsignore") || dirs.Item(j) == wxT("_darcs") ||
-               dirs.Item(j) == wxT(".deps") || dirs.Item(j) == wxT("EIFGEN") || dirs.Item(j) == wxT(".git") ||
-               dirs.Item(j) == wxT(".hg") || dirs.Item(j) == wxT("PENDING") || dirs.Item(j) == wxT("RCS") ||
-               dirs.Item(j) == wxT("RESYNC") || dirs.Item(j) == wxT("SCCS") || dirs.Item(j) == wxT("{arch}")) {
+            if(dirs.Item(j) == ".svn" || dirs.Item(j) == ".cvs" || dirs.Item(j) == ".arch-ids" ||
+               dirs.Item(j) == "arch-inventory" || dirs.Item(j) == "autom4te.cache" || dirs.Item(j) == "BitKeeper" ||
+               dirs.Item(j) == ".bzr" || dirs.Item(j) == ".bzrignore" || dirs.Item(j) == "CVS" ||
+               dirs.Item(j) == ".cvsignore" || dirs.Item(j) == "_darcs" || dirs.Item(j) == ".deps" ||
+               dirs.Item(j) == "EIFGEN" || dirs.Item(j) == ".git" || dirs.Item(j) == ".hg" ||
+               dirs.Item(j) == "PENDING" || dirs.Item(j) == "RCS" || dirs.Item(j) == "RESYNC" ||
+               dirs.Item(j) == "SCCS" || dirs.Item(j) == "{arch}") {
                 cont = false;
                 break;
             }
         }
 
         // skip the directory?
-        if(!cont)
+        if(!cont) {
             continue;
+        }
 
         if(specMap.empty()) {
             files.Add(all_files.Item(i));
@@ -1623,7 +1647,7 @@ void FileViewTree::DoImportFolder(ProjectPtr proj, const wxString& baseDir, cons
 
     wxString path = baseDir;
     //{ Fixe bug 2847625
-    if(path.EndsWith(wxT("/")) || path.EndsWith(wxT("\\"))) {
+    if(path.EndsWith("/") || path.EndsWith("\\")) {
         path.RemoveLast();
     } //} Fixe bug 2847625
 
@@ -1637,7 +1661,7 @@ void FileViewTree::DoImportFolder(ProjectPtr proj, const wxString& baseDir, cons
     proj->BeginTranscation();
     {
         // Create a progress dialog
-        clProgressDlg* prgDlg = new clProgressDlg(NULL, _("Importing files ..."), wxT(""), (int)files.GetCount());
+        clProgressDlg* prgDlg = new clProgressDlg(NULL, _("Importing files ..."), "", (int)files.GetCount());
 
         // get list of files
         for(size_t i = 0; i < files.GetCount(); i++) {
@@ -1655,8 +1679,8 @@ void FileViewTree::DoImportFolder(ProjectPtr proj, const wxString& baseDir, cons
             fn.MakeRelativeTo(path);
 
             wxString relativePath = fn.GetPath();
-            relativePath.Replace(wxT("/"), wxT(":"));
-            relativePath.Replace(wxT("\\"), wxT(":"));
+            relativePath.Replace("/", ":");
+            relativePath.Replace("\\", ":");
 
             if(relativePath.IsEmpty()) {
                 // the file is probably under the root, add it under
@@ -1664,7 +1688,7 @@ void FileViewTree::DoImportFolder(ProjectPtr proj, const wxString& baseDir, cons
                 // root folder
                 relativePath = rootPath.GetName();
             }
-            // relativePath.Append(wxT(":"));
+            // relativePath.Append(":");
 
             fvitem.virtualDir = relativePath;
             DoAddItem(proj, fvitem);
@@ -1710,7 +1734,7 @@ void FileViewTree::RedefineProjFiles(ProjectPtr proj, const wxString& path, std:
     proj->BeginTranscation();
     {
         // Create a progress dialog
-        clProgressDlg* prgDlg = new clProgressDlg(NULL, _("Importing files ..."), wxT(""), (int)files.size());
+        clProgressDlg* prgDlg = new clProgressDlg(NULL, _("Importing files ..."), "", (int)files.size());
 
         proj->ClearAllVirtDirs();
 
@@ -1725,9 +1749,9 @@ void FileViewTree::RedefineProjFiles(ProjectPtr proj, const wxString& path, std:
             fn.MakeRelativeTo(path);
 
             // anchor all files to a base folder
-            relativePath = rootPath.GetName() + wxT(":") + fn.GetPath() + wxT(":");
-            relativePath.Replace(wxT("/"), wxT(":"));
-            relativePath.Replace(wxT("\\"), wxT(":"));
+            relativePath = rootPath.GetName() + ":" + fn.GetPath() + ":";
+            relativePath.Replace("/", ":");
+            relativePath.Replace("\\", ":");
 
             fvitem.virtualDir = relativePath;
             DoAddItem(proj, fvitem);
@@ -1791,7 +1815,7 @@ void FileViewTree::OnRenameItem(wxCommandEvent& e)
             if(parent.IsOk()) {
 
                 wxString path = GetItemPath(parent);
-                wxString proj = path.BeforeFirst(wxT(':'));
+                wxString proj = path.BeforeFirst(':');
 
                 ProjectPtr p = ManagerST::Get()->GetProject(proj);
                 if(p) {
@@ -1842,9 +1866,9 @@ void FileViewTree::OnRenameVirtualFolder(wxCommandEvent& e)
 
         // locate the project
         wxString path = GetItemPath(item);
-        wxString proj = path.BeforeFirst(wxT(':'));
+        wxString proj = path.BeforeFirst(':');
 
-        path = path.AfterFirst(wxT(':'));
+        path = path.AfterFirst(':');
         ProjectPtr p = ManagerST::Get()->GetProject(proj);
         if(!p) {
             clLogMessage(_("failed to rename virtual folder: ") + path + _(", reason: could not locate project ") +
@@ -1880,7 +1904,7 @@ void FileViewTree::OnReBuild(wxCommandEvent& event)
             QueueCommand buildInfo(projectName, conf, false, QueueCommand::kRebuild);
             if(bldConf && bldConf->IsCustomBuild()) {
                 buildInfo.SetKind(QueueCommand::kCustomBuild);
-                buildInfo.SetCustomBuildTarget(wxT("Rebuild"));
+                buildInfo.SetCustomBuildTarget("Rebuild");
             }
 
             ManagerST::Get()->PushQueueCommand(buildInfo);
@@ -1916,23 +1940,24 @@ wxTreeItemId FileViewTree::DoGetItemByText(const wxTreeItemId& parent, const wxS
 bool FileViewTree::CreateVirtualDirectory(const wxString& parentPath, const wxString& vdName)
 {
     // try to locate that VD first, if it exists, do nothing
-    wxTreeItemId item = ItemByFullPath(wxString::Format(wxT("%s:%s"), parentPath.c_str(), vdName.c_str()));
+    wxTreeItemId item = ItemByFullPath(wxString::Format("%s:%s", parentPath.c_str(), vdName.c_str()));
     if(item.IsOk()) {
         return true;
     }
 
-    wxString project = parentPath.BeforeFirst(wxT(':'));
-    wxString parentVDs = parentPath.AfterFirst(wxT(':'));
-    wxArrayString vds = ::wxStringTokenize(parentVDs, wxT(":"), wxTOKEN_STRTOK);
+    wxString project = parentPath.BeforeFirst(':');
+    wxString parentVDs = parentPath.AfterFirst(':');
+    wxArrayString vds = ::wxStringTokenize(parentVDs, ":", wxTOKEN_STRTOK);
 
     wxTreeItemId curItem = ItemByFullPath(project);
-    if(!curItem.IsOk())
+    if(!curItem.IsOk()) {
         // Could not locate the project item...
         return false;
+    }
 
     wxString path = project;
     for(size_t i = 0; i < vds.GetCount(); i++) {
-        path << wxT(":") << vds.Item(i);
+        path << ":" << vds.Item(i);
         wxTreeItemId tmpItem = ItemByFullPath(path);
         if(!tmpItem.IsOk()) {
             curItem = DoAddVirtualFolder(curItem, vds.Item(i));
@@ -1945,8 +1970,9 @@ bool FileViewTree::CreateVirtualDirectory(const wxString& parentPath, const wxSt
         }
     }
 
-    if(!curItem.IsOk())
+    if(!curItem.IsOk()) {
         return false;
+    }
 
     DoAddVirtualFolder(curItem, vdName);
     return true;
@@ -1978,7 +2004,7 @@ bool FileViewTree::DoAddNewItem(wxTreeItemId& item, const wxString& filename, co
     wxFileName fnFileName(filename);
     wxString path(vdFullpath);
 
-    path += wxT(":");
+    path += ":";
     path += fnFileName.GetFullName();
     ProjectItem projItem(path, fnFileName.GetFullName(), fnFileName.GetFullPath(), ProjectItem::TypeFile);
 
@@ -2010,7 +2036,7 @@ void FileViewTree::OnRebuildProjectOnly(wxCommandEvent& event)
         QueueCommand info(projectName, conf, true, QueueCommand::kRebuild);
         if(bldConf && bldConf->IsCustomBuild()) {
             info.SetKind(QueueCommand::kCustomBuild);
-            info.SetCustomBuildTarget(wxT("Rebuild"));
+            info.SetCustomBuildTarget("Rebuild");
         }
 
         ManagerST::Get()->PushQueueCommand(info);
@@ -2065,7 +2091,7 @@ void FileViewTree::OnOpenWithDefaultApplication(wxCommandEvent& event)
 #ifdef __WXGTK__
             if(!bFoundCommand && itemData && itemData->GetData().GetKind() == ProjectItem::TypeFile) {
                 // All hell break loose, try xdg-open
-                wxString cmd = wxString::Format(wxT("xdg-open \"%s\""), fn.GetFullPath().c_str());
+                wxString cmd = wxString::Format("xdg-open \"%s\"", fn.GetFullPath().c_str());
                 wxExecute(cmd);
             }
 #endif
@@ -2131,7 +2157,7 @@ void FileViewTree::OnBuildProjectOnlyInternal(wxCommandEvent& e)
     QueueCommand info(projectName, conf, true, QueueCommand::kBuild);
     if(bldConf && bldConf->IsCustomBuild()) {
         info.SetKind(QueueCommand::kCustomBuild);
-        info.SetCustomBuildTarget(wxT("Build"));
+        info.SetCustomBuildTarget("Build");
     }
     ManagerST::Get()->PushQueueCommand(info);
     ManagerST::Get()->ProcessCommandQueue();
@@ -2155,7 +2181,7 @@ void FileViewTree::OnCleanProjectOnlyInternal(wxCommandEvent& e)
     QueueCommand info(projectName, conf, true, QueueCommand::kClean);
     if(bldConf && bldConf->IsCustomBuild()) {
         info.SetKind(QueueCommand::kCustomBuild);
-        info.SetCustomBuildTarget(wxT("Clean"));
+        info.SetCustomBuildTarget("Clean");
     }
 
     ManagerST::Get()->PushQueueCommand(info);
@@ -2217,8 +2243,9 @@ bool FileViewTree::IsFileExcludedFromBuild(const wxTreeItemId& item) const
 void FileViewTree::OnSelectionChanged(wxTreeEvent& e)
 {
     e.Skip();
-    if(!e.GetItem().IsOk())
+    if(!e.GetItem().IsOk()) {
         return;
+    }
 
     FilewViewTreeItemData* data = dynamic_cast<FilewViewTreeItemData*>(GetItemData(e.GetItem()));
     if(data && data->GetData().GetKind() == ProjectItem::TypeProject) {
@@ -2258,8 +2285,9 @@ void FileViewTree::OnRenameProject(wxCommandEvent& event)
 
         wxString oldname = data->GetData().GetDisplayName();
         // If the new name and the old name are the same, do nothing
-        if(oldname == newname)
+        if(oldname == newname) {
             return;
+        }
 
         // If a project with this name already exists, abort
         if(m_projectsMap.count(newname)) {
@@ -2378,8 +2406,9 @@ void FileViewTree::OnFolderDropped(clCommandEvent& event)
     }
 
     // user cancelled?
-    if(projectName.IsEmpty())
+    if(projectName.IsEmpty()) {
         return;
+    }
     ProjectPtr pProj = clCxxWorkspaceST::Get()->GetProject(projectName);
     CHECK_PTR_RET(pProj);
 
@@ -2595,8 +2624,9 @@ void FileViewTree::UnselectAllProject()
 
 wxTreeItemId FileViewTree::AddWorkspaceFolder(const wxString& folderPath)
 {
-    if(folderPath.IsEmpty())
+    if(folderPath.IsEmpty()) {
         return GetRootItem();
+    }
     wxTreeItemId folderItemId;
     wxArrayString folders = ::wxStringTokenize(folderPath, "/", wxTOKEN_STRTOK);
     wxString current;
@@ -2692,8 +2722,9 @@ void FileViewTree::OnWorkspaceFolderDelete(wxCommandEvent& evt)
 void FileViewTree::OnWorkspaceNewWorkspaceFolder(wxCommandEvent& evt)
 {
     wxString name = ::wxGetTextFromUser(_("Enter folder name:"), _("New Folder Name"));
-    if(name.IsEmpty())
+    if(name.IsEmpty()) {
         return;
+    }
     clCxxWorkspaceST::Get()->CreateWorkspaceFolder(name);
     CallAfter(&FileViewTree::BuildTree);
 }
@@ -2704,8 +2735,9 @@ void FileViewTree::OnWorkspaceFolderNewFolder(wxCommandEvent& evt)
     CHECK_ITEM_RET(item);
 
     wxString name = ::wxGetTextFromUser(_("Enter folder name:"), _("New Folder Name"));
-    if(name.IsEmpty())
+    if(name.IsEmpty()) {
         return;
+    }
 
     // Append the path
     FilewViewTreeItemData* data = static_cast<FilewViewTreeItemData*>(GetItemData(item));
@@ -2717,8 +2749,9 @@ void FileViewTree::OnWorkspaceFolderNewFolder(wxCommandEvent& evt)
 
 void FileViewTree::DoBindEvents()
 {
-    if(m_eventsBound)
+    if(m_eventsBound) {
         return;
+    }
     wxFrame* frame = EventNotifier::Get()->TopFrame();
     frame->Bind(wxEVT_MENU, &FileViewTree::OnWorkspaceNewWorkspaceFolder, this, XRCID("add_workspace_folder"));
     frame->Bind(wxEVT_MENU, &FileViewTree::OnNewProject, this, XRCID("new_cxx_project"));
@@ -2791,8 +2824,9 @@ void FileViewTree::DoFilesEndDrag(wxTreeItemId& itemDst)
         FilewViewTreeItemData* srcData = static_cast<FilewViewTreeItemData*>(GetItemData(itemSrc));
 
         // no tree-item-data? skip this one
-        if(!srcData)
+        if(!srcData) {
             continue;
+        }
 
         wxString filename = srcData->GetData().GetFile();
 
@@ -2821,8 +2855,9 @@ void FileViewTree::DoProjectsEndDrag(wxTreeItemId& itemDst)
     CHECK_PTR_RET(cd);
 
     // Sanity
-    if(m_draggedProjects.IsEmpty())
+    if(m_draggedProjects.IsEmpty()) {
         return;
+    }
 
     wxString targetPath;
     if(cd->GetData().GetKind() == ProjectItem::TypeWorkspaceFolder) {
@@ -2849,13 +2884,15 @@ void FileViewTree::OnSetBgColourVirtualFolder(wxCommandEvent& e)
 
     // Get colour from the user
     wxColour col = ::wxGetColourFromUser(EventNotifier::Get()->TopFrame());
-    if(!col.IsOk())
+    if(!col.IsOk()) {
         return;
+    }
 
     // Read the current colours map
     FolderColour::Map_t coloursMap;
-    if(!clCxxWorkspaceST::Get()->GetLocalWorkspace()->GetFolderColours(coloursMap))
+    if(!clCxxWorkspaceST::Get()->GetLocalWorkspace()->GetFolderColours(coloursMap)) {
         return;
+    }
     // Colour the tree (it will also update the 'coloursMap' table)
     m_colourHelper->SetBgColour(item, col, coloursMap);
     // Store the settings
@@ -2870,8 +2907,9 @@ void FileViewTree::OnClearBgColourVirtualFolder(wxCommandEvent& e)
 
     // Fetch the current colours map
     FolderColour::Map_t coloursMap;
-    if(!clCxxWorkspaceST::Get()->GetLocalWorkspace()->GetFolderColours(coloursMap))
+    if(!clCxxWorkspaceST::Get()->GetLocalWorkspace()->GetFolderColours(coloursMap)) {
         return;
+    }
 
     // Colour the tree (it will also update the 'coloursMap' table)
     m_colourHelper->ResetBgColour(item, coloursMap);
@@ -2889,10 +2927,12 @@ void FileViewTree::OnAddProjectToWorkspaceFolder(wxCommandEvent& evt)
     FilewViewTreeItemData* data = static_cast<FilewViewTreeItemData*>(GetItemData(item));
     CHECK_PTR_RET(data);
 
-    if(data->GetData().GetKind() != ProjectItem::TypeWorkspaceFolder)
+    if(data->GetData().GetKind() != ProjectItem::TypeWorkspaceFolder) {
         return;
+    }
     wxString workspaceFolder = data->GetData().Key();
-    const wxString ALL(wxT("CodeLite Projects (*.project)|*.project|") wxT("All Files (*)|*"));
+    const wxString ALL("CodeLite Projects (*.project)|*.project|"
+                       "All Files (*)|*");
     wxFileDialog dlg(this, _("Open Project"), wxEmptyString, wxEmptyString, ALL, wxFD_OPEN | wxFD_FILE_MUST_EXIST,
                      wxDefaultPosition);
     if(dlg.ShowModal() == wxID_OK) {
@@ -2955,12 +2995,14 @@ void FileViewTree::DoAddChildren(const wxTreeItemId& parentItem)
     // int iconIndex = GetIconIndex(node->GetData());
 
     FilewViewTreeItemData* cd = ItemData(parentItem);
-    if(!cd)
+    if(!cd) {
         return;
+    }
 
     const ProjectItem& pi = cd->GetData();
-    if(!pi.IsVirtualFolder() && !pi.IsProject())
+    if(!pi.IsVirtualFolder() && !pi.IsProject()) {
         return;
+    }
 
     wxArrayString folders, files;
     wxString vdFullPath;

--- a/LiteEditor/fileview.h
+++ b/LiteEditor/fileview.h
@@ -25,15 +25,16 @@
 #ifndef FILE_VIEW_TREE_H
 #define FILE_VIEW_TREE_H
 
+#include "VirtualDirectoryColour.h"
 #include "clThemedTreeCtrl.h"
 #include "clTreeCtrlColourHelper.h"
 #include "imanager.h"
-#include "map"
 #include "pluginmanager.h"
 #include "project.h"
-#include "wx/treectrl.h"
 #include "wxStringHash.h"
-#include <VirtualDirectoryColour.h>
+
+#include <map>
+#include <wx/treectrl.h>
 
 class wxMenu;
 
@@ -244,11 +245,11 @@ private:
 
     void DoGetProjectIconIndex(const wxString& projectName, int& iconIndex, bool& fromPlugin);
     bool DoAddNewItem(wxTreeItemId& item, const wxString& filename, const wxString& vdFullpath);
-    void DoRemoveProject(const wxString& name);
+    bool DoRemoveProject(const wxString& name);
     void DoSetProjectActive(wxTreeItemId& item);
     void DoSetProjectActiveUI(wxTreeItemId& item);
     wxTreeItemId DoAddVirtualFolder(wxTreeItemId& parent, const wxString& text);
-    void DoRemoveVirtualFolder(wxTreeItemId& parent);
+    bool DoRemoveVirtualFolder(const wxTreeItemId& parent);
     void DoRemoveItems();
     void DoItemActivated(wxTreeItemId& item, wxEvent& event);
     void DoAddItem(ProjectPtr proj, const FileViewItem& item);

--- a/LiteEditor/pluginmanager.h
+++ b/LiteEditor/pluginmanager.h
@@ -27,17 +27,16 @@
 
 #include "debugger.h"
 #include "dynamiclibrary.h"
-#include "list"
-#include "map"
 #include "plugin.h"
 #include "plugindata.h"
 #include "project.h"
-#include "vector"
-#include "wx/string.h"
-#include "wx/treectrl.h"
 
+#include <list>
 #include <map>
 #include <set>
+#include <vector>
+#include <wx/string.h>
+#include <wx/treectrl.h>
 
 class clToolBar;
 class clEditorBar;
@@ -179,7 +178,7 @@ public:
     bool IsToolBarShown() const override;
     void ShowToolBar(bool show = true) override;
     void ShowBuildMenu(clToolBar* toolbar, wxWindowID buttonId) override;
-    void OpenFileAndAsyncExecute(const wxString& fileName, std::function<void(IEditor*)>&& func);
+    void OpenFileAndAsyncExecute(const wxString& fileName, std::function<void(IEditor*)>&& func) override;
     /**
      * @brief return list of all breakpoints
      */

--- a/Plugin/NewProjectDialog.cpp
+++ b/Plugin/NewProjectDialog.cpp
@@ -1,5 +1,6 @@
 #include "NewProjectDialog.h"
 
+#include "ICompilerLocator.h" // for COMPILER_FAMILY_VC
 #include "build_settings_config.h"
 #include "buildmanager.h"
 #include "clWorkspaceManager.h"
@@ -32,7 +33,8 @@ bool SetChoiceOptions(wxChoice* choice, const wxArrayString& values, const wxStr
     }
     return (match != wxNOT_FOUND);
 }
-wxString GENRATOR_UNIX = "CodeLite Makefile Generator - UNIX";
+wxString GENERATOR_UNIX = "CodeLite Makefile Generator - UNIX";
+wxString GENERATOR_NMAKE = "NMakefile for MSVC toolset";
 wxString CONFIG_LAST_SELECTED_CATEGORY = "NewProject/LastCategory";
 wxString CONFIG_LAST_SELECTED_TYPE = "NewProject/LastType";
 wxString CONFIG_USE_SEPARATE_FOLDER = "NewProjectDialog/UseSeparateFolder";
@@ -229,16 +231,33 @@ void NewProjectDialog::OnCompilerChanged(wxCommandEvent& event)
     static const wxRegEx re("(clang(arm)?|mingw|ucrt)(32|64)", wxRE_DEFAULT | wxRE_NOSUB);
     bool isUnixGeneratorRequired = newCompiler.Contains("MSYS") && !re.Matches(cxx);
 
-    if(isUnixGeneratorRequired && m_choiceBuild->GetStringSelection() != GENRATOR_UNIX) {
+    if(isUnixGeneratorRequired && m_choiceBuild->GetStringSelection() != GENERATOR_UNIX) {
         if(::wxMessageBox(
                _("MSYS based compiler requires a UNIX Makefile Generator\nWould like CodeLite to fix this for you?"),
                "CodeLite", wxICON_QUESTION | wxYES_NO | wxYES_DEFAULT) != wxYES) {
             return;
         }
-        int unixMakefiles = m_choiceBuild->FindString(GENRATOR_UNIX);
+        int unixMakefiles = m_choiceBuild->FindString(GENERATOR_UNIX);
         if(unixMakefiles != wxNOT_FOUND) {
             m_choiceBuild->SetSelection(unixMakefiles);
         }
+        return;
+    }
+
+    // Suggest NMake generator for Visual C++ family compilers
+    bool isNMakeGeneratorRequired = compiler->GetCompilerFamily() == COMPILER_FAMILY_VC;
+
+    if(isNMakeGeneratorRequired && m_choiceBuild->GetStringSelection() != GENERATOR_NMAKE) {
+        if(::wxMessageBox(
+               _("Visual C++ compiler requires an NMake generator\nWould like CodeLite to fix this for you?"),
+               "CodeLite", wxICON_QUESTION | wxYES_NO | wxYES_DEFAULT) != wxYES) {
+            return;
+        }
+        int nMakefiles = m_choiceBuild->FindString(GENERATOR_NMAKE);
+        if(nMakefiles != wxNOT_FOUND) {
+            m_choiceBuild->SetSelection(nMakefiles);
+        }
+        return;
     }
 #endif
 }

--- a/Plugin/clKeyboardManager.h
+++ b/Plugin/clKeyboardManager.h
@@ -138,6 +138,7 @@ class WXDLLIMPEXP_SDK clKeyboardManager : public wxEvtHandler
 {
 private:
     typedef std::list<wxFrame*> FrameList_t;
+    bool m_initialized = false;
     MenuItemDataMap_t m_accelTable;        // a set of accelerators configured by user
     MenuItemDataMap_t m_defaultAccelTable; // a set of default accelerators
     wxStringSet_t m_keyCodes;

--- a/Remoty/RemotySwitchToWorkspaceDlg.h
+++ b/Remoty/RemotySwitchToWorkspaceDlg.h
@@ -2,6 +2,7 @@
 #define REMOTYSWITCHTOWORKSPACEDLG_H
 #include "RemotyConfig.hpp"
 #include "RemotyUI.h"
+
 #include <unordered_map>
 #include <vector>
 
@@ -18,11 +19,11 @@ public:
     wxString GetAccount();
 
 protected:
-    virtual void OnPathChanged(wxCommandEvent& event);
-    virtual void OnChoiceWorkspaceType(wxCommandEvent& event);
-    virtual void OnBrowse(wxCommandEvent& event);
-    virtual void OnRemoteUI(wxUpdateUIEvent& event);
-    void OnOKUI(wxUpdateUIEvent& event) override;
+    virtual void OnPathChanged(wxCommandEvent& event) override;
+    virtual void OnChoiceWorkspaceType(wxCommandEvent& event) override;
+    virtual void OnBrowse(wxCommandEvent& event) override;
+    virtual void OnRemoteUI(wxUpdateUIEvent& event) override;
+    virtual void OnOKUI(wxUpdateUIEvent& event) override;
     void SyncPathToAccount();
     void InitialiseDialog();
 };

--- a/Runtime/rc/menu.xrc
+++ b/Runtime/rc/menu.xrc
@@ -997,10 +997,6 @@
             <label>Add an Existing Project</label>
         </object>
         <object class="wxMenuItem" name="wxID_SEPARATOR"/>
-        <object class="wxMenuItem" name="retag_workspace">
-            <label>Parse Workspace - Incremental</label>
-        </object>
-        <object class="wxMenuItem" name="wxID_SEPARATOR"/>
         <object class="wxMenuItem" name="close_workspace">
             <label>Close Workspace</label>
         </object>

--- a/SpellChecker/scGlobals.h
+++ b/SpellChecker/scGlobals.h
@@ -34,24 +34,23 @@
 // License:
 /////////////////////////////////////////////////////////////////////////////
 //------------------------------------------------------------
-static const wxString s_plugName( wxT( "SpellCheck" ) );
-static const wxString s_spOptions( wxT( "SpellCheckOptions" ) );
-static const wxString s_noEditor( wxT( "There is no active editor\n" ) );
-static const wxString s_codeLite( wxT( "CodeLite" ) );
-static const wxString s_userDict( wxT("userwords.dict") );
-static const wxString s_cppDelimiters( wxT( " \t\r\n.,?!@#$%^&*()-=+[]{}\\|_;:\"\'<>/~0123456789`" ) );
-static const wxString s_commentDelimiters( wxT( " \t\r\n.,?!@#$%^&*()-=+[]{}\\|;:\"\'<>/" ) );
-static const wxString s_defDelimiters( wxT( " \t\r\n.,?!@#$%^&*()-=+[]{}\\|;:\"\'<>/~0123456789`" ) );
-static const wxString s_dectHex( wxT("^0[xX]([0-9a-f]+|[0-9A-F]+)$"));
+static const wxString s_plugName("SpellCheck");
+static const wxString s_spOptions("SpellCheckOptions");
+static const wxString s_noEditor(wxTRANSLATE("There is no active editor\n"));
+static const wxString s_codeLite("CodeLite");
+static const wxString s_userDict("userwords.dict");
+static const wxString s_cppDelimiters(" \t\r\n.,?!@#$%^&*()-=+[]{}\\|_;:\"\'<>/~0123456789`");
+static const wxString s_commentDelimiters(" \t\r\n.,?!@#$%^&*()-=+[]{}\\|;:\"\'<>/");
+static const wxString s_defDelimiters(" \t\r\n.,?!@#$%^&*()-=+[]{}\\|;:\"\'<>/~0123456789`");
+static const wxString s_dectHex("^0[xX]([0-9a-f]+|[0-9A-F]+)$");
 
-static const wxString s_include( wxT( "#include" ) );
-static const wxString s_wsRegEx( wxT( "(\\\\[^\\\\])" ) );
+static const wxString s_include("#include");
+static const wxString s_wsRegEx("(\\\\[^\\\\])");
 
-static const wxString s_doCheckID(wxT("do_spell_check"));
-static const wxString s_contCheckID(wxT("do_continuous_check"));
+static const wxString s_doCheckID("do_spell_check");
+static const wxString s_contCheckID("do_continuous_check");
 
-static const wxString s_PLACE_HOLDER     = "@#)(";
+static const wxString s_PLACE_HOLDER = "@#)(";
 static const wxString s_DOUBLE_BACKSLASH = "\\\\";
 
 //------------------------------------------------------------
-

--- a/SpellChecker/spellcheck.cpp
+++ b/SpellChecker/spellcheck.cpp
@@ -33,31 +33,33 @@
 // Copyright:   2014 Frank Lichtner
 // License:
 /////////////////////////////////////////////////////////////////////////////
-#include "clToolBarButtonBase.h"
-#include "event_notifier.h"
-#include "globals.h"
-#include "wx/wxprec.h"
-#ifndef WX_PRECOMP
-#include "wx/wx.h"
-#endif
+#include "spellcheck.h"
 
 #include "IHunSpell.h"
 #include "SpellCheckerSettings.h"
+#include "clToolBarButtonBase.h"
 #include "ctags_manager.h"
+#include "event_notifier.h"
+#include "globals.h"
 #include "macros.h"
 #include "scGlobals.h"
-#include "spellcheck.h"
 #include "workspace.h"
 
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
 #include <wx/mstream.h>
 #include <wx/stc/stc.h>
 #include <wx/tokenzr.h>
 #include <wx/xrc/xmlres.h>
 
+// clang-format off
 #include "res/spellcheck16.b2c"
 #include "res/spellcheck22.b2c"
 //#include "res/contCheck16.b2c"
 //#include "res/contCheck22.b2c"
+// clang-format on
 
 namespace
 {
@@ -88,10 +90,10 @@ CL_PLUGIN_API IPlugin* CreatePlugin(IManager* manager)
 CL_PLUGIN_API PluginInfo* GetPluginInfo()
 {
     static PluginInfo info;
-    info.SetAuthor(wxT("Frank Lichtner"));
-    info.SetName(wxT("SpellCheck"));
+    info.SetAuthor("Frank Lichtner");
+    info.SetName("SpellCheck");
     info.SetDescription(_("CodeLite spell checker"));
-    info.SetVersion(wxT("v1.6"));
+    info.SetVersion("v1.6");
     return &info;
 }
 // ------------------------------------------------------------
@@ -141,16 +143,18 @@ void SpellCheck::Init()
     if(m_pEngine) {
         LoadSettings();
         wxString userDictPath = clStandardPaths::Get().GetUserDataDir();
-        userDictPath << wxFILE_SEP_PATH << wxT("spellcheck") << wxFILE_SEP_PATH;
+        userDictPath << wxFILE_SEP_PATH << "spellcheck" << wxFILE_SEP_PATH;
 
-        if(!wxFileName::DirExists(userDictPath))
+        if(!wxFileName::DirExists(userDictPath)) {
             wxFileName::Mkdir(userDictPath);
+        }
 
         m_pEngine->SetUserDictPath(userDictPath);
         m_pEngine->SetPlugIn(this);
 
-        if(!m_options.GetDictionaryFileName().IsEmpty())
+        if(!m_options.GetDictionaryFileName().IsEmpty()) {
             m_pEngine->InitEngine();
+        }
     }
 
     m_timer.Bind(wxEVT_TIMER, &SpellCheck::OnTimer, this);
@@ -246,8 +250,9 @@ void SpellCheck::AppendSubMenuItems(wxMenu& subMenu)
 // ------------------------------------------------------------
 void SpellCheck::UnPlug()
 {
-    if(m_timer.IsRunning())
+    if(m_timer.IsRunning()) {
         m_timer.Stop();
+    }
 }
 
 // ------------------------------------------------------------
@@ -257,7 +262,7 @@ IEditor* SpellCheck::GetEditor()
     IEditor* editor = m_mgr->GetActiveEditor();
 
     if(!editor) {
-        ::wxMessageBox(s_noEditor, s_codeLite, wxICON_WARNING | wxOK);
+        ::wxMessageBox(::wxGetTranslation(s_noEditor), s_codeLite, wxICON_WARNING | wxOK);
         return NULL;
     }
     return editor;
@@ -384,8 +389,9 @@ void SpellCheck::OnTimer(wxTimerEvent& e)
 {
     wxTopLevelWindow* pWnd = dynamic_cast<wxTopLevelWindow*>(GetTopWnd());
 
-    if(!pWnd->IsActive())
+    if(!pWnd->IsActive()) {
         return;
+    }
 
     IEditor* editor = m_mgr->GetActiveEditor();
     CHECK_PTR_RET(editor);
@@ -418,8 +424,9 @@ void SpellCheck::SetCheckContinuous(bool value)
             clGetManager()->GetToolBar()->Refresh();
         }
     } else {
-        if(m_timer.IsRunning())
+        if(m_timer.IsRunning()) {
             m_timer.Stop();
+        }
         if(btn) {
             btn->Check(false);
             clGetManager()->GetToolBar()->Refresh();

--- a/wxcrafter/wxcrafter.project
+++ b/wxcrafter/wxcrafter.project
@@ -917,6 +917,7 @@
         <IncludePath Value="../sdk/wxsqlite3/include"/>
         <IncludePath Value="../sdk/wxscintilla/include"/>
         <IncludePath Value="wxcLib/"/>
+        <Preprocessor Value="NDEBUG"/>
         <Preprocessor Value="__WX__"/>
         <Preprocessor Value="WXUSINGDLL"/>
         <Preprocessor Value="_WIN32_WINNT=0x501"/>
@@ -1095,6 +1096,7 @@
         <IncludePath Value="../sdk/wxsqlite3/include"/>
         <IncludePath Value="../sdk/wxscintilla/include"/>
         <IncludePath Value="wxcLib/"/>
+        <Preprocessor Value="NDEBUG"/>
       </Compiler>
       <Linker Options=";;$(shell wx-config --debug=no --unicode=yes --libs std,stc,propgrid,webview,ribbon,richtext)" Required="yes">
         <LibraryPath Value="$(WorkspacePath)/build-$(WorkspaceConfiguration)/lib"/>
@@ -1151,6 +1153,7 @@
         <IncludePath Value="../sdk/wxsqlite3/include"/>
         <IncludePath Value="../sdk/wxscintilla/include"/>
         <IncludePath Value="wxcLib/"/>
+        <Preprocessor Value="NDEBUG"/>
       </Compiler>
       <Linker Options=";-O2;$(shell wx-config --debug=no --unicode=yes --libs std,stc,propgrid,webview,ribbon)" Required="yes">
         <LibraryPath Value="$(WorkspacePath)/build-$(WorkspaceConfiguration)/lib"/>


### PR DESCRIPTION
* Fix build warning (`-Winconsistent-missing-override` and `-Wself-assign-field`).

* Code completion: Enable `Display type info tooltips` by default.
This is one of very important features expected in IDEs. I don't see any reason to make it disabled by default.

* Preferences > Misc: Fix broken restart prompt.
Changing toolbar icon size or locale setting should prompt to restart.

* New project dialog: Suggest NMake generator for Visual C++ family compilers.

* CCLP: Accept VC++ style `/I`, `/D`, `/FI` and `/std:` options.

* wxCrafter: Define `NDEBUG` in Windows release build.
Without this, wxCrafter uses `codelite-dbg` (or `wxcrafter-dbg` in standalone build) directory to store its configuration files.

* Workspace pane: Remove obsolete `Parse Workspace - Incremental` menu.
It was still left in workspace pane's right-click menu.

* SnipWiz: Fix keyboard shortcut is broken (#2934 regression).

* C++ file view: Fix crash by removing files and its parent VD together:
![fileview-remove-all](https://user-images.githubusercontent.com/32811754/150668708-3388bf8d-745b-4e71-a6bf-bb8c01ce12e3.png)

* Add a missing translation.