### PR TITLE
GNU make builder: Respect user-configured intermediate/output directory

### DIFF
--- a/Plugin/build_config.cpp
+++ b/Plugin/build_config.cpp
@@ -31,7 +31,6 @@
 #include "globals.h"
 #include "macros.h"
 #include "project.h"
-#include "wx/tokenzr.h"
 #include "wx_xml_compatibility.h"
 #include "xmlutils.h"
 
@@ -53,18 +52,18 @@ BuildConfig::BuildConfig(wxXmlNode* node)
     , m_buildSystem("Default")
 {
     if(node) {
-        m_name = XmlUtils::ReadString(node, wxT("Name"));
-        m_compilerType = XmlUtils::ReadString(node, wxT("CompilerType"));
-        m_debuggerType = XmlUtils::ReadString(node, wxT("DebuggerType"));
-        m_projectType = XmlUtils::ReadString(node, wxT("Type"));
+        m_name = XmlUtils::ReadString(node, "Name");
+        m_compilerType = XmlUtils::ReadString(node, "CompilerType");
+        m_debuggerType = XmlUtils::ReadString(node, "DebuggerType");
+        m_projectType = XmlUtils::ReadString(node, "Type");
         m_buildCmpWithGlobalSettings =
-            XmlUtils::ReadString(node, wxT("BuildCmpWithGlobalSettings"), APPEND_TO_GLOBAL_SETTINGS);
+            XmlUtils::ReadString(node, "BuildCmpWithGlobalSettings", APPEND_TO_GLOBAL_SETTINGS);
         m_buildLnkWithGlobalSettings =
-            XmlUtils::ReadString(node, wxT("BuildLnkWithGlobalSettings"), APPEND_TO_GLOBAL_SETTINGS);
+            XmlUtils::ReadString(node, "BuildLnkWithGlobalSettings", APPEND_TO_GLOBAL_SETTINGS);
         m_buildResWithGlobalSettings =
-            XmlUtils::ReadString(node, wxT("BuildResWithGlobalSettings"), APPEND_TO_GLOBAL_SETTINGS);
+            XmlUtils::ReadString(node, "BuildResWithGlobalSettings", APPEND_TO_GLOBAL_SETTINGS);
 
-        wxXmlNode* buildSystem = XmlUtils::FindFirstByTagName(node, wxT("BuildSystem"));
+        wxXmlNode* buildSystem = XmlUtils::FindFirstByTagName(node, "BuildSystem");
         if(buildSystem) {
             m_buildSystem = XmlUtils::ReadString(buildSystem, "Name", m_buildSystem);
             if(m_buildSystem == "CodeLite Make Generator") {
@@ -73,78 +72,78 @@ BuildConfig::BuildConfig(wxXmlNode* node)
             m_buildSystemArguments = buildSystem->GetNodeContent();
         }
 
-        wxXmlNode* completion = XmlUtils::FindFirstByTagName(node, wxT("Completion"));
+        wxXmlNode* completion = XmlUtils::FindFirstByTagName(node, "Completion");
         if(completion) {
-            wxXmlNode* search_paths = XmlUtils::FindFirstByTagName(completion, wxT("SearchPaths"));
+            wxXmlNode* search_paths = XmlUtils::FindFirstByTagName(completion, "SearchPaths");
             if(search_paths) {
                 m_ccSearchPaths = search_paths->GetNodeContent();
                 m_ccSearchPaths.Trim().Trim(false);
             }
 
-            wxXmlNode* clang_pp = XmlUtils::FindFirstByTagName(completion, wxT("ClangPP"));
+            wxXmlNode* clang_pp = XmlUtils::FindFirstByTagName(completion, "ClangPP");
             if(clang_pp) {
                 m_clangPPFlags = clang_pp->GetNodeContent();
                 m_clangPPFlags.Trim().Trim(false);
             }
 
-            wxXmlNode* clang_cmp_flags = XmlUtils::FindFirstByTagName(completion, wxT("ClangCmpFlags"));
+            wxXmlNode* clang_cmp_flags = XmlUtils::FindFirstByTagName(completion, "ClangCmpFlags");
             if(clang_cmp_flags) {
                 m_clangCmpFlags = clang_cmp_flags->GetNodeContent();
                 m_clangCmpFlags.Trim().Trim(false);
             }
 
-            wxXmlNode* clang_c_cmp_flags = XmlUtils::FindFirstByTagName(completion, wxT("ClangCmpFlagsC"));
+            wxXmlNode* clang_c_cmp_flags = XmlUtils::FindFirstByTagName(completion, "ClangCmpFlagsC");
             if(clang_c_cmp_flags) {
                 m_clangCmpFlagsC = clang_c_cmp_flags->GetNodeContent();
                 m_clangCmpFlagsC.Trim().Trim(false);
             }
 
-            wxXmlNode* clang_pch = XmlUtils::FindFirstByTagName(completion, wxT("ClangPCH"));
+            wxXmlNode* clang_pch = XmlUtils::FindFirstByTagName(completion, "ClangPCH");
             if(clang_pch) {
                 m_ccPCH = clang_pch->GetNodeContent();
                 m_ccPCH.Trim().Trim(false);
             }
 
-            m_clangC11 = XmlUtils::ReadBool(completion, wxT("EnableCpp11"));
-            m_clangC14 = XmlUtils::ReadBool(completion, wxT("EnableCpp14"));
+            m_clangC11 = XmlUtils::ReadBool(completion, "EnableCpp11");
+            m_clangC14 = XmlUtils::ReadBool(completion, "EnableCpp14");
         }
 
-        wxXmlNode* compile = XmlUtils::FindFirstByTagName(node, wxT("Compiler"));
+        wxXmlNode* compile = XmlUtils::FindFirstByTagName(node, "Compiler");
         if(compile) {
-            m_compilerRequired = XmlUtils::ReadBool(compile, wxT("Required"), true);
-            m_precompiledHeader = XmlUtils::ReadString(compile, wxT("PreCompiledHeader"));
-            m_pchInCommandLine = XmlUtils::ReadBool(compile, wxT("PCHInCommandLine"), false);
-            m_pchCompileFlags = XmlUtils::ReadString(compile, wxT("PCHFlags"));
+            m_compilerRequired = XmlUtils::ReadBool(compile, "Required", true);
+            m_precompiledHeader = XmlUtils::ReadString(compile, "PreCompiledHeader");
+            m_pchInCommandLine = XmlUtils::ReadBool(compile, "PCHInCommandLine", false);
+            m_pchCompileFlags = XmlUtils::ReadString(compile, "PCHFlags");
             m_pchPolicy = (ePCHPolicy)XmlUtils::ReadLong(compile, "PCHFlagsPolicy", m_pchPolicy);
         }
 
-        wxXmlNode* linker = XmlUtils::FindFirstByTagName(node, wxT("Linker"));
+        wxXmlNode* linker = XmlUtils::FindFirstByTagName(node, "Linker");
         if(linker) {
-            m_linkerRequired = XmlUtils::ReadBool(linker, wxT("Required"), true);
+            m_linkerRequired = XmlUtils::ReadBool(linker, "Required", true);
         }
 
-        wxXmlNode* resCmp = XmlUtils::FindFirstByTagName(node, wxT("ResourceCompiler"));
+        wxXmlNode* resCmp = XmlUtils::FindFirstByTagName(node, "ResourceCompiler");
         if(resCmp) {
-            m_isResCmpNeeded = XmlUtils::ReadBool(resCmp, wxT("Required"), true);
+            m_isResCmpNeeded = XmlUtils::ReadBool(resCmp, "Required", true);
         }
 
         // read the postbuild commands
-        wxXmlNode* debugger = XmlUtils::FindFirstByTagName(node, wxT("Debugger"));
+        wxXmlNode* debugger = XmlUtils::FindFirstByTagName(node, "Debugger");
         m_isDbgRemoteTarget = false;
 
         if(debugger) {
-            m_isDbgRemoteTarget = XmlUtils::ReadBool(debugger, wxT("IsRemote"));
-            m_dbgHostName = XmlUtils::ReadString(debugger, wxT("RemoteHostName"));
-            m_dbgHostPort = XmlUtils::ReadString(debugger, wxT("RemoteHostPort"));
-            m_debuggerPath = XmlUtils::ReadString(debugger, wxT("DebuggerPath"));
-            m_isDbgRemoteExtended = XmlUtils::ReadBool(debugger, wxT("IsExtended"));
+            m_isDbgRemoteTarget = XmlUtils::ReadBool(debugger, "IsRemote");
+            m_dbgHostName = XmlUtils::ReadString(debugger, "RemoteHostName");
+            m_dbgHostPort = XmlUtils::ReadString(debugger, "RemoteHostPort");
+            m_debuggerPath = XmlUtils::ReadString(debugger, "DebuggerPath");
+            m_isDbgRemoteExtended = XmlUtils::ReadBool(debugger, "IsExtended");
 
             wxXmlNode* child = debugger->GetChildren();
             while(child) {
-                if(child->GetName() == wxT("StartupCommands")) {
+                if(child->GetName() == "StartupCommands") {
                     m_debuggerStartupCmds = child->GetNodeContent();
 
-                } else if(child->GetName() == wxT("PostConnectCommands")) {
+                } else if(child->GetName() == "PostConnectCommands") {
                     m_debuggerPostRemoteConnectCmds = child->GetNodeContent();
 
                 } else if(child->GetName() == "DebuggerSearchPaths") {
@@ -157,12 +156,12 @@ BuildConfig::BuildConfig(wxXmlNode* node)
         }
 
         // read the prebuild commands
-        wxXmlNode* preBuild = XmlUtils::FindFirstByTagName(node, wxT("PreBuild"));
+        wxXmlNode* preBuild = XmlUtils::FindFirstByTagName(node, "PreBuild");
         if(preBuild) {
             wxXmlNode* child = preBuild->GetChildren();
             while(child) {
-                if(child->GetName() == wxT("Command")) {
-                    bool enabled = XmlUtils::ReadBool(child, wxT("Enabled"));
+                if(child->GetName() == "Command") {
+                    bool enabled = XmlUtils::ReadBool(child, "Enabled");
 
                     BuildCommand cmd(child->GetNodeContent(), enabled);
                     if(cmd.IsOk()) {
@@ -173,12 +172,12 @@ BuildConfig::BuildConfig(wxXmlNode* node)
             }
         }
         // read the postbuild commands
-        wxXmlNode* postBuild = XmlUtils::FindFirstByTagName(node, wxT("PostBuild"));
+        wxXmlNode* postBuild = XmlUtils::FindFirstByTagName(node, "PostBuild");
         if(postBuild) {
             wxXmlNode* child = postBuild->GetChildren();
             while(child) {
-                if(child->GetName() == wxT("Command")) {
-                    bool enabled = XmlUtils::ReadBool(child, wxT("Enabled"));
+                if(child->GetName() == "Command") {
+                    bool enabled = XmlUtils::ReadBool(child, "Enabled");
                     BuildCommand cmd(child->GetNodeContent(), enabled);
                     if(cmd.IsOk()) {
                         m_postBuildCommands.push_back(cmd);
@@ -192,36 +191,36 @@ BuildConfig::BuildConfig(wxXmlNode* node)
         SetDbgEnvSet(USE_GLOBAL_SETTINGS);
 
         // read the environment page
-        wxXmlNode* envNode = XmlUtils::FindFirstByTagName(node, wxT("Environment"));
+        wxXmlNode* envNode = XmlUtils::FindFirstByTagName(node, "Environment");
         if(envNode) {
-            SetEnvVarSet(XmlUtils::ReadString(envNode, wxT("EnvVarSetName")));
-            SetDbgEnvSet(XmlUtils::ReadString(envNode, wxT("DbgSetName")));
+            SetEnvVarSet(XmlUtils::ReadString(envNode, "EnvVarSetName"));
+            SetDbgEnvSet(XmlUtils::ReadString(envNode, "DbgSetName"));
             m_envvars = envNode->GetNodeContent();
         }
 
-        wxXmlNode* customBuild = XmlUtils::FindFirstByTagName(node, wxT("CustomBuild"));
+        wxXmlNode* customBuild = XmlUtils::FindFirstByTagName(node, "CustomBuild");
         if(customBuild) {
-            m_enableCustomBuild = XmlUtils::ReadBool(customBuild, wxT("Enabled"), false);
+            m_enableCustomBuild = XmlUtils::ReadBool(customBuild, "Enabled", false);
             wxXmlNode* child = customBuild->GetChildren();
             while(child) {
-                if(child->GetName() == wxT("BuildCommand")) {
+                if(child->GetName() == "BuildCommand") {
                     m_customBuildCmd = child->GetNodeContent();
-                } else if(child->GetName() == wxT("CleanCommand")) {
+                } else if(child->GetName() == "CleanCommand") {
                     m_customCleanCmd = child->GetNodeContent();
-                } else if(child->GetName() == wxT("RebuildCommand")) {
+                } else if(child->GetName() == "RebuildCommand") {
                     m_customRebuildCmd = child->GetNodeContent();
-                } else if(child->GetName() == wxT("SingleFileCommand")) {
+                } else if(child->GetName() == "SingleFileCommand") {
                     m_singleFileBuildCommand = child->GetNodeContent();
-                } else if(child->GetName() == wxT("PreprocessFileCommand")) {
+                } else if(child->GetName() == "PreprocessFileCommand") {
                     m_preprocessFileCommand = child->GetNodeContent();
-                } else if(child->GetName() == wxT("WorkingDirectory")) {
+                } else if(child->GetName() == "WorkingDirectory") {
                     m_customBuildWorkingDir = child->GetNodeContent();
-                } else if(child->GetName() == wxT("ThirdPartyToolName")) {
+                } else if(child->GetName() == "ThirdPartyToolName") {
                     m_toolName = child->GetNodeContent();
-                } else if(child->GetName() == wxT("MakefileGenerationCommand")) {
+                } else if(child->GetName() == "MakefileGenerationCommand") {
                     m_makeGenerationCommand = child->GetNodeContent();
-                } else if(child->GetName() == wxT("Target")) {
-                    wxString target_name = child->GetPropVal(wxT("Name"), wxT(""));
+                } else if(child->GetName() == "Target") {
+                    wxString target_name = child->GetPropVal("Name", "");
                     wxString target_cmd = child->GetNodeContent();
                     if(target_name.IsEmpty() == false) {
                         m_customTargets[target_name] = target_cmd;
@@ -233,15 +232,15 @@ BuildConfig::BuildConfig(wxXmlNode* node)
             m_enableCustomBuild = false;
         }
 
-        wxXmlNode* customPreBuild = XmlUtils::FindFirstByTagName(node, wxT("AdditionalRules"));
+        wxXmlNode* customPreBuild = XmlUtils::FindFirstByTagName(node, "AdditionalRules");
         if(customPreBuild) {
             wxXmlNode* child = customPreBuild->GetChildren();
             while(child) {
-                if(child->GetName() == wxT("CustomPreBuild")) {
+                if(child->GetName() == "CustomPreBuild") {
                     m_customPreBuildRule = child->GetNodeContent();
                     m_customPreBuildRule.Trim().Trim(false);
 
-                } else if(child->GetName() == wxT("CustomPostBuild")) {
+                } else if(child->GetName() == "CustomPostBuild") {
                     m_customPostBuildRule = child->GetNodeContent();
                     m_customPostBuildRule.Trim().Trim(false);
                 }
@@ -249,16 +248,16 @@ BuildConfig::BuildConfig(wxXmlNode* node)
             }
         }
 
-        wxXmlNode* general = XmlUtils::FindFirstByTagName(node, wxT("General"));
+        wxXmlNode* general = XmlUtils::FindFirstByTagName(node, "General");
         if(general) {
-            m_outputFile = XmlUtils::ReadString(general, wxT("OutputFile"));
-            m_intermediateDirectory = XmlUtils::ReadString(general, wxT("IntermediateDirectory"), wxT("."));
-            m_command = XmlUtils::ReadString(general, wxT("Command"));
-            m_commandArguments = XmlUtils::ReadString(general, wxT("CommandArguments"));
-            m_workingDirectory = XmlUtils::ReadString(general, wxT("WorkingDirectory"), wxT("."));
-            m_pauseWhenExecEnds = XmlUtils::ReadBool(general, wxT("PauseExecWhenProcTerminates"), true);
-            m_useSeparateDebugArgs = XmlUtils::ReadBool(general, wxT("UseSeparateDebugArgs"), false);
-            m_debugArgs = XmlUtils::ReadString(general, wxT("DebugArguments"));
+            m_outputFile = XmlUtils::ReadString(general, "OutputFile");
+            m_intermediateDirectory = XmlUtils::ReadString(general, "IntermediateDirectory", ".");
+            m_command = XmlUtils::ReadString(general, "Command");
+            m_commandArguments = XmlUtils::ReadString(general, "CommandArguments");
+            m_workingDirectory = XmlUtils::ReadString(general, "WorkingDirectory", ".");
+            m_pauseWhenExecEnds = XmlUtils::ReadBool(general, "PauseExecWhenProcTerminates", true);
+            m_useSeparateDebugArgs = XmlUtils::ReadBool(general, "UseSeparateDebugArgs", false);
+            m_debugArgs = XmlUtils::ReadString(general, "DebugArguments");
             m_isGUIProgram = XmlUtils::ReadBool(general, "IsGUIProgram", false);
             m_isProjectEnabled = XmlUtils::ReadBool(general, "IsEnabled", true);
         }
@@ -266,15 +265,15 @@ BuildConfig::BuildConfig(wxXmlNode* node)
     } else {
 
         // create default project settings
-        m_commonConfig.SetCompileOptions(wxT("-g -Wall"));
-        m_commonConfig.SetLinkOptions(wxT("-O0"));
-        m_commonConfig.SetLibPath(wxT(".;Debug"));
+        m_commonConfig.SetCompileOptions("-g -Wall");
+        m_commonConfig.SetLinkOptions("-O0");
+        m_commonConfig.SetLibPath(".;Debug");
 
-        m_name = wxT("Debug");
+        m_name = "Debug";
         m_compilerRequired = true;
         m_linkerRequired = true;
-        m_intermediateDirectory = wxT("./Debug");
-        m_workingDirectory = wxT("./Debug");
+        m_intermediateDirectory = "./Debug";
+        m_workingDirectory = "./Debug";
         m_projectType = PROJECT_TYPE_EXECUTABLE;
         m_enableCustomBuild = false;
         m_customBuildCmd = wxEmptyString;
@@ -293,8 +292,8 @@ BuildConfig::BuildConfig(wxXmlNode* node)
         m_useSeparateDebugArgs = false;
         m_debugArgs = wxEmptyString;
 
-        SetEnvVarSet(wxT("<Use Workspace Settings>"));
-        SetDbgEnvSet(wxT("<Use Global Settings>"));
+        SetEnvVarSet("<Use Workspace Settings>");
+        SetDbgEnvSet("<Use Global Settings>");
 
         BuildSettingsConfigCookie cookie;
         CompilerPtr cmp = BuildSettingsConfigST::Get()->GetFirstCompiler(cookie);
@@ -326,80 +325,80 @@ wxXmlNode* BuildConfig::ToXml() const
     // Create the common nodes
     wxXmlNode* node = m_commonConfig.ToXml();
 
-    node->AddProperty(wxT("Name"), m_name);
-    node->AddProperty(wxT("CompilerType"), m_compilerType);
-    node->AddProperty(wxT("DebuggerType"), m_debuggerType);
-    node->AddProperty(wxT("Type"), m_projectType);
-    node->AddProperty(wxT("BuildCmpWithGlobalSettings"), m_buildCmpWithGlobalSettings);
-    node->AddProperty(wxT("BuildLnkWithGlobalSettings"), m_buildLnkWithGlobalSettings);
-    node->AddProperty(wxT("BuildResWithGlobalSettings"), m_buildResWithGlobalSettings);
+    node->AddProperty("Name", m_name);
+    node->AddProperty("CompilerType", m_compilerType);
+    node->AddProperty("DebuggerType", m_debuggerType);
+    node->AddProperty("Type", m_projectType);
+    node->AddProperty("BuildCmpWithGlobalSettings", m_buildCmpWithGlobalSettings);
+    node->AddProperty("BuildLnkWithGlobalSettings", m_buildLnkWithGlobalSettings);
+    node->AddProperty("BuildResWithGlobalSettings", m_buildResWithGlobalSettings);
 
-    wxXmlNode* compile = XmlUtils::FindFirstByTagName(node, wxT("Compiler"));
+    wxXmlNode* compile = XmlUtils::FindFirstByTagName(node, "Compiler");
     if(compile) {
-        compile->AddProperty(wxT("Required"), BoolToString(m_compilerRequired));
-        compile->AddProperty(wxT("PreCompiledHeader"), m_precompiledHeader);
-        compile->AddProperty(wxT("PCHInCommandLine"), BoolToString(m_pchInCommandLine));
-        compile->AddProperty(wxT("PCHFlags"), m_pchCompileFlags);
+        compile->AddProperty("Required", BoolToString(m_compilerRequired));
+        compile->AddProperty("PreCompiledHeader", m_precompiledHeader);
+        compile->AddProperty("PCHInCommandLine", BoolToString(m_pchInCommandLine));
+        compile->AddProperty("PCHFlags", m_pchCompileFlags);
         compile->AddProperty("PCHFlagsPolicy", wxString() << (int)m_pchPolicy);
     }
 
-    wxXmlNode* link = XmlUtils::FindFirstByTagName(node, wxT("Linker"));
+    wxXmlNode* link = XmlUtils::FindFirstByTagName(node, "Linker");
     if(link) {
-        link->AddProperty(wxT("Required"), BoolToString(m_linkerRequired));
+        link->AddProperty("Required", BoolToString(m_linkerRequired));
     }
 
-    wxXmlNode* resCmp = XmlUtils::FindFirstByTagName(node, wxT("ResourceCompiler"));
+    wxXmlNode* resCmp = XmlUtils::FindFirstByTagName(node, "ResourceCompiler");
     if(resCmp) {
-        resCmp->AddProperty(wxT("Required"), BoolToString(m_isResCmpNeeded));
+        resCmp->AddProperty("Required", BoolToString(m_isResCmpNeeded));
     }
 
-    wxXmlNode* general = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("General"));
-    general->AddProperty(wxT("OutputFile"), m_outputFile);
-    general->AddProperty(wxT("IntermediateDirectory"), m_intermediateDirectory);
-    general->AddProperty(wxT("Command"), m_command);
-    general->AddProperty(wxT("CommandArguments"), m_commandArguments);
-    general->AddProperty(wxT("UseSeparateDebugArgs"), BoolToString(m_useSeparateDebugArgs));
-    general->AddProperty(wxT("DebugArguments"), m_debugArgs);
-    general->AddProperty(wxT("WorkingDirectory"), m_workingDirectory);
-    general->AddProperty(wxT("PauseExecWhenProcTerminates"), BoolToString(m_pauseWhenExecEnds));
+    wxXmlNode* general = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "General");
+    general->AddProperty("OutputFile", m_outputFile);
+    general->AddProperty("IntermediateDirectory", m_intermediateDirectory);
+    general->AddProperty("Command", m_command);
+    general->AddProperty("CommandArguments", m_commandArguments);
+    general->AddProperty("UseSeparateDebugArgs", BoolToString(m_useSeparateDebugArgs));
+    general->AddProperty("DebugArguments", m_debugArgs);
+    general->AddProperty("WorkingDirectory", m_workingDirectory);
+    general->AddProperty("PauseExecWhenProcTerminates", BoolToString(m_pauseWhenExecEnds));
     general->AddProperty("IsGUIProgram", BoolToString(m_isGUIProgram));
     general->AddProperty("IsEnabled", BoolToString(m_isProjectEnabled));
     node->AddChild(general);
 
-    wxXmlNode* buildSystem = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("BuildSystem"));
+    wxXmlNode* buildSystem = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "BuildSystem");
     buildSystem->AddProperty("Name", m_buildSystem);
     XmlUtils::SetNodeContent(buildSystem, m_buildSystemArguments);
     node->AddChild(buildSystem);
 
-    wxXmlNode* debugger = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("Debugger"));
-    debugger->AddProperty(wxT("IsRemote"), BoolToString(m_isDbgRemoteTarget));
-    debugger->AddProperty(wxT("RemoteHostName"), m_dbgHostName);
-    debugger->AddProperty(wxT("RemoteHostPort"), m_dbgHostPort);
-    debugger->AddProperty(wxT("DebuggerPath"), m_debuggerPath);
-    debugger->AddProperty(wxT("IsExtended"), BoolToString(m_isDbgRemoteExtended));
+    wxXmlNode* debugger = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "Debugger");
+    debugger->AddProperty("IsRemote", BoolToString(m_isDbgRemoteTarget));
+    debugger->AddProperty("RemoteHostName", m_dbgHostName);
+    debugger->AddProperty("RemoteHostPort", m_dbgHostPort);
+    debugger->AddProperty("DebuggerPath", m_debuggerPath);
+    debugger->AddProperty("IsExtended", BoolToString(m_isDbgRemoteExtended));
 
-    wxXmlNode* envNode = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("Environment"));
-    envNode->AddProperty(wxT("EnvVarSetName"), GetEnvVarSet());
-    envNode->AddProperty(wxT("DbgSetName"), GetDbgEnvSet());
+    wxXmlNode* envNode = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "Environment");
+    envNode->AddProperty("EnvVarSetName", GetEnvVarSet());
+    envNode->AddProperty("DbgSetName", GetDbgEnvSet());
 
     // Add CDATA section with project environment variables
     wxXmlNode* envContent = new wxXmlNode(wxXML_CDATA_SECTION_NODE, wxEmptyString, m_envvars);
     envNode->AddChild(envContent);
     node->AddChild(envNode);
 
-    wxXmlNode* dbgStartupCommands = new wxXmlNode(debugger, wxXML_ELEMENT_NODE, wxT("StartupCommands"));
+    wxXmlNode* dbgStartupCommands = new wxXmlNode(debugger, wxXML_ELEMENT_NODE, "StartupCommands");
     XmlUtils::SetNodeContent(dbgStartupCommands, m_debuggerStartupCmds);
 
-    wxXmlNode* dbgPostConnectCommands = new wxXmlNode(debugger, wxXML_ELEMENT_NODE, wxT("PostConnectCommands"));
+    wxXmlNode* dbgPostConnectCommands = new wxXmlNode(debugger, wxXML_ELEMENT_NODE, "PostConnectCommands");
     XmlUtils::SetNodeContent(dbgPostConnectCommands, m_debuggerPostRemoteConnectCmds);
 
-    wxXmlNode* dbgSearchPaths = new wxXmlNode(debugger, wxXML_ELEMENT_NODE, wxT("DebuggerSearchPaths"));
+    wxXmlNode* dbgSearchPaths = new wxXmlNode(debugger, wxXML_ELEMENT_NODE, "DebuggerSearchPaths");
     XmlUtils::SetNodeContent(dbgSearchPaths, ::wxImplode(m_debuggerSearchPaths, "\n"));
 
     node->AddChild(debugger);
 
     // add prebuild commands
-    wxXmlNode* preBuild = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("PreBuild"));
+    wxXmlNode* preBuild = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "PreBuild");
     node->AddChild(preBuild);
 
     for(const auto& cmd : m_preBuildCommands) {
@@ -407,14 +406,14 @@ wxXmlNode* BuildConfig::ToXml() const
             continue;
         }
 
-        wxXmlNode* command = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("Command"));
-        command->AddProperty(wxT("Enabled"), BoolToString(cmd.GetEnabled()));
+        wxXmlNode* command = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "Command");
+        command->AddProperty("Enabled", BoolToString(cmd.GetEnabled()));
         XmlUtils::SetNodeContent(command, cmd.GetCommand());
         preBuild->AddChild(command);
     }
 
     // add postbuild commands
-    wxXmlNode* postBuild = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("PostBuild"));
+    wxXmlNode* postBuild = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "PostBuild");
     node->AddChild(postBuild);
 
     for(const auto& cmd : m_postBuildCommands) {
@@ -422,45 +421,45 @@ wxXmlNode* BuildConfig::ToXml() const
             continue;
         }
 
-        wxXmlNode* command = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("Command"));
-        command->AddProperty(wxT("Enabled"), BoolToString(cmd.GetEnabled()));
+        wxXmlNode* command = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "Command");
+        command->AddProperty("Enabled", BoolToString(cmd.GetEnabled()));
         XmlUtils::SetNodeContent(command, cmd.GetCommand());
         postBuild->AddChild(command);
     }
 
     // add postbuild commands
-    wxXmlNode* customBuild = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("CustomBuild"));
+    wxXmlNode* customBuild = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "CustomBuild");
     node->AddChild(customBuild);
-    customBuild->AddProperty(wxT("Enabled"), BoolToString(m_enableCustomBuild));
+    customBuild->AddProperty("Enabled", BoolToString(m_enableCustomBuild));
 
     // add the working directory of the custom build
-    wxXmlNode* customBuildWd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, wxT("WorkingDirectory"));
+    wxXmlNode* customBuildWd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, "WorkingDirectory");
     XmlUtils::SetNodeContent(customBuildWd, m_customBuildWorkingDir);
 
     // add the makefile generation command
-    wxXmlNode* toolName = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, wxT("ThirdPartyToolName"));
+    wxXmlNode* toolName = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, "ThirdPartyToolName");
     XmlUtils::SetNodeContent(toolName, m_toolName);
 
     // add the makefile generation command
-    wxXmlNode* makeGenCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, wxT("MakefileGenerationCommand"));
+    wxXmlNode* makeGenCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, "MakefileGenerationCommand");
     XmlUtils::SetNodeContent(makeGenCmd, m_makeGenerationCommand);
 
     // add the makefile generation command
-    wxXmlNode* singleFileCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, wxT("SingleFileCommand"));
+    wxXmlNode* singleFileCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, "SingleFileCommand");
     XmlUtils::SetNodeContent(singleFileCmd, m_singleFileBuildCommand);
 
     // add the makefile generation command
-    wxXmlNode* preprocessFileCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, wxT("PreprocessFileCommand"));
+    wxXmlNode* preprocessFileCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, "PreprocessFileCommand");
     XmlUtils::SetNodeContent(preprocessFileCmd, m_preprocessFileCommand);
 
     // add build and clean commands
-    wxXmlNode* bldCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, wxT("BuildCommand"));
+    wxXmlNode* bldCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, "BuildCommand");
     XmlUtils::SetNodeContent(bldCmd, m_customBuildCmd);
 
-    wxXmlNode* clnCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, wxT("CleanCommand"));
+    wxXmlNode* clnCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, "CleanCommand");
     XmlUtils::SetNodeContent(clnCmd, m_customCleanCmd);
 
-    wxXmlNode* rebldCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, wxT("RebuildCommand"));
+    wxXmlNode* rebldCmd = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, "RebuildCommand");
     XmlUtils::SetNodeContent(rebldCmd, m_customRebuildCmd);
 
     // add all 'Targets'
@@ -469,36 +468,36 @@ wxXmlNode* BuildConfig::ToXml() const
         wxString target_name = ir->first;
         wxString target_cmd = ir->second;
 
-        wxXmlNode* customTarget = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, wxT("Target"));
-        customTarget->AddProperty(wxT("Name"), target_name);
+        wxXmlNode* customTarget = new wxXmlNode(customBuild, wxXML_ELEMENT_NODE, "Target");
+        customTarget->AddProperty("Name", target_name);
         XmlUtils::SetNodeContent(customTarget, target_cmd);
     }
 
     // add the additional rules
-    wxXmlNode* additionalCmds = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("AdditionalRules"));
+    wxXmlNode* additionalCmds = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "AdditionalRules");
     node->AddChild(additionalCmds);
 
-    wxXmlNode* preCmd = new wxXmlNode(additionalCmds, wxXML_ELEMENT_NODE, wxT("CustomPreBuild"));
+    wxXmlNode* preCmd = new wxXmlNode(additionalCmds, wxXML_ELEMENT_NODE, "CustomPreBuild");
     XmlUtils::SetNodeContent(preCmd, m_customPreBuildRule);
-    wxXmlNode* postCmd = new wxXmlNode(additionalCmds, wxXML_ELEMENT_NODE, wxT("CustomPostBuild"));
+    wxXmlNode* postCmd = new wxXmlNode(additionalCmds, wxXML_ELEMENT_NODE, "CustomPostBuild");
     XmlUtils::SetNodeContent(postCmd, m_customPostBuildRule);
 
     // Set the completion flags
-    wxXmlNode* completion = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, wxT("Completion"));
+    wxXmlNode* completion = new wxXmlNode(NULL, wxXML_ELEMENT_NODE, "Completion");
     node->AddChild(completion);
-    completion->AddProperty(wxT("EnableCpp11"), BoolToString(m_clangC11));
-    completion->AddProperty(wxT("EnableCpp14"), BoolToString(m_clangC14));
+    completion->AddProperty("EnableCpp11", BoolToString(m_clangC11));
+    completion->AddProperty("EnableCpp14", BoolToString(m_clangC14));
 
-    wxXmlNode* search_paths = new wxXmlNode(completion, wxXML_ELEMENT_NODE, wxT("SearchPaths"));
+    wxXmlNode* search_paths = new wxXmlNode(completion, wxXML_ELEMENT_NODE, "SearchPaths");
     XmlUtils::SetNodeContent(search_paths, m_ccSearchPaths);
 
-    wxXmlNode* clang_pp = new wxXmlNode(completion, wxXML_ELEMENT_NODE, wxT("ClangPP"));
+    wxXmlNode* clang_pp = new wxXmlNode(completion, wxXML_ELEMENT_NODE, "ClangPP");
     XmlUtils::SetNodeContent(clang_pp, m_clangPPFlags);
 
-    wxXmlNode* clang_cmp_flags = new wxXmlNode(completion, wxXML_ELEMENT_NODE, wxT("ClangCmpFlags"));
+    wxXmlNode* clang_cmp_flags = new wxXmlNode(completion, wxXML_ELEMENT_NODE, "ClangCmpFlags");
     XmlUtils::SetNodeContent(clang_cmp_flags, m_clangCmpFlags);
 
-    wxXmlNode* clang_c_cmp_flags = new wxXmlNode(completion, wxXML_ELEMENT_NODE, wxT("ClangCmpFlagsC"));
+    wxXmlNode* clang_c_cmp_flags = new wxXmlNode(completion, wxXML_ELEMENT_NODE, "ClangCmpFlagsC");
     XmlUtils::SetNodeContent(clang_c_cmp_flags, m_clangCmpFlagsC);
 
     return node;
@@ -519,6 +518,8 @@ wxString BuildConfig::GetLibraries() const { return m_commonConfig.GetLibraries(
 wxString BuildConfig::GetIncludePath() const { return m_commonConfig.GetIncludePath(); }
 
 wxString BuildConfig::GetPreprocessor() const { return m_commonConfig.GetPreprocessor(); }
+
+wxString BuildConfig::GetOutputDirectory() const { return GetOutputFileName().BeforeLast('/'); }
 
 wxString BuildConfig::GetOutputFileName() const { return NormalizePath(m_outputFile); }
 

--- a/Plugin/build_config.h
+++ b/Plugin/build_config.h
@@ -231,6 +231,7 @@ public:
     const wxString& GetName() const { return m_name; }
     bool IsCompilerRequired() const { return m_compilerRequired; }
     bool IsLinkerRequired() const { return m_linkerRequired; }
+    wxString GetOutputDirectory() const;
     wxString GetOutputFileName() const;
     wxString GetIntermediateDirectory() const;
     const wxString& GetCommand() const { return m_command; }

--- a/Plugin/builder_NMake.h
+++ b/Plugin/builder_NMake.h
@@ -64,6 +64,9 @@ public:
     virtual wxString GetStaticLibSuffix() const { return ".lib"; }
 
 protected:
+    virtual wxString GetIntermediateDirectory(ProjectPtr proj, BuildConfigPtr bldConf) const;
+
+protected:
     virtual void CreateListMacros(ProjectPtr proj, const wxString& confToBuild, wxString& text);
     void CreateSrcList(ProjectPtr proj, const wxString& confToBuild, wxString& text);
     void CreateObjectList(ProjectPtr proj, const wxString& confToBuild, wxString& text);

--- a/Plugin/builder_gnumake.cpp
+++ b/Plugin/builder_gnumake.cpp
@@ -1193,6 +1193,7 @@ void BuilderGNUMakeClassic::CreateConfigsVariables(ProjectPtr proj, BuildConfigP
 
     text << "ProjectName            :=" << projectName << "\n";
     text << "ConfigurationName      :=" << name << "\n";
+    text << "WorkspaceConfiguration :=" << clCxxWorkspaceST::Get()->GetSelectedConfig()->GetName() << "\n";
     text << "WorkspacePath          :=" << ::WrapWithQuotes(workspacepath) << "\n";
     text << "ProjectPath            :=" << ::WrapWithQuotes(projectpath) << "\n";
     text << "IntermediateDirectory  :=" << bldConf->GetIntermediateDirectory() << "\n";
@@ -1215,6 +1216,7 @@ void BuilderGNUMakeClassic::CreateConfigsVariables(ProjectPtr proj, BuildConfigP
     text << "LibraryPathSwitch      :=" << cmp->GetSwitch("LibraryPath") << "\n";
     text << "PreprocessorSwitch     :=" << cmp->GetSwitch("Preprocessor") << "\n";
     text << "SourceSwitch           :=" << cmp->GetSwitch("Source") << "\n";
+    text << "OutputDirectory        :=" << bldConf->GetOutputDirectory() << "\n";
     text << "OutputFile             :=" << outputFile << "\n";
     text << "Preprocessors          :=" << ParsePreprocessor(bldConf->GetPreprocessor()) << "\n";
     text << "ObjectSwitch           :=" << cmp->GetSwitch("Object") << "\n";

--- a/Plugin/builder_gnumake_default.cpp
+++ b/Plugin/builder_gnumake_default.cpp
@@ -40,13 +40,13 @@
 #include "macromanager.h"
 #include "macros.h"
 #include "project.h"
-#include "wx/sstream.h"
-#include "wx/tokenzr.h"
 
 #include <algorithm>
 #include <wx/app.h>
 #include <wx/msgdlg.h>
+#include <wx/sstream.h>
 #include <wx/stopwatch.h>
+#include <wx/tokenzr.h>
 
 BuilderGnuMake::BuilderGnuMake()
     : Builder("CodeLite Makefile Generator")
@@ -68,60 +68,48 @@ BuilderGnuMake::~BuilderGnuMake() {}
 wxString BuilderGnuMake::MakeDir(const wxString& path)
 {
     wxString d;
-    wxString q = "\"";
-    if(path.StartsWith("$")) {
-        q.clear();
-    }
     wxString fixedPath = path;
+    if(fixedPath.StartsWith("$") || fixedPath.Contains(" ") ||
+       m_isWindows // HACK: windows mkdir accepts forward-slash if it was double-quoted
+    ) {
+        fixedPath.Prepend("\"").Append("\"");
+    }
 
 #ifdef __WXMSW__
     if(m_isWindows) {
-        fixedPath.Replace("/", "\\"); // mkdir does not accept /
-        d << "@if not exist " << q << fixedPath << q << " mkdir " << q << fixedPath << q << "";
+        d << "@if not exist " << fixedPath << " $(MakeDirCommand) " << fixedPath;
     } else {
         fixedPath.Replace("\\", "/");
-        d << "@mkdir -p " << q << fixedPath << q << "";
+        d << "@$(MakeDirCommand) " << fixedPath;
     }
 #else
-    d << "@mkdir -p " << q << fixedPath << q << "";
+    d << "@$(MakeDirCommand) " << fixedPath;
 #endif
     return d;
 }
 
-wxString BuilderGnuMake::GetIntermediateFolder(ProjectPtr proj, const wxString& workspacepath)
+wxString BuilderGnuMake::GetIntermediateDirectory(ProjectPtr proj, BuildConfigPtr bldConf) const
 {
-    // Build the intermediate folder path
-    // {WorkspacePath}/{Project Path Relative}
-    wxFileName workspacePathRelativeToProject(workspacepath, "");
-    wxFileName projectPath(proj->GetFileName());
-    workspacePathRelativeToProject.MakeRelativeTo(projectPath.GetPath());
-
-    projectPath.MakeRelativeTo(workspacepath);
-    wxString projRel = projectPath.GetPath(false, wxPATH_UNIX);
-    projRel.Replace(".", "_");
-
-    wxString imd = workspacePathRelativeToProject.GetPath(false, wxPATH_UNIX)
-                   << "/build-$(ConfigurationName)/" << projRel;
-    imd.Replace(" ", "\\ ");
-    return imd;
-}
-
-wxString BuilderGnuMake::GetOutputFolder(ProjectPtr proj, BuildConfigPtr bldConf)
-{
-    wxFileName workspacePathRelativeToProject(clCxxWorkspaceST::Get()->GetFileName().GetPath(), "");
-    wxFileName projectPath(proj->GetFileName());
-    workspacePathRelativeToProject.MakeRelativeTo(projectPath.GetPath());
-
-    wxString imd = workspacePathRelativeToProject.GetPath(false, wxPATH_UNIX) << "/build-$(ConfigurationName)/";
-
-    wxString type = bldConf->GetProjectType();
-    if(type == PROJECT_TYPE_EXECUTABLE) {
-        imd << "bin";
-    } else {
-        imd << "lib";
+    wxString workspacePath = clCxxWorkspaceST::Get()->GetWorkspaceFileName().GetPath();
+    wxString projectPath = proj->GetFileName().GetPath();
+    wxString intermediateDir = bldConf->GetIntermediateDirectory();
+    if(intermediateDir.IsEmpty()) {
+        wxFileName projName = proj->GetFileName();
+        projName.MakeRelativeTo(workspacePath);
+        wxString projRel = projName.GetPath(wxPATH_NO_SEPARATOR);
+        projRel.Replace(".", "_");
+        projRel.Replace(" ", "_");
+        intermediateDir << "$(WorkspacePath)/build-$(WorkspaceConfiguration)/" << projRel;
     }
-    imd.Replace(" ", "\\ ");
-    return imd;
+    intermediateDir.Replace("$(WorkspacePath)", workspacePath);
+    intermediateDir.Replace("$(ProjectPath)", projectPath);
+    wxFileName fnIntermediateDir(intermediateDir, "");
+    if(fnIntermediateDir.IsAbsolute()) {
+        fnIntermediateDir.MakeRelativeTo(projectPath);
+    }
+    intermediateDir = fnIntermediateDir.GetPath(wxPATH_NO_SEPARATOR);
+    intermediateDir.Replace("\\", "/");
+    return intermediateDir;
 }
 
 bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild, const wxString& arguments,
@@ -132,7 +120,7 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
     }
     ProjectPtr proj = clCxxWorkspaceST::Get()->FindProjectByName(project, errMsg);
     if(!proj) {
-        errMsg << _("Cant open project '") << project << wxT("'");
+        errMsg << _("Cant open project '") << project << "'";
         return false;
     }
 
@@ -142,7 +130,7 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
     if(confToBuild.IsEmpty()) {
         BuildConfigPtr bldConf = clCxxWorkspaceST::Get()->GetProjBuildConf(project, confToBuild);
         if(!bldConf) {
-            errMsg << _("Cant find build configuration for project '") << project << wxT("'");
+            errMsg << _("Cant find build configuration for project '") << project << "'";
             return false;
         }
         bld_conf_name = bldConf->GetName();
@@ -150,11 +138,11 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
 
     BuildConfigPtr bldConf = clCxxWorkspaceST::Get()->GetProjBuildConf(project, bld_conf_name);
     if(!bldConf) {
-        errMsg << _("Cant find build configuration for project '") << project << wxT("'");
+        errMsg << _("Cant find build configuration for project '") << project << "'";
         return false;
     }
     if(!bldConf->GetCompiler()) {
-        errMsg << _("Cant find proper compiler for project '") << project << wxT("'");
+        errMsg << _("Cant find proper compiler for project '") << project << "'";
         return false;
     }
 
@@ -215,8 +203,9 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
         bool modified = proj->IsModified();
 
         // Update the dependencies only if needed
-        if(settingsChanged)
+        if(settingsChanged) {
             proj->SetDependencies(depsArr, bld_conf_name);
+        }
 
         // the set settings functions marks the project as 'modified' this causes
         // an unneeded makefile generation if the settings was not really modified
@@ -231,15 +220,15 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
 
     wxFileName wspfile(clCxxWorkspaceST::Get()->GetWorkspaceFileName());
 
-    text << wxT(".PHONY: clean All\n\n");
-    text << wxT("All:\n");
+    text << ".PHONY: clean All\n\n";
+    text << "All:\n";
 
     // iterate over the dependencies projects and generate makefile
     wxString buildTool = GetBuildToolCommand(project, confToBuild, arguments, false);
     buildTool = EnvironmentConfig::Instance()->ExpandVariables(buildTool, true);
 
     // fix: replace all Windows like slashes to POSIX
-    buildTool.Replace(wxT("\\"), wxT("/"));
+    buildTool.Replace("\\", "/");
 
     // generate the makefile for the selected workspace configuration
     BuildMatrixPtr matrix = clCxxWorkspaceST::Get()->GetBuildMatrix();
@@ -271,8 +260,8 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
                 continue;
             }
 
-            text << wxT("\t@echo \"") << BUILD_PROJECT_PREFIX << dependProj->GetName() << wxT(" - ") << projectSelConf
-                 << wxT(" ]----------\"\n");
+            text << "\t@echo \"" << BUILD_PROJECT_PREFIX << dependProj->GetName() << " - " << projectSelConf
+                 << " ]----------\"\n";
             // make the paths relative, if it's sensible to do so
             wxFileName fn(dependProj->GetFileName());
             MakeRelativeIfSensible(fn, wspfile.GetPath());
@@ -290,7 +279,7 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
                 e.SetConfigurationName(projectSelConf);
                 e.SetProjectOnly(false);
                 EventNotifier::Get()->ProcessEvent(e);
-                text << wxT("\t") << e.GetCommand() << wxT("\n");
+                text << "\t" << e.GetCommand() << "\n";
 
             } else if(isCustom) {
 
@@ -308,19 +297,19 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
                 build_cmd.Trim().Trim(false);
 
                 if(build_cmd.empty()) {
-                    build_cmd << wxT("@echo Project has no custom build command!");
+                    build_cmd << "@echo Project has no custom build command!";
                 }
 
                 // if a working directory is provided apply it, otherwise use the project
                 // path
                 customWd.Trim().Trim(false);
                 if(customWd.empty() == false) {
-                    customWdCmd << wxT("@cd \"") << ExpandVariables(customWd, dependProj, NULL) << wxT("\" && ");
+                    customWdCmd << "@cd \"" << ExpandVariables(customWd, dependProj, NULL) << "\" && ";
                 } else {
                     customWdCmd << GetCdCmd(wspfile, fn);
                 }
 
-                text << wxT("\t") << customWdCmd << build_cmd << wxT("\n");
+                text << "\t" << customWdCmd << build_cmd << "\n";
                 CreateCustomPostBuildEvents(dependProjbldConf, text);
 
             } else {
@@ -350,8 +339,7 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
         projectSelConf = confToBuild;
     }
 
-    text << wxT("\t@echo \"") << BUILD_PROJECT_PREFIX << project << wxT(" - ") << projectSelConf
-         << wxT(" ]----------\"\n");
+    text << "\t@echo \"" << BUILD_PROJECT_PREFIX << project << " - " << projectSelConf << " ]----------\"\n";
 
     // make the paths relative, if it's sensible to do so
     wxFileName projectPath(proj->GetFileName());
@@ -370,14 +358,14 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
         EventNotifier::Get()->ProcessEvent(e);
 
         cmd = e.GetCommand();
-        text << wxT("\t") << cmd << wxT("\n");
+        text << "\t" << cmd << "\n";
 
     } else {
         text << GetProjectMakeCommand(wspfile, projectPath, proj, projectSelConf);
     }
 
     // create the clean target
-    text << wxT("clean:\n");
+    text << "clean:\n";
     if(!isProjectOnly) {
         for(size_t i = 0; i < depsArr.GetCount(); i++) {
             bool isCustom(false);
@@ -389,8 +377,8 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
                 continue;
             }
 
-            text << wxT("\t@echo \"") << CLEAN_PROJECT_PREFIX << dependProj->GetName() << wxT(" - ") << projectSelConf
-                 << wxT(" ]----------\"\n");
+            text << "\t@echo \"" << CLEAN_PROJECT_PREFIX << dependProj->GetName() << " - " << projectSelConf
+                 << " ]----------\"\n";
 
             // make the paths relative
             wxFileName fn(dependProj->GetFileName());
@@ -418,12 +406,12 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
                 e.SetProjectName(pname);
                 e.SetConfigurationName(projectSelConf);
                 EventNotifier::Get()->ProcessEvent(e);
-                text << wxT("\t") << e.GetCommand() << wxT("\n");
+                text << "\t" << e.GetCommand() << "\n";
 
             } else if(!isCustom) {
 
-                text << wxT("\t") << GetCdCmd(wspfile, fn) << buildTool << wxT(" \"") << dependProj->GetName()
-                     << wxT(".mk\"  clean\n");
+                text << "\t" << GetCdCmd(wspfile, fn) << buildTool << " \"" << dependProj->GetName()
+                     << ".mk\"  clean\n";
 
             } else {
 
@@ -439,18 +427,18 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
 
                 clean_cmd.Trim().Trim(false);
                 if(clean_cmd.empty()) {
-                    clean_cmd << wxT("@echo Project has no custom clean command!");
+                    clean_cmd << "@echo Project has no custom clean command!";
                 }
 
                 // if a working directory is provided apply it, otherwise use the project
                 // path
                 customWd.Trim().Trim(false);
                 if(customWd.empty() == false) {
-                    customWdCmd << wxT("@cd \"") << ExpandVariables(customWd, dependProj, NULL) << wxT("\" && ");
+                    customWdCmd << "@cd \"" << ExpandVariables(customWd, dependProj, NULL) << "\" && ";
                 } else {
                     customWdCmd << GetCdCmd(wspfile, fn);
                 }
-                text << wxT("\t") << customWdCmd << clean_cmd << wxT("\n");
+                text << "\t" << customWdCmd << clean_cmd << "\n";
             }
         }
     }
@@ -463,8 +451,7 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
         projectSelConf = confToBuild;
     }
 
-    text << wxT("\t@echo \"") << CLEAN_PROJECT_PREFIX << project << wxT(" - ") << projectSelConf
-         << wxT(" ]----------\"\n");
+    text << "\t@echo \"" << CLEAN_PROJECT_PREFIX << project << " - " << projectSelConf << " ]----------\"\n";
     if(isPluginGeneratedMakefile) {
 
         wxString cmd;
@@ -475,11 +462,10 @@ bool BuilderGnuMake::Export(const wxString& project, const wxString& confToBuild
         e.SetProjectOnly(isProjectOnly);
         EventNotifier::Get()->ProcessEvent(e);
         cmd = e.GetCommand();
-        text << wxT("\t") << cmd << wxT("\n");
+        text << "\t" << cmd << "\n";
 
     } else {
-        text << wxT("\t") << GetCdCmd(wspfile, projectPath) << buildTool << wxT(" \"") << proj->GetName()
-             << wxT(".mk\" clean\n");
+        text << "\t" << GetCdCmd(wspfile, projectPath) << buildTool << " \"" << proj->GetName() << ".mk\" clean\n";
     }
 
     // dump the content to file
@@ -531,7 +517,7 @@ void BuilderGnuMake::GenerateMakefile(ProjectPtr proj, const wxString& confToBui
 
     // create new makefile file
     wxString fn(path);
-    fn << PATH_SEP << proj->GetName() << wxT(".mk");
+    fn << PATH_SEP << proj->GetName() << ".mk";
 
     // skip the next test if the makefile does not exist
     if(wxFileName::FileExists(fn)) {
@@ -549,10 +535,14 @@ void BuilderGnuMake::GenerateMakefile(ProjectPtr proj, const wxString& confToBui
     // wxTextOutputStream text(output);
     wxString text;
 
-    text << wxT("##") << wxT("\n");
-    text << wxT("## Auto Generated makefile by CodeLite IDE") << wxT("\n");
-    text << wxT("## any manual changes will be erased      ") << wxT("\n");
-    text << wxT("##") << wxT("\n");
+    text << "##"
+         << "\n";
+    text << "## Auto Generated makefile by CodeLite IDE"
+         << "\n";
+    text << "## any manual changes will be erased      "
+         << "\n";
+    text << "##"
+         << "\n";
 
     // Create the makefile variables
     CreateConfigsVariables(proj, bldConf, text);
@@ -564,17 +554,21 @@ void BuilderGnuMake::GenerateMakefile(ProjectPtr proj, const wxString& confToBui
     // variables by defining its own
     //----------------------------------------------------------
     EvnVarList vars;
-    EnvironmentConfig::Instance()->ReadObject(wxT("Variables"), &vars);
-    EnvMap varMap = vars.GetVariables(wxT(""), true, proj->GetName(), bldConf->GetName());
+    EnvironmentConfig::Instance()->ReadObject("Variables", &vars);
+    EnvMap varMap = vars.GetVariables("", true, proj->GetName(), bldConf->GetName());
 
-    text << wxT("##") << wxT("\n");
-    text << wxT("## User defined environment variables") << wxT("\n");
-    text << wxT("##") << wxT("\n");
+    text << "##"
+         << "\n";
+    text << "## User defined environment variables"
+         << "\n";
+    text << "##"
+         << "\n";
 
     for(size_t i = 0; i < varMap.GetCount(); i++) {
         wxString name, value;
         varMap.Get(i, name, value);
-        text << name << wxT(":=") << value << wxT("") << wxT("\n");
+        text << name << ":=" << value << ""
+             << "\n";
     }
 
     CreateListMacros(proj, confToBuild, text); // list of srcs and list of objects
@@ -582,20 +576,20 @@ void BuilderGnuMake::GenerateMakefile(ProjectPtr proj, const wxString& confToBui
     //-----------------------------------------------------------
     // create the build targets
     //-----------------------------------------------------------
-    text << wxT("##\n");
-    text << wxT("## Main Build Targets \n");
-    text << wxT("##\n");
+    text << "##\n";
+    text << "## Main Build Targets \n";
+    text << "##\n";
 
     // incase project is type exe or dll, force link
     // this is to workaround bug in the generated makefiles
     // which causes the makefile to report 'nothing to be done'
     // even when a dependency was modified
-    wxString targetName(bldConf->GetIntermediateDirectory());
+    wxString targetName("$(IntermediateDirectory)");
     CreateLinkTargets(proj->GetSettings()->GetProjectType(bldConf->GetName()), bldConf, text, targetName,
                       proj->GetName(), depsProj);
 
     CreatePostBuildEvents(proj, bldConf, text);
-    CreateMakeDirsTarget(proj, bldConf, targetName, text);
+    CreateMakeDirsTarget(targetName, text);
     CreatePreBuildEvents(proj, bldConf, text);
     CreatePreCompiledHeaderTarget(bldConf, text);
 
@@ -608,7 +602,7 @@ void BuilderGnuMake::GenerateMakefile(ProjectPtr proj, const wxString& confToBui
 
     // dump the content to a file
     wxFFile output;
-    output.Open(fn, wxT("w+"));
+    output.Open(fn, "w+");
     if(output.IsOpened()) {
         output.Write(text);
         output.Close();
@@ -618,21 +612,16 @@ void BuilderGnuMake::GenerateMakefile(ProjectPtr proj, const wxString& confToBui
     proj->SetModified(false);
 }
 
-void BuilderGnuMake::CreateMakeDirsTarget(ProjectPtr proj, BuildConfigPtr bldConf, const wxString& targetName,
-                                          wxString& text)
+void BuilderGnuMake::CreateMakeDirsTarget(const wxString& targetName, wxString& text)
 {
-    wxString workspacepath = clCxxWorkspaceST::Get()->GetFileName().GetPath();
-    wxString imd = GetIntermediateFolder(proj, workspacepath);
-    wxString outputDir = GetOutputFolder(proj, bldConf);
-
     text << "\n";
     text << "MakeIntermediateDirs:\n";
-    text << "\t" << MakeDir(imd) << "\n";
-    text << "\t" << MakeDir("\"" + outputDir + "\"") << "\n";
+    text << "\t" << MakeDir("$(IntermediateDirectory)") << "\n";
+    text << "\t" << MakeDir("$(OutputDirectory)") << "\n";
 
-    text << wxT("\n");
-    text << targetName << wxT(":\n");
-    text << wxT("\t") << MakeDir(imd) << wxT("\n");
+    text << "\n";
+    text << targetName << ":\n";
+    text << "\t" << MakeDir("$(IntermediateDirectory)") << "\n";
 }
 
 void BuilderGnuMake::CreateSrcList(ProjectPtr proj, const wxString& confToBuild, wxString& text)
@@ -648,7 +637,7 @@ void BuilderGnuMake::CreateSrcList(ProjectPtr proj, const wxString& confToBuild,
                       }
                   });
 
-    text << wxT("Srcs=");
+    text << "Srcs=";
 
     BuildConfigPtr bldConf = clCxxWorkspaceST::Get()->GetProjBuildConf(proj->GetName(), confToBuild);
     wxString cmpType = bldConf->GetCompilerType();
@@ -663,8 +652,9 @@ void BuilderGnuMake::CreateSrcList(ProjectPtr proj, const wxString& confToBuild,
     for(size_t i = 0; i < files.size(); i++) {
 
         // is this a valid file?
-        if(!cmp->GetCmpFileType(files[i].GetExt(), ft))
+        if(!cmp->GetCmpFileType(files[i].GetExt(), ft)) {
             continue;
+        }
 
         if(IsResourceFile(ft) && !HandleResourceFiles()) {
             continue;
@@ -672,14 +662,14 @@ void BuilderGnuMake::CreateSrcList(ProjectPtr proj, const wxString& confToBuild,
 
         relPath = files.at(i).GetPath(true, wxPATH_UNIX);
         relPath.Trim().Trim(false);
-        text << relPath << files[i].GetFullName() << wxT(" ");
+        text << relPath << files[i].GetFullName() << " ";
 
         if(counter % 10 == 0) {
-            text << wxT("\\\n\t");
+            text << "\\\n\t";
         }
         counter++;
     }
-    text << wxT("\n\n");
+    text << "\n\n";
 }
 
 void BuilderGnuMake::CreateObjectList(ProjectPtr proj, const wxString& confToBuild, wxString& text)
@@ -711,7 +701,6 @@ void BuilderGnuMake::CreateObjectList(ProjectPtr proj, const wxString& confToBui
     int numOfObjectsInCurrentChunk = 0;
     wxString curChunk;
 
-    wxString imd = GetIntermediateFolder(proj, clCxxWorkspaceST::Get()->GetFileName().GetPath());
     // We break the list of files into a seriese of objects variables
     // each variable contains up to 100 files.
     // This is needed because on MSW, the ECHO command can not handle over 8K bytes
@@ -737,19 +726,20 @@ void BuilderGnuMake::CreateObjectList(ProjectPtr proj, const wxString& confToBui
         }
 
         // is this a valid file?
-        if(!cmp->GetCmpFileType(files[i].GetExt(), ft))
+        if(!cmp->GetCmpFileType(files[i].GetExt(), ft)) {
             continue;
+        }
 
         if(IsResourceFile(ft) && !HandleResourceFiles()) {
             continue;
         }
 
         wxString objPrefix = DoGetTargetPrefix(files.at(i), projectPath, cmp);
-        curChunk << imd << "/" << objPrefix << files[i].GetFullName() << wxT("$(ObjectSuffix) ");
+        curChunk << "$(IntermediateDirectory)/" << objPrefix << files[i].GetFullName() << "$(ObjectSuffix) ";
 
         // for readability, break every 10 objects and start a new line
         if(counter % 10 == 0) {
-            curChunk << wxT("\\\n\t");
+            curChunk << "\\\n\t";
         }
         counter++;
         numOfObjectsInCurrentChunk++;
@@ -767,7 +757,7 @@ void BuilderGnuMake::CreateObjectList(ProjectPtr proj, const wxString& confToBui
     for(size_t i = 0; i < objCounter; ++i)
         text << "$(Objects" << i << ") ";
 
-    text << wxT("\n\n");
+    text << "\n\n";
     m_objectChunks = objCounter;
 }
 
@@ -781,7 +771,7 @@ void BuilderGnuMake::CreateFileTargets(ProjectPtr proj, const wxString& confToBu
     CompilerPtr cmp = BuildSettingsConfigST::Get()->GetCompiler(cmpType);
     bool generateDependenciesFiles = cmp->GetGenerateDependeciesFile() && !cmp->GetDependSuffix().IsEmpty();
     bool supportPreprocessOnlyFiles =
-        !cmp->GetSwitch(wxT("PreprocessOnly")).IsEmpty() && !cmp->GetPreprocessSuffix().IsEmpty();
+        !cmp->GetSwitch("PreprocessOnly").IsEmpty() && !cmp->GetPreprocessSuffix().IsEmpty();
 
     std::vector<wxFileName> abs_files, rel_paths;
 
@@ -798,11 +788,11 @@ void BuilderGnuMake::CreateFileTargets(ProjectPtr proj, const wxString& confToBu
                       }
                   });
 
-    text << wxT("\n\n");
+    text << "\n\n";
     // create rule per object
-    text << wxT("##\n");
-    text << wxT("## Objects\n");
-    text << wxT("##\n");
+    text << "##\n";
+    text << "## Objects\n";
+    text << "##\n";
 
     Compiler::CmpFileTypeInfo ft;
 
@@ -810,7 +800,6 @@ void BuilderGnuMake::CreateFileTargets(ProjectPtr proj, const wxString& confToBu
     wxArrayString subDirs;
 
     wxString cwd = proj->GetFileName().GetPath();
-    wxString imd = GetIntermediateFolder(proj, clCxxWorkspaceST::Get()->GetFileName().GetPath()) + "/";
     for(size_t i = 0; i < abs_files.size(); i++) {
         // is this file interests the compiler?
         if(cmp->GetCmpFileType(abs_files.at(i).GetExt().Lower(), ft)) {
@@ -824,7 +813,7 @@ void BuilderGnuMake::CreateFileTargets(ProjectPtr proj, const wxString& confToBu
 
             // use UNIX style slashes
             absFileName = abs_files[i].GetFullPath();
-            absFileName.Replace(wxT("\\"), wxT("/"));
+            absFileName.Replace("\\", "/");
             wxString relPath;
 
             relPath = rel_paths.at(i).GetPath(true, wxPATH_UNIX);
@@ -832,14 +821,14 @@ void BuilderGnuMake::CreateFileTargets(ProjectPtr proj, const wxString& confToBu
 
             wxString objPrefix = DoGetTargetPrefix(abs_files.at(i), cwd, cmp);
 
-            compilationLine.Replace(wxT("$(FileName)"), filenameOnly);
-            compilationLine.Replace(wxT("$(FileFullName)"), fullnameOnly);
-            compilationLine.Replace(wxT("$(FileFullPath)"), fullpathOnly);
-            compilationLine.Replace(wxT("$(FilePath)"), relPath);
+            compilationLine.Replace("$(FileName)", filenameOnly);
+            compilationLine.Replace("$(FileFullName)", fullnameOnly);
+            compilationLine.Replace("$(FileFullPath)", fullpathOnly);
+            compilationLine.Replace("$(FilePath)", relPath);
 
             // The object name is handled differently when using resource files
-            compilationLine.Replace(wxT("$(ObjectName)"), objPrefix + fullnameOnly);
-            compilationLine.Replace(wxT("\\"), wxT("/"));
+            compilationLine.Replace("$(ObjectName)", objPrefix + fullnameOnly);
+            compilationLine.Replace("\\", "/");
 
             if(ft.kind == Compiler::CmpFileKindSource) {
                 wxString objectName;
@@ -848,27 +837,27 @@ void BuilderGnuMake::CreateFileTargets(ProjectPtr proj, const wxString& confToBu
 
                 bool isCFile = FileExtManager::GetType(rel_paths.at(i).GetFullName()) == FileExtManager::TypeSourceC;
 
-                objectName << imd << objPrefix << fullnameOnly << wxT("$(ObjectSuffix)");
+                objectName << "$(IntermediateDirectory)/" << objPrefix << fullnameOnly << "$(ObjectSuffix)";
                 if(generateDependenciesFiles) {
-                    dependFile << imd << objPrefix << fullnameOnly << wxT("$(DependSuffix)");
+                    dependFile << "$(IntermediateDirectory)/" << objPrefix << fullnameOnly << "$(DependSuffix)";
                 }
                 if(supportPreprocessOnlyFiles) {
-                    preprocessedFile << imd << objPrefix << fullnameOnly << wxT("$(PreprocessSuffix)");
+                    preprocessedFile << "$(IntermediateDirectory)/" << objPrefix << fullnameOnly
+                                     << "$(PreprocessSuffix)";
                 }
 
                 if(!isCFile) {
                     // Add the PCH include line
-                    compilationLine.Replace(wxT("$(CXX)"), wxT("$(CXX) $(IncludePCH)"));
+                    compilationLine.Replace("$(CXX)", "$(CXX) $(IncludePCH)");
                 }
 
                 // set the file rule
-                text << objectName << wxT(": ") << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << wxT(" ") << dependFile
-                     << wxT("\n");
-                text << wxT("\t") << compilationLine << wxT("\n");
+                text << objectName << ": " << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << " " << dependFile << "\n";
+                text << "\t" << compilationLine << "\n";
 
-                wxString cmpOptions(wxT("$(CXXFLAGS) $(IncludePCH)"));
+                wxString cmpOptions("$(CXXFLAGS) $(IncludePCH)");
                 if(isCFile) {
-                    cmpOptions = wxT("$(CFLAGS)");
+                    cmpOptions = "$(CFLAGS)";
                 }
 
                 // set the source file we want to compile
@@ -877,34 +866,34 @@ void BuilderGnuMake::CreateFileTargets(ProjectPtr proj, const wxString& confToBu
 
                 wxString compilerMacro = DoGetCompilerMacro(rel_paths.at(i).GetFullPath(wxPATH_UNIX));
                 if(generateDependenciesFiles) {
-                    text << dependFile << wxT(": ") << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << wxT("\n");
-                    text << wxT("\t") << wxT("@") << compilerMacro << wxT(" ") << cmpOptions
-                         << wxT(" $(IncludePath) -MG -MP -MT") << objectName << wxT(" -MF") << dependFile
-                         << wxT(" -MM ") << source_file_to_compile << wxT("\n\n");
+                    text << dependFile << ": " << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << "\n";
+                    text << "\t"
+                         << "@" << compilerMacro << " " << cmpOptions << " $(IncludePath) -MG -MP -MT" << objectName
+                         << " -MF" << dependFile << " -MM " << source_file_to_compile << "\n\n";
                 }
 
                 if(supportPreprocessOnlyFiles) {
-                    text << preprocessedFile << wxT(": ") << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << wxT("\n");
-                    text << wxT("\t") << compilerMacro << wxT(" ") << cmpOptions
-                         << wxT(" $(IncludePath) $(PreprocessOnlySwitch) $(OutputSwitch) ") << preprocessedFile
-                         << wxT(" ") << source_file_to_compile << wxT("\n\n");
+                    text << preprocessedFile << ": " << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << "\n";
+                    text << "\t" << compilerMacro << " " << cmpOptions
+                         << " $(IncludePath) $(PreprocessOnlySwitch) $(OutputSwitch) " << preprocessedFile << " "
+                         << source_file_to_compile << "\n\n";
                 }
 
             } else if(IsResourceFile(ft) && HandleResourceFiles()) {
                 // we construct an object name which also includes the full name of the reousrce file and appends a
                 // .o to the name (to be more precised, $(ObjectSuffix))
                 wxString objectName;
-                objectName << imd << objPrefix << fullnameOnly << wxT("$(ObjectSuffix)");
+                objectName << "$(IntermediateDirectory)/" << objPrefix << fullnameOnly << "$(ObjectSuffix)";
 
-                text << objectName << wxT(": ") << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << wxT("\n");
-                text << wxT("\t") << compilationLine << wxT("\n");
+                text << objectName << ": " << rel_paths.at(i).GetFullPath(wxPATH_UNIX) << "\n";
+                text << "\t" << compilationLine << "\n";
             }
         }
     }
 
     if(generateDependenciesFiles) {
-        text << wxT("\n");
-        text << wxT("-include ") << imd << wxT("/*$(DependSuffix)\n");
+        text << "\n";
+        text << "-include $(IntermediateDirectory)/*$(DependSuffix)\n";
     }
 }
 
@@ -918,21 +907,25 @@ void BuilderGnuMake::CreateCleanTargets(ProjectPtr proj, const wxString& confToB
     CompilerPtr cmp = BuildSettingsConfigST::Get()->GetCompiler(cmpType);
 
     // add clean target
-    text << wxT("##\n");
-    text << wxT("## Clean\n");
-    text << wxT("##\n");
-    text << wxT("clean:\n");
+    text << "##\n";
+    text << "## Clean\n";
+    text << "##\n";
+    text << "clean:\n";
 
     // Remove the entire build folder
-    text << wxT("\t") << wxT("$(RM) -r $(IntermediateDirectory)") << "\n";
+    text << "\t"
+         << "$(RM) -r $(IntermediateDirectory)"
+         << "\n";
 
     // Remove the pre-compiled header
     wxString pchFile = bldConf->GetPrecompiledHeader();
     pchFile.Trim().Trim(false);
     if(pchFile.IsEmpty() == false && (bldConf->GetPCHFlagsPolicy() != BuildConfig::kPCHJustInclude)) {
-        text << wxT("\t") << wxT("$(RM) ") << pchFile << wxT(".gch") << wxT("\n");
+        text << "\t"
+             << "$(RM) " << pchFile << ".gch"
+             << "\n";
     }
-    text << wxT("\n\n");
+    text << "\n\n";
 }
 
 void BuilderGnuMake::CreateListMacros(ProjectPtr proj, const wxString& confToBuild, wxString& text)
@@ -950,7 +943,7 @@ void BuilderGnuMake::CreateLinkTargets(const wxString& type, BuildConfigPtr bldC
     // this is to workaround bug in the generated makefiles
     // which causes the makefile to report 'nothing to be done'
     // even when a dependency was modified
-    text << wxT(".PHONY: all clean PreBuild PrePreBuild PostBuild MakeIntermediateDirs\n");
+    text << ".PHONY: all clean PreBuild PrePreBuild PostBuild MakeIntermediateDirs\n";
 
     wxString extraDeps;
     wxString depsRules;
@@ -960,42 +953,46 @@ void BuilderGnuMake::CreateLinkTargets(const wxString& type, BuildConfigPtr bldC
 
     for(size_t i = 0; i < depsProj.GetCount(); i++) {
         wxFileName fn(depsProj.Item(i));
-        // CL_DEBUG(wxT("making %s relative to %s"), fn.GetFullPath().c_str(),
+        // CL_DEBUG("making %s relative to %s", fn.GetFullPath().c_str(),
         // proj->GetFileName().GetPath().c_str());
         fn.MakeRelativeTo(proj->GetProjectPath());
-        extraDeps << "\"" << fn.GetFullPath() << wxT("\" ");
+        extraDeps << "\"" << fn.GetFullPath() << "\" ";
 
-        depsRules << "\"" << fn.GetFullPath() << wxT("\":\n");
+        depsRules << "\"" << fn.GetFullPath() << "\":\n";
         // Make sure the dependecy directory exists
         depsRules << "\t" << MakeDir(fn.GetPath()) << "\n";
-        depsRules << wxT("\t@echo stam > ") << wxT("\"") << fn.GetFullPath() << wxT("\"\n");
-        depsRules << wxT("\n\n");
+        depsRules << "\t@echo stam > "
+                  << "\"" << fn.GetFullPath() << "\"\n";
+        depsRules << "\n\n";
     }
-    wxString imd = GetIntermediateFolder(proj, clCxxWorkspaceST::Get()->GetFileName().GetPath());
+
     if(type == PROJECT_TYPE_EXECUTABLE || type == PROJECT_TYPE_DYNAMIC_LIBRARY) {
-        text << wxT("all: MakeIntermediateDirs ");
-        text << wxT("$(OutputFile)\n\n");
+        text << "all: MakeIntermediateDirs ";
+        text << "$(OutputFile)\n\n";
 
-        text << wxT("$(OutputFile): " << imd << "/.d ");
-        if(extraDeps.IsEmpty() == false)
+        text << "$(OutputFile): $(IntermediateDirectory)/.d ";
+        if(extraDeps.IsEmpty() == false) {
             text << extraDeps;
+        }
 
-        text << wxT("$(Objects) \n");
-        targetName = wxString() << imd << wxT("/.d");
+        text << "$(Objects) \n";
+        targetName = "$(IntermediateDirectory)/.d";
 
     } else {
-        text << wxT("all: MakeIntermediateDirs ") << imd << "/" << wxT("$(OutputFile)\n\n");
-        text << imd << "/" << wxT("$(OutputFile): $(Objects)\n");
+        text << "all: MakeIntermediateDirs $(IntermediateDirectory)/"
+             << "$(OutputFile)\n\n";
+        text << "$(IntermediateDirectory)/"
+             << "$(OutputFile): $(Objects)\n";
     }
 
     if(bldConf->IsLinkerRequired()) {
-        text << "\t" << MakeDir(imd) << "\n";
+        text << "\t" << MakeDir("$(IntermediateDirectory)") << "\n";
         text << "\t@echo \"\" > $(IntermediateDirectory)/.d\n";
         CreateTargets(type, bldConf, text, projName);
 
         if(type == PROJECT_TYPE_EXECUTABLE || type == PROJECT_TYPE_DYNAMIC_LIBRARY) {
             if(depsRules.IsEmpty() == false) {
-                text << wxT("\n") << depsRules << wxT("\n");
+                text << "\n" << depsRules << "\n";
             }
         }
     }
@@ -1012,9 +1009,9 @@ void BuilderGnuMake::CreateTargets(const wxString& type, BuildConfigPtr bldConf,
     // $(Objects) variable (to be used with the @<file-name> option of the LD
     for(size_t i = 0; i < m_objectChunks; ++i) {
         wxString oper = ">>";
-        if(i == 0)
+        if(i == 0) {
             oper = " >";
-
+        }
         text << "\t@echo $(Objects" << i << ") " << oper << " $(ObjectsFileList)\n";
     }
 
@@ -1031,8 +1028,9 @@ void BuilderGnuMake::CreateTargets(const wxString& type, BuildConfigPtr bldConf,
 
 void BuilderGnuMake::CreatePostBuildEvents(ProjectPtr proj, BuildConfigPtr bldConf, wxString& text)
 {
-    if(!HasPostbuildCommands(bldConf))
+    if(!HasPostbuildCommands(bldConf)) {
         return;
+    }
 
     // generate postbuild commands
     BuildCommandList cmds;
@@ -1045,9 +1043,9 @@ void BuilderGnuMake::CreatePostBuildEvents(ProjectPtr proj, BuildConfigPtr bldCo
     //            bldConf->GetName()));
     //    });
 
-    text << wxT("\n");
-    text << wxT("PostBuild:\n");
-    text << wxT("\t@echo Executing Post Build commands ...\n");
+    text << "\n";
+    text << "PostBuild:\n";
+    text << "\t@echo Executing Post Build commands ...\n";
 
     BuildCommandList::const_iterator iter = cmds.begin();
     for(; iter != cmds.end(); iter++) {
@@ -1057,18 +1055,18 @@ void BuilderGnuMake::CreatePostBuildEvents(ProjectPtr proj, BuildConfigPtr bldCo
             // we set all slashes to backward slashes
             wxString command = iter->GetCommand();
             command.Trim().Trim(false);
-            if(m_isWindows && command.StartsWith(wxT("copy"))) {
-                command.Replace(wxT("/"), wxT("\\"));
+            if(m_isWindows && command.StartsWith("copy")) {
+                command.Replace("/", "\\");
             }
 
-            if(m_isWindows && command.EndsWith(wxT("\\"))) {
+            if(m_isWindows && command.EndsWith("\\")) {
                 command.RemoveLast();
             }
 
-            text << wxT("\t") << iter->GetCommand() << wxT("\n");
+            text << "\t" << iter->GetCommand() << "\n";
         }
     }
-    text << wxT("\t@echo Done\n");
+    text << "\t@echo Done\n";
 }
 
 bool BuilderGnuMake::HasPrebuildCommands(BuildConfigPtr bldConf) const
@@ -1096,10 +1094,10 @@ void BuilderGnuMake::CreatePreBuildEvents(ProjectPtr proj, BuildConfigPtr bldCon
     wxString preprebuild = bldConf->GetPreBuildCustom();
     preprebuild.Trim().Trim(false);
     if(preprebuild.IsEmpty() == false) {
-        text << wxT("PrePreBuild: ");
-        text << bldConf->GetPreBuildCustom() << wxT("\n");
+        text << "PrePreBuild: ";
+        text << bldConf->GetPreBuildCustom() << "\n";
     }
-    text << wxT("\n");
+    text << "\n";
     bldConf->GetPreBuildCommands(cmds);
 
     // Loop over the commands and replace any macros
@@ -1109,20 +1107,20 @@ void BuilderGnuMake::CreatePreBuildEvents(ProjectPtr proj, BuildConfigPtr bldCon
     });
 
     bool first(true);
-    text << wxT("PreBuild:\n");
+    text << "PreBuild:\n";
     if(!cmds.empty()) {
         iter = cmds.begin();
         for(; iter != cmds.end(); iter++) {
             if(iter->GetEnabled()) {
                 if(first) {
-                    text << wxT("\t@echo Executing Pre Build commands ...\n");
+                    text << "\t@echo Executing Pre Build commands ...\n";
                     first = false;
                 }
-                text << wxT("\t") << iter->GetCommand() << wxT("\n");
+                text << "\t" << iter->GetCommand() << "\n";
             }
         }
         if(!first) {
-            text << wxT("\t@echo Done\n");
+            text << "\t@echo Done\n";
         }
     }
 }
@@ -1138,7 +1136,7 @@ void BuilderGnuMake::CreateConfigsVariables(ProjectPtr proj, BuildConfigPtr bldC
     wxString objectsFileName;
     objectsFileName << "$(IntermediateDirectory)/ObjectsList.txt";
 
-    text << wxT("## ") << name << wxT("\n");
+    text << "## " << name << "\n";
 
     wxString outputFile = bldConf->GetOutputFileName();
     if(m_isWindows && (bldConf->GetProjectType() == PROJECT_TYPE_EXECUTABLE || bldConf->GetProjectType().IsEmpty())) {
@@ -1146,33 +1144,52 @@ void BuilderGnuMake::CreateConfigsVariables(ProjectPtr proj, BuildConfigPtr bldC
     }
 
     // Expand the build macros into the generated makefile
-    wxString projectName = proj->GetName();
-    wxString projectpath, workspacepath, startupdir, intermediatedir;
-    workspacepath = clCxxWorkspaceST::Get()->GetWorkspaceFileName().GetPath();
-    projectpath = proj->GetFileName().GetPath();
-    startupdir = clCxxWorkspaceST::Get()->GetStartupDir();
-    workspacepath.Replace("\\", "/");
-    projectpath.Replace("\\", "/");
-    startupdir.Replace("\\", "/");
-    intermediatedir = GetIntermediateFolder(proj, workspacepath);
+    wxString workspacePath = clCxxWorkspaceST::Get()->GetWorkspaceFileName().GetPath();
+    wxString projectPath = proj->GetFileName().GetPath();
+    wxString startupDir = clCxxWorkspaceST::Get()->GetStartupDir();
+    workspacePath.Replace("\\", "/");
+    projectPath.Replace("\\", "/");
+    startupDir.Replace("\\", "/");
 
-    wxFileName fnOutputFile(GetOutputFolder(proj, bldConf), outputFile.AfterLast('/'));
-    outputFile = fnOutputFile.GetFullPath();
-    ::WrapWithQuotes(outputFile);
+    // We use relative path in $(IntermediateDirectory) and $(OutputFile)
+    // to reduce issues with path containing spaces
+    wxString intermediateDir = GetIntermediateDirectory(proj, bldConf);
 
-    text << "ProjectName            :=" << projectName << "\n";
-    text << "ConfigurationName      :=" << clCxxWorkspaceST::Get()->GetSelectedConfig()->GetName() << "\n";
-    text << "WorkspaceConfiguration := $(ConfigurationName)\n";
-    text << "WorkspacePath          :=" << ::WrapWithQuotes(workspacepath) << "\n";
-    text << "ProjectPath            :=" << ::WrapWithQuotes(projectpath) << "\n";
-    text << "IntermediateDirectory  :=" << intermediatedir << "\n";
-    text << "OutDir                 :=" << intermediatedir << "\n";
+    wxString outputDir = bldConf->GetOutputDirectory();
+    if(outputDir.IsEmpty()) {
+        outputDir << "$(WorkspacePath)/build-$(WorkspaceConfiguration)/"
+                  << (bldConf->GetProjectType() == PROJECT_TYPE_EXECUTABLE ? "bin" : "lib");
+    }
+    outputDir.Replace("$(WorkspacePath)", workspacePath);
+    outputDir.Replace("$(ProjectPath)", projectPath);
+    outputDir.Replace("$(IntermediateDirectory)", intermediateDir);
+    wxFileName fnOutputFile(outputDir, outputFile.AfterLast('/'));
+    if(fnOutputFile.IsAbsolute()) {
+        fnOutputFile.MakeRelativeTo(projectPath);
+    }
+    // $(OutputFile) uses native path separator for backward-compatibility reasons
+    // (i.e. it will be backslash on Windows, and forward slash otherwise)
+    outputFile = fnOutputFile.GetFullPath(wxPATH_NATIVE);
+
+    wxString mkdirCommand = cmp->GetTool("MakeDirCommand");
+    if(mkdirCommand.IsEmpty()) {
+        mkdirCommand = m_isWindows ? "mkdir" : "mkdir -p";
+    }
+
+    text << "ProjectName            :=" << proj->GetName() << "\n";
+    text << "ConfigurationName      :=" << name << "\n";
+    text << "WorkspaceConfiguration :=" << clCxxWorkspaceST::Get()->GetSelectedConfig()->GetName() << "\n";
+    text << "WorkspacePath          :=" << ::WrapWithQuotes(workspacePath) << "\n";
+    text << "ProjectPath            :=" << ::WrapWithQuotes(projectPath) << "\n";
+    text << "IntermediateDirectory  :=" << intermediateDir << "\n";
+    text << "OutDir                 :=$(IntermediateDirectory)\n";
     text << "CurrentFileName        :=\n";
     text << "CurrentFilePath        :=\n";
     text << "CurrentFileFullPath    :=\n";
     text << "User                   :=" << wxGetUserName() << "\n";
     text << "Date                   :=" << wxDateTime::Now().FormatDate() << "\n";
-    text << "CodeLitePath           :=" << ::WrapWithQuotes(startupdir) << "\n";
+    text << "CodeLitePath           :=" << ::WrapWithQuotes(startupDir) << "\n";
+    text << "MakeDirCommand         :=" << mkdirCommand << "\n";
     text << "LinkerName             :=" << cmp->GetTool("LinkerName") << "\n";
     text << "SharedObjectLinkerName :=" << cmp->GetTool("SharedObjectLinkerName") << "\n";
     text << "ObjectSuffix           :=" << cmp->GetObjectSuffix() << "\n";
@@ -1185,19 +1202,20 @@ void BuilderGnuMake::CreateConfigsVariables(ProjectPtr proj, BuildConfigPtr bldC
     text << "LibraryPathSwitch      :=" << cmp->GetSwitch("LibraryPath") << "\n";
     text << "PreprocessorSwitch     :=" << cmp->GetSwitch("Preprocessor") << "\n";
     text << "SourceSwitch           :=" << cmp->GetSwitch("Source") << "\n";
+    text << "OutputDirectory        :=" << outputDir << "\n";
     text << "OutputFile             :=" << outputFile << "\n";
     text << "Preprocessors          :=" << ParsePreprocessor(bldConf->GetPreprocessor()) << "\n";
     text << "ObjectSwitch           :=" << cmp->GetSwitch("Object") << "\n";
     text << "ArchiveOutputSwitch    :=" << cmp->GetSwitch("ArchiveOutput") << "\n";
     text << "PreprocessOnlySwitch   :=" << cmp->GetSwitch("PreprocessOnly") << "\n";
     text << "ObjectsFileList        :=" << objectsFileName << "\n";
-    text << "PCHCompileFlags        :=" << bldConf->GetPchCompileFlags() << wxT("\n");
+    text << "PCHCompileFlags        :=" << bldConf->GetPchCompileFlags() << "\n";
 
     wxString buildOpts = bldConf->GetCompileOptions();
-    buildOpts.Replace(wxT(";"), wxT(" "));
+    buildOpts.Replace(";", " ");
 
     wxString cBuildOpts = bldConf->GetCCompileOptions();
-    cBuildOpts.Replace(wxT(";"), wxT(" "));
+    cBuildOpts.Replace(";", " ");
 
     wxString asOptions = bldConf->GetAssmeblerOptions();
     asOptions.Replace(";", " ");
@@ -1210,23 +1228,23 @@ void BuilderGnuMake::CreateConfigsVariables(ProjectPtr proj, BuildConfigPtr bldC
 
     wxString additionalCompileFlags = e.GetCommand();
     if(additionalCompileFlags.IsEmpty() == false) {
-        buildOpts << wxT(" ") << additionalCompileFlags;
-        cBuildOpts << wxT(" ") << additionalCompileFlags;
+        buildOpts << " " << additionalCompileFlags;
+        cBuildOpts << " " << additionalCompileFlags;
     }
 
     // only if resource compiler required, evaluate the resource variables
     if(HandleResourceFiles()) {
         wxString rcBuildOpts = bldConf->GetResCompileOptions();
-        rcBuildOpts.Replace(wxT(";"), wxT(" "));
-        text << wxT("RcCmpOptions           :=") << rcBuildOpts << wxT("\n");
-        text << wxT("RcCompilerName         :=") << cmp->GetTool(wxT("ResourceCompiler")) << wxT("\n");
+        rcBuildOpts.Replace(";", " ");
+        text << "RcCmpOptions           :=" << rcBuildOpts << "\n";
+        text << "RcCompilerName         :=" << cmp->GetTool("ResourceCompiler") << "\n";
     }
 
     wxString linkOpt = bldConf->GetLinkOptions();
-    linkOpt.Replace(wxT(";"), wxT(" "));
+    linkOpt.Replace(";", " ");
 
     // link options are kept with semi-colons, strip them
-    text << wxT("LinkOptions            := ") << linkOpt << wxT("\n");
+    text << "LinkOptions            := " << linkOpt << "\n";
 
     // add the global include path followed by the project include path
     wxString pchFile;
@@ -1237,46 +1255,47 @@ void BuilderGnuMake::CreateConfigsVariables(ProjectPtr proj, BuildConfigPtr bldC
         pchFile = bldConf->GetPrecompiledHeader();
         pchFile.Trim().Trim(false);
         if(pchFile.IsEmpty() == false) {
-            pchFile.Prepend(wxT(" -include ")).Append(wxT(" "));
+            pchFile.Prepend(" -include ").Append(" ");
         }
     }
 
     wxString libraries = bldConf->GetLibraries();
-    wxArrayString libsArr = ::wxStringTokenize(libraries, wxT(";"), wxTOKEN_STRTOK);
+    wxArrayString libsArr = ::wxStringTokenize(libraries, ";", wxTOKEN_STRTOK);
     libraries.Clear();
-    libraries << wxT(" ");
+    libraries << " ";
     for(size_t i = 0; i < libsArr.GetCount(); i++) {
         libsArr.Item(i).Trim().Trim(false);
-        libraries << wxT("\"") << libsArr.Item(i) << wxT("\" ");
+        libraries << "\"" << libsArr.Item(i) << "\" ";
     }
 
-    text << wxT("IncludePath            := ")
-         << ParseIncludePath(cmp->GetGlobalIncludePath(), proj->GetName(), bldConf->GetName()) << wxT(" ")
-         << ParseIncludePath(bldConf->GetIncludePath(), proj->GetName(), bldConf->GetName()) << wxT("\n");
-    text << wxT("IncludePCH             := ") << pchFile << wxT("\n");
-    text << wxT("RcIncludePath          := ")
-         << ParseIncludePath(bldConf->GetResCmpIncludePath(), proj->GetName(), bldConf->GetName()) << wxT("\n");
-    text << wxT("Libs                   := ") << ParseLibs(bldConf->GetLibraries()) << wxT("\n");
-    text << wxT("ArLibs                 := ") << libraries << wxT("\n");
+    text << "IncludePath            := "
+         << ParseIncludePath(cmp->GetGlobalIncludePath(), proj->GetName(), bldConf->GetName()) << " "
+         << ParseIncludePath(bldConf->GetIncludePath(), proj->GetName(), bldConf->GetName()) << "\n";
+    text << "IncludePCH             := " << pchFile << "\n";
+    text << "RcIncludePath          := "
+         << ParseIncludePath(bldConf->GetResCmpIncludePath(), proj->GetName(), bldConf->GetName()) << "\n";
+    text << "Libs                   := " << ParseLibs(bldConf->GetLibraries()) << "\n";
+    text << "ArLibs                 := " << libraries << "\n";
 
     // add the global library path followed by the project library path
-    text << wxT("LibPath                :=")
-         << ParseLibPath(cmp->GetGlobalLibPath(), proj->GetName(), bldConf->GetName()) << wxT(" ")
-         << ParseLibPath(bldConf->GetLibPath(), proj->GetName(), bldConf->GetName()) << wxT("\n");
+    text << "LibPath                :=" << ParseLibPath(cmp->GetGlobalLibPath(), proj->GetName(), bldConf->GetName())
+         << " " << ParseLibPath(bldConf->GetLibPath(), proj->GetName(), bldConf->GetName()) << "\n";
 
-    text << wxT("\n");
-    text << wxT("##\n");
-    text << wxT("## Common variables\n");
-    text << wxT("## AR, CXX, CC, AS, CXXFLAGS and CFLAGS can be overriden using an environment variables\n");
-    text << wxT("##\n");
-    text << wxT("AR       := ") << cmp->GetTool(wxT("AR")) << wxT("\n");
-    text << wxT("CXX      := ") << cmp->GetTool(wxT("CXX")) << wxT("\n");
-    text << wxT("CC       := ") << cmp->GetTool(wxT("CC")) << wxT("\n");
-    text << wxT("CXXFLAGS := ") << buildOpts << wxT(" $(Preprocessors)") << wxT("\n");
-    text << wxT("CFLAGS   := ") << cBuildOpts << wxT(" $(Preprocessors)") << wxT("\n");
-    text << wxT("ASFLAGS  := ") << asOptions << "\n";
-    text << wxT("AS       := ") << cmp->GetTool(wxT("AS")) << "\n";
-    text << wxT("\n\n");
+    text << "\n";
+    text << "##\n";
+    text << "## Common variables\n";
+    text << "## AR, CXX, CC, AS, CXXFLAGS and CFLAGS can be overriden using an environment variables\n";
+    text << "##\n";
+    text << "AR       := " << cmp->GetTool("AR") << "\n";
+    text << "CXX      := " << cmp->GetTool("CXX") << "\n";
+    text << "CC       := " << cmp->GetTool("CC") << "\n";
+    text << "CXXFLAGS := " << buildOpts << " $(Preprocessors)"
+         << "\n";
+    text << "CFLAGS   := " << cBuildOpts << " $(Preprocessors)"
+         << "\n";
+    text << "ASFLAGS  := " << asOptions << "\n";
+    text << "AS       := " << cmp->GetTool("AS") << "\n";
+    text << "\n\n";
 }
 
 wxString BuilderGnuMake::ParseIncludePath(const wxString& paths, const wxString& projectName, const wxString& selConf)
@@ -1284,12 +1303,12 @@ wxString BuilderGnuMake::ParseIncludePath(const wxString& paths, const wxString&
     // convert semi-colon delimited string into GNU list of
     // include paths:
     wxString incluedPath(wxEmptyString);
-    wxStringTokenizer tkz(paths, wxT(";"), wxTOKEN_STRTOK);
+    wxStringTokenizer tkz(paths, ";", wxTOKEN_STRTOK);
     while(tkz.HasMoreTokens()) {
         wxString path(tkz.NextToken());
         TrimString(path);
         ::WrapWithQuotes(path);
-        incluedPath << wxT("$(IncludeSwitch)") << path << wxT(" ");
+        incluedPath << "$(IncludeSwitch)" << path << " ";
     }
     return incluedPath;
 }
@@ -1299,13 +1318,13 @@ wxString BuilderGnuMake::ParseLibPath(const wxString& paths, const wxString& pro
     // convert semi-colon delimited string into GNU list of
     // lib path
     wxString libPath(wxEmptyString);
-    wxStringTokenizer tkz(paths, wxT(";"), wxTOKEN_STRTOK);
+    wxStringTokenizer tkz(paths, ";", wxTOKEN_STRTOK);
     // prepend each include path with libpath switch
     while(tkz.HasMoreTokens()) {
         wxString path(tkz.NextToken());
         path.Trim().Trim(false);
         ::WrapWithQuotes(path);
-        libPath << wxT("$(LibraryPathSwitch)") << path << wxT(" ");
+        libPath << "$(LibraryPathSwitch)" << path << " ";
     }
     return libPath;
 }
@@ -1317,13 +1336,13 @@ wxString BuilderGnuMake::ParsePreprocessor(const wxString& prep)
     // prepend each include path with libpath switch
     for(wxString& p : tokens) {
         p.Trim().Trim(false);
-        preprocessor << wxT("$(PreprocessorSwitch)") << p << wxT(" ");
+        preprocessor << "$(PreprocessorSwitch)" << p << " ";
     }
 
     // if the macro contains # escape it
     // But first remove any manual escaping done by the user
-    preprocessor.Replace(wxT("\\#"), wxT("#"));
-    preprocessor.Replace(wxT("#"), wxT("\\#"));
+    preprocessor.Replace("\\#", "#");
+    preprocessor.Replace("#", "\\#");
     return preprocessor;
 }
 
@@ -1332,24 +1351,23 @@ wxString BuilderGnuMake::ParseLibs(const wxString& libs)
     // convert semi-colon delimited string into GNU list of
     // libs
     wxString slibs(wxEmptyString);
-    wxStringTokenizer tkz(libs, wxT(";"), wxTOKEN_STRTOK);
+    wxStringTokenizer tkz(libs, ";", wxTOKEN_STRTOK);
     // prepend each include path with -l and strip trailing lib string
     // also, if the file contains an extension (.a, .so, .dynlib) remove them as well
     while(tkz.HasMoreTokens()) {
         wxString lib(tkz.NextToken());
         TrimString(lib);
         // remove lib prefix
-        if(lib.StartsWith(wxT("lib"))) {
+        if(lib.StartsWith("lib")) {
             lib = lib.Mid(3);
         }
 
         // remove known suffixes
-        if(lib.EndsWith(wxT(".a")) || lib.EndsWith(wxT(".so")) || lib.EndsWith(wxT(".dylib")) ||
-           lib.EndsWith(wxT(".dll"))) {
-            lib = lib.BeforeLast(wxT('.'));
+        if(lib.EndsWith(".a") || lib.EndsWith(".so") || lib.EndsWith(".dylib") || lib.EndsWith(".dll")) {
+            lib = lib.BeforeLast('.');
         }
 
-        slibs << wxT("$(LibrarySwitch)") << lib << wxT(" ");
+        slibs << "$(LibrarySwitch)" << lib << " ";
     }
     return slibs;
 }
@@ -1370,8 +1388,8 @@ wxString BuilderGnuMake::GetBuildCommand(const wxString& project, const wxString
     buildTool = EnvironmentConfig::Instance()->ExpandVariables(buildTool, true);
 
     // fix: replace all Windows like slashes to POSIX
-    buildTool.Replace(wxT("\\"), wxT("/"));
-    cmd << buildTool << wxT(" Makefile");
+    buildTool.Replace("\\", "/");
+    cmd << buildTool << " Makefile";
     return cmd;
 }
 
@@ -1391,11 +1409,11 @@ wxString BuilderGnuMake::GetCleanCommand(const wxString& project, const wxString
     buildTool = EnvironmentConfig::Instance()->ExpandVariables(buildTool, true);
 
     // fix: replace all Windows like slashes to POSIX
-    buildTool.Replace(wxT("\\"), wxT("/"));
+    buildTool.Replace("\\", "/");
 
     BuildMatrixPtr matrix = clCxxWorkspaceST::Get()->GetBuildMatrix();
     wxString type = Builder::NormalizeConfigName(matrix->GetSelectedConfigurationName());
-    cmd << buildTool << wxT(" Makefile clean");
+    cmd << buildTool << " Makefile clean";
     return cmd;
 }
 
@@ -1410,7 +1428,7 @@ wxString BuilderGnuMake::GetPOBuildCommand(const wxString& project, const wxStri
 
     // generate the makefile
     Export(project, confToBuild, arguments, true, false, errMsg);
-    cmd = GetProjectMakeCommand(proj, confToBuild, wxT("all"), kIncludePreBuild | kIncludePostBuild);
+    cmd = GetProjectMakeCommand(proj, confToBuild, "all", kIncludePreBuild | kIncludePostBuild);
     return cmd;
 }
 
@@ -1425,7 +1443,7 @@ wxString BuilderGnuMake::GetPOCleanCommand(const wxString& project, const wxStri
 
     // generate the makefile
     Export(project, confToBuild, arguments, true, false, errMsg);
-    cmd = GetProjectMakeCommand(proj, confToBuild, wxT("clean"), kCleanOnly | kIncludePreBuild);
+    cmd = GetProjectMakeCommand(proj, confToBuild, "clean", kCleanOnly | kIncludePreBuild);
     return cmd;
 }
 
@@ -1470,8 +1488,8 @@ wxString BuilderGnuMake::GetSingleFileCmd(const wxString& project, const wxStrin
 
     wxString relPath = fn.GetPath(true, wxPATH_UNIX);
     wxString objNamePrefix = DoGetTargetPrefix(fn, proj->GetFileName().GetPath(), cmp);
-    target << GetIntermediateFolder(proj, clCxxWorkspaceST::Get()->GetFileName().GetPath()) << wxT("/") << objNamePrefix
-           << fn.GetFullName() << cmp->GetObjectSuffix();
+    target << GetIntermediateDirectory(proj, bldConf) << "/" << objNamePrefix << fn.GetFullName()
+           << cmp->GetObjectSuffix();
 
     target = ExpandAllVariables(target, clCxxWorkspaceST::Get(), proj->GetName(), confToBuild, wxEmptyString);
     cmd = GetProjectMakeCommand(proj, confToBuild, target, kIncludePreBuild);
@@ -1501,7 +1519,7 @@ wxString BuilderGnuMake::GetPreprocessFileCmd(const wxString& project, const wxS
     wxString type = matrix->GetProjectSelectedConf(matrix->GetSelectedConfigurationName(), project);
 
     // fix: replace all Windows like slashes to POSIX
-    buildTool.Replace(wxT("\\"), wxT("/"));
+    buildTool.Replace("\\", "/");
 
     // create the target
     wxString target;
@@ -1512,8 +1530,8 @@ wxString BuilderGnuMake::GetPreprocessFileCmd(const wxString& project, const wxS
     CompilerPtr cmp = BuildSettingsConfigST::Get()->GetCompiler(cmpType);
 
     wxString objNamePrefix = DoGetTargetPrefix(fn, proj->GetFileName().GetPath(), cmp);
-    target << GetIntermediateFolder(proj, clCxxWorkspaceST::Get()->GetFileName().GetPath()) << wxT("/") << objNamePrefix
-           << fn.GetFullName() << cmp->GetPreprocessSuffix();
+    target << GetIntermediateDirectory(proj, bldConf) << "/" << objNamePrefix << fn.GetFullName()
+           << cmp->GetPreprocessSuffix();
 
     target = ExpandAllVariables(target, clCxxWorkspaceST::Get(), proj->GetName(), confToBuild, wxEmptyString);
     cmd = GetProjectMakeCommand(proj, confToBuild, target, kIncludePreBuild);
@@ -1522,13 +1540,13 @@ wxString BuilderGnuMake::GetPreprocessFileCmd(const wxString& project, const wxS
 
 wxString BuilderGnuMake::GetCdCmd(const wxFileName& path1, const wxFileName& path2)
 {
-    wxString cd_cmd(wxT("@"));
+    wxString cd_cmd("@");
     if(path2.GetPath().IsEmpty()) {
         return cd_cmd;
     }
 
     if(path1.GetPath() != path2.GetPath()) {
-        cd_cmd << wxT("cd \"") << path2.GetPath() << wxT("\" && ");
+        cd_cmd << "cd \"" << path2.GetPath() << "\" && ";
     }
     return cd_cmd;
 }
@@ -1546,14 +1564,14 @@ void BuilderGnuMake::CreateCustomPostBuildEvents(BuildConfigPtr bldConf, wxStrin
         for(; iter != cmds.end(); iter++) {
             if(iter->GetEnabled()) {
                 if(first) {
-                    text << wxT("\t@echo Executing Post Build commands ...\n");
+                    text << "\t@echo Executing Post Build commands ...\n";
                     first = false;
                 }
-                text << wxT("\t") << iter->GetCommand() << wxT("\n");
+                text << "\t" << iter->GetCommand() << "\n";
             }
         }
         if(!first) {
-            text << wxT("\t@echo Done\n");
+            text << "\t@echo Done\n";
         }
     }
 }
@@ -1571,14 +1589,14 @@ void BuilderGnuMake::CreateCustomPreBuildEvents(BuildConfigPtr bldConf, wxString
         for(; iter != cmds.end(); iter++) {
             if(iter->GetEnabled()) {
                 if(first) {
-                    text << wxT("\t@echo Executing Pre Build commands ...\n");
+                    text << "\t@echo Executing Pre Build commands ...\n";
                     first = false;
                 }
-                text << wxT("\t") << iter->GetCommand() << wxT("\n");
+                text << "\t" << iter->GetCommand() << "\n";
             }
         }
         if(!first) {
-            text << wxT("\t@echo Done\n");
+            text << "\t@echo Done\n";
         }
     }
 }
@@ -1594,9 +1612,9 @@ wxString BuilderGnuMake::GetProjectMakeCommand(const wxFileName& wspfile, const 
 
     wxString buildTool = GetBuildToolCommand(proj->GetName(), confToBuild, "", false);
     buildTool = EnvironmentConfig::Instance()->ExpandVariables(buildTool, true);
-    basicMakeCommand << buildTool << wxT(" \"") << proj->GetName() << wxT(".mk\"");
+    basicMakeCommand << buildTool << " \"" << proj->GetName() << ".mk\"";
 
-    makeCommand << wxT("\t") << GetCdCmd(wspfile, projectPath);
+    makeCommand << "\t" << GetCdCmd(wspfile, projectPath);
 
     if(bldConf) {
         wxString preprebuild = bldConf->GetPreBuildCustom();
@@ -1605,16 +1623,17 @@ wxString BuilderGnuMake::GetProjectMakeCommand(const wxFileName& wspfile, const 
         preprebuild.Trim().Trim(false);
 
         if(preprebuild.IsEmpty() == false) {
-            makeCommand << basicMakeCommand << wxT(" PrePreBuild && ");
+            makeCommand << basicMakeCommand << " PrePreBuild && ";
         }
 
         if(HasPrebuildCommands(bldConf)) {
-            makeCommand << basicMakeCommand << wxT(" PreBuild && ");
+            makeCommand << basicMakeCommand << " PreBuild && ";
         }
 
         // Run pre-compiled header compilation if any
         if(precmpheader.IsEmpty() == false && (bldConf->GetPCHFlagsPolicy() != BuildConfig::kPCHJustInclude)) {
-            makeCommand << basicMakeCommand << wxT(" ") << precmpheader << wxT(".gch") << wxT(" && ");
+            makeCommand << basicMakeCommand << " " << precmpheader << ".gch"
+                        << " && ";
         }
     }
 
@@ -1623,9 +1642,9 @@ wxString BuilderGnuMake::GetProjectMakeCommand(const wxFileName& wspfile, const 
 
     // post
     if(bldConf && HasPostbuildCommands(bldConf)) {
-        makeCommand << wxT(" && ") << basicMakeCommand << wxT(" PostBuild");
+        makeCommand << " && " << basicMakeCommand << " PostBuild";
     }
-    makeCommand << wxT("\n");
+    makeCommand << "\n";
     return makeCommand;
 }
 
@@ -1645,10 +1664,10 @@ wxString BuilderGnuMake::GetProjectMakeCommand(ProjectPtr proj, const wxString& 
 
     wxString buildTool = GetBuildToolCommand(proj->GetName(), confToBuild, "", true);
     buildTool = EnvironmentConfig::Instance()->ExpandVariables(buildTool, true);
-    basicMakeCommand << buildTool << wxT(" \"") << proj->GetName() << wxT(".mk\" ");
+    basicMakeCommand << buildTool << " \"" << proj->GetName() << ".mk\" ";
 
     if(bAddCleanTarget) {
-        makeCommand << basicMakeCommand << wxT(" clean && ");
+        makeCommand << basicMakeCommand << " clean && ";
     }
 
     if(bldConf && !bCleanOnly) {
@@ -1660,24 +1679,25 @@ wxString BuilderGnuMake::GetProjectMakeCommand(ProjectPtr proj, const wxString& 
         makeCommand << basicMakeCommand << " MakeIntermediateDirs && ";
 
         if(!preprebuild.IsEmpty()) {
-            makeCommand << basicMakeCommand << wxT(" PrePreBuild && ");
+            makeCommand << basicMakeCommand << " PrePreBuild && ";
         }
 
         if(bIncludePreBuild && HasPrebuildCommands(bldConf)) {
-            makeCommand << basicMakeCommand << wxT(" PreBuild && ");
+            makeCommand << basicMakeCommand << " PreBuild && ";
         }
 
         // Run pre-compiled header compilation if any
         if(!precmpheader.IsEmpty() && (bldConf->GetPCHFlagsPolicy() != BuildConfig::kPCHJustInclude)) {
-            makeCommand << basicMakeCommand << wxT(" ") << precmpheader << wxT(".gch") << wxT(" && ");
+            makeCommand << basicMakeCommand << " " << precmpheader << ".gch"
+                        << " && ";
         }
     }
 
-    makeCommand << basicMakeCommand << wxT(" ") << target;
+    makeCommand << basicMakeCommand << " " << target;
 
     // post
     if(bldConf && !bCleanOnly && bIncludePostBuild && HasPostbuildCommands(bldConf)) {
-        makeCommand << wxT(" && ") << basicMakeCommand << wxT(" PostBuild");
+        makeCommand << " && " << basicMakeCommand << " PostBuild";
     }
     return makeCommand;
 }
@@ -1687,8 +1707,9 @@ void BuilderGnuMake::CreatePreCompiledHeaderTarget(BuildConfigPtr bldConf, wxStr
     wxString filename = bldConf->GetPrecompiledHeader();
     filename.Trim().Trim(false);
 
-    if(filename.IsEmpty())
+    if(filename.IsEmpty()) {
         return;
+    }
 
     auto pchPolicy = bldConf->GetPCHFlagsPolicy();
     if(pchPolicy == BuildConfig::kPCHJustInclude) {
@@ -1696,23 +1717,22 @@ void BuilderGnuMake::CreatePreCompiledHeaderTarget(BuildConfigPtr bldConf, wxStr
         return;
     }
 
-    text << wxT("\n");
-    text << wxT("# PreCompiled Header\n");
-    text << filename << wxT(".gch: ") << filename << wxT("\n");
+    text << "\n";
+    text << "# PreCompiled Header\n";
+    text << filename << ".gch: " << filename << "\n";
     switch(pchPolicy) {
     case BuildConfig::kPCHPolicyReplace:
-        text << wxT("\t") << DoGetCompilerMacro(filename) << wxT(" $(SourceSwitch) ") << filename
-             << wxT(" $(PCHCompileFlags)\n");
+        text << "\t" << DoGetCompilerMacro(filename) << " $(SourceSwitch) " << filename << " $(PCHCompileFlags)\n";
         break;
     case BuildConfig::kPCHPolicyAppend:
-        text << wxT("\t") << DoGetCompilerMacro(filename) << wxT(" $(SourceSwitch) ") << filename
-             << wxT(" $(PCHCompileFlags) $(CXXFLAGS) $(IncludePath)\n");
+        text << "\t" << DoGetCompilerMacro(filename) << " $(SourceSwitch) " << filename
+             << " $(PCHCompileFlags) $(CXXFLAGS) $(IncludePath)\n";
         break;
     case BuildConfig::kPCHJustInclude:
         // for completeness
         break;
     }
-    text << wxT("\n");
+    text << "\n";
 }
 
 wxString BuilderGnuMake::GetPORebuildCommand(const wxString& project, const wxString& confToBuild,
@@ -1726,7 +1746,7 @@ wxString BuilderGnuMake::GetPORebuildCommand(const wxString& project, const wxSt
 
     // generate the makefile
     Export(project, confToBuild, arguments, true, false, errMsg);
-    cmd = GetProjectMakeCommand(proj, confToBuild, wxT("all"), kIncludePreBuild | kIncludePostBuild | kAddCleanTarget);
+    cmd = GetProjectMakeCommand(proj, confToBuild, "all", kIncludePreBuild | kIncludePostBuild | kAddCleanTarget);
     return cmd;
 }
 
@@ -1737,19 +1757,21 @@ wxString BuilderGnuMake::GetBuildToolCommand(const wxString& project, const wxSt
     wxString buildTool;
 
     BuildConfigPtr bldConf = clCxxWorkspaceST::Get()->GetProjBuildConf(project, confToBuild);
-    if(!bldConf)
+    if(!bldConf) {
         return wxEmptyString;
+    }
 
     CompilerPtr compiler = bldConf->GetCompiler();
-    if(!compiler)
+    if(!compiler) {
         return wxEmptyString;
+    }
 
     if(isCommandlineCommand) {
         buildTool = compiler->GetTool("MAKE");
 
     } else {
         jobsCmd = wxEmptyString;
-        buildTool = wxT("\"$(MAKE)\"");
+        buildTool = "\"$(MAKE)\"";
     }
 
     if(buildTool.Lower().Contains("make")) {
@@ -1768,14 +1790,14 @@ wxString BuilderGnuMake::GetBuildToolCommand(const wxString& project, const wxSt
 
 wxString BuilderGnuMake::DoGetCompilerMacro(const wxString& filename)
 {
-    wxString compilerMacro(wxT("$(CXX)"));
+    wxString compilerMacro("$(CXX)");
     switch(FileExtManager::GetType(filename)) {
     case FileExtManager::TypeSourceC:
-        compilerMacro = wxT("$(CC)");
+        compilerMacro = "$(CC)";
         break;
     case FileExtManager::TypeSourceCpp:
     default:
-        compilerMacro = wxT("$(CXX)");
+        compilerMacro = "$(CXX)";
         break;
     }
     return compilerMacro;
@@ -1786,11 +1808,13 @@ wxString BuilderGnuMake::DoGetTargetPrefix(const wxFileName& filename, const wxS
     wxString lastDir;
     wxString ret;
 
-    if(cwd == filename.GetPath())
+    if(cwd == filename.GetPath()) {
         return wxEmptyString;
+    }
 
-    if(cmp && cmp->GetObjectNameIdenticalToFileName())
+    if(cmp && cmp->GetObjectNameIdenticalToFileName()) {
         return wxEmptyString;
+    }
 
     if(cwd == filename.GetPath()) {
         return wxEmptyString;
@@ -1805,15 +1829,15 @@ wxString BuilderGnuMake::DoGetTargetPrefix(const wxFileName& filename, const wxS
         lastDir = dirs.Item(i);
 
         // Handle special directory paths
-        if(lastDir == wxT("..")) {
-            lastDir = wxT("up");
+        if(lastDir == "..") {
+            lastDir = "up";
 
-        } else if(lastDir == wxT(".")) {
-            lastDir = wxT("cur");
+        } else if(lastDir == ".") {
+            lastDir = "cur";
         }
 
         if(lastDir.IsEmpty() == false) {
-            lastDir << wxT("_");
+            lastDir << "_";
         }
 
         ret += lastDir;

--- a/Plugin/builder_gnumake_default.h
+++ b/Plugin/builder_gnumake_default.h
@@ -74,8 +74,7 @@ public:
 
 protected:
     virtual wxString MakeDir(const wxString& path);
-    virtual wxString GetIntermediateFolder(ProjectPtr proj, const wxString& workspacepath);
-    virtual wxString GetOutputFolder(ProjectPtr proj, BuildConfigPtr bldConf);
+    virtual wxString GetIntermediateDirectory(ProjectPtr proj, BuildConfigPtr bldConf) const;
 
 protected:
     virtual void CreateListMacros(ProjectPtr proj, const wxString& confToBuild, wxString& text);
@@ -96,7 +95,7 @@ protected:
 private:
     void GenerateMakefile(ProjectPtr proj, const wxString& confToBuild, bool force, const wxArrayString& depsProj);
     void CreateConfigsVariables(ProjectPtr proj, BuildConfigPtr bldConf, wxString& text);
-    void CreateMakeDirsTarget(ProjectPtr proj, BuildConfigPtr bldConf, const wxString& targetName, wxString& text);
+    void CreateMakeDirsTarget(const wxString& targetName, wxString& text);
     void CreateTargets(const wxString& type, BuildConfigPtr bldConf, wxString& text, const wxString& projName);
     void CreatePreBuildEvents(ProjectPtr proj, BuildConfigPtr bldConf, wxString& text);
     void CreatePostBuildEvents(ProjectPtr proj, BuildConfigPtr bldConf, wxString& text);

--- a/Plugin/globals.cpp
+++ b/Plugin/globals.cpp
@@ -52,11 +52,6 @@
 #include "project.h"
 #include "windowattrmanager.h"
 #include "workspace.h"
-#include "wx/app.h"
-#include "wx/ffile.h"
-#include "wx/listctrl.h"
-#include "wx/tokenzr.h"
-#include "wx/window.h"
 #include "wxmd5.h"
 
 #include <algorithm>
@@ -70,11 +65,13 @@
 #include <wx/dcscreen.h>
 #include <wx/dir.h>
 #include <wx/display.h>
+#include <wx/ffile.h>
 #include <wx/filename.h>
 #include <wx/fontmap.h>
 #include <wx/graphics.h>
 #include <wx/icon.h>
 #include <wx/imaglist.h>
+#include <wx/listctrl.h>
 #include <wx/log.h>
 #include <wx/regex.h>
 #include <wx/richmsgdlg.h>
@@ -84,6 +81,7 @@
 #include <wx/stdpaths.h>
 #include <wx/tokenzr.h>
 #include <wx/wfstream.h>
+#include <wx/window.h>
 #include <wx/xrc/xmlres.h>
 #include <wx/zipstrm.h>
 
@@ -268,8 +266,8 @@ static wxString MacGetInstallPath()
     // remove he MacOS part of the exe path
     wxString file_name = fname.GetPath(wxPATH_GET_VOLUME | wxPATH_GET_SEPARATOR);
     wxString rest;
-    file_name.EndsWith(wxT("MacOS/"), &rest);
-    rest.Append(wxT("SharedSupport/"));
+    file_name.EndsWith("MacOS/", &rest);
+    rest.Append("SharedSupport/");
 
     return rest;
 }
@@ -294,9 +292,9 @@ static bool IsBOMFile(const char* file_name)
 
             // Read the first 4 bytes (or less)
             size_t size = buff.st_size;
-            if(size > 4)
+            if(size > 4) {
                 size = 4;
-
+            }
             char* buffer = new char[size];
             if(fread(buffer, sizeof(char), size, fp) == size) {
                 BOM bom(buffer, size);
@@ -325,8 +323,9 @@ static bool ReadBOMFile(const char* file_name, wxString& content, BOM& bom)
                 wxFontEncoding encoding(wxFONTENCODING_SYSTEM);
                 size_t bomSize(size);
 
-                if(bomSize > 4)
+                if(bomSize > 4) {
                     bomSize = 4;
+                }
                 bom.SetData(buffer, bomSize);
                 encoding = bom.Encoding();
 
@@ -443,9 +442,11 @@ bool RemoveDirectory(const wxString& path)
     wxString cmd;
     if(wxGetOsVersion() & wxOS_WINDOWS) {
         // any of the windows variants
-        cmd << wxT("rmdir /S /Q ") << wxT("\"") << path << wxT("\"");
+        cmd << "rmdir /S /Q "
+            << "\"" << path << "\"";
     } else {
-        cmd << wxT("\rm -fr ") << wxT("\"") << path << wxT("\"");
+        cmd << "\rm -fr "
+            << "\"" << path << "\"";
     }
     return wxShell(cmd);
 }
@@ -457,11 +458,11 @@ bool IsValidCppIndetifier(const wxString& id)
     }
     // first char can be only _A-Za-z
     wxString first(id.Mid(0, 1));
-    if(first.find_first_not_of(wxT("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")) != wxString::npos) {
+    if(first.find_first_not_of("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") != wxString::npos) {
         return false;
     }
     // make sure that rest of the id contains only a-zA-Z0-9_
-    if(id.find_first_not_of(wxT("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")) != wxString::npos) {
+    if(id.find_first_not_of("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") != wxString::npos) {
         return false;
     }
     return true;
@@ -487,7 +488,7 @@ bool IsValidCppFile(const wxString& id)
     }
 
     // make sure that rest of the id contains only a-zA-Z0-9_
-    if(id.find_first_not_of(wxT("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")) != wxString::npos) {
+    if(id.find_first_not_of("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") != wxString::npos) {
         return false;
     }
     return true;
@@ -511,13 +512,13 @@ wxString ExpandAllVariables(const wxString& expression, clCxxWorkspace* workspac
     wxString tmpExp;
     wxString noBackticksExpression;
     for(size_t i = 0; i < expression.Length(); i++) {
-        if(expression.GetChar(i) == wxT('`')) {
+        if(expression.GetChar(i) == '`') {
             // found a backtick, loop over until we found the closing backtick
             wxString backtick;
             bool found(false);
             i++;
             for(; i < expression.Length(); i++) {
-                if(expression.GetChar(i) == wxT('`')) {
+                if(expression.GetChar(i) == '`') {
                     found = true;
                     i++;
                     break;
@@ -527,7 +528,7 @@ wxString ExpandAllVariables(const wxString& expression, clCxxWorkspace* workspac
 
             if(!found) {
                 // dont replace anything
-                clLogMessage(wxT("Syntax error in expression: ") + expression + wxT(": expecting '`'"));
+                clLogMessage("Syntax error in expression: " + expression + ": expecting '`'");
                 return expression;
             } else {
                 // expand the backtick statement
@@ -540,7 +541,7 @@ wxString ExpandAllVariables(const wxString& expression, clCxxWorkspace* workspac
                 // concatenate the array into sAssign To:pace delimited string
                 backtick.Clear();
                 for(size_t xx = 0; xx < output.GetCount(); xx++) {
-                    backtick << output.Item(xx).Trim().Trim(false) << wxT(" ");
+                    backtick << output.Item(xx).Trim().Trim(false) << " ";
                 }
 
                 // and finally concatente the result of the backtick command back to the expression
@@ -566,21 +567,24 @@ wxString DoExpandAllVariables(const wxString& expression, clCxxWorkspace* worksp
         ++retries;
         DollarEscaper de(output);
         if(workspace) {
-            output.Replace(wxT("$(WorkspaceName)"), workspace->GetName());
+            output.Replace("$(WorkspaceName)", workspace->GetName());
+            output.Replace("$(WorkspaceConfiguration)",
+                           workspace->GetSelectedConfig() ? workspace->GetSelectedConfig()->GetName() : "");
             ProjectPtr proj = workspace->FindProjectByName(projectName, errMsg);
             if(proj) {
                 wxString project_name(proj->GetName());
 
                 // make sure that the project name does not contain any spaces
-                project_name.Replace(wxT(" "), wxT("_"));
+                project_name.Replace(" ", "_");
 
                 BuildConfigPtr bldConf = workspace->GetProjBuildConf(proj->GetName(), confToBuild);
-                output.Replace(wxT("$(ProjectPath)"), proj->GetFileName().GetPath());
-                output.Replace(wxT("$(WorkspacePath)"), workspace->GetWorkspaceFileName().GetPath());
-                output.Replace(wxT("$(ProjectName)"), project_name);
+                output.Replace("$(ProjectPath)", proj->GetFileName().GetPath());
+                output.Replace("$(WorkspacePath)", workspace->GetWorkspaceFileName().GetPath());
+                output.Replace("$(ProjectName)", project_name);
 
                 if(bldConf) {
-                    output.Replace(wxT("$(ConfigurationName)"), bldConf->GetName());
+                    output.Replace("$(ConfigurationName)", bldConf->GetName());
+                    output.Replace("$(OutputDirectory)", bldConf->GetOutputDirectory());
                     output.Replace("$(OutputFile)", bldConf->GetOutputFileName());
 
                     // the IntermediateDirectory variable is special, since it can contains
@@ -588,81 +592,82 @@ wxString DoExpandAllVariables(const wxString& expression, clCxxWorkspace* worksp
                     wxString id(bldConf->GetIntermediateDirectory());
 
                     // Substitute all macros from $(IntermediateDirectory)
-                    id.Replace(wxT("$(ProjectPath)"), proj->GetFileName().GetPath());
-                    id.Replace(wxT("$(WorkspacePath)"), workspace->GetWorkspaceFileName().GetPath());
-                    id.Replace(wxT("$(ProjectName)"), project_name);
-                    id.Replace(wxT("$(ConfigurationName)"), bldConf->GetName());
+                    id.Replace("$(ProjectPath)", proj->GetFileName().GetPath());
+                    id.Replace("$(WorkspacePath)", workspace->GetWorkspaceFileName().GetPath());
+                    id.Replace("$(ProjectName)", project_name);
+                    id.Replace("$(ConfigurationName)", bldConf->GetName());
 
-                    output.Replace(wxT("$(IntermediateDirectory)"), id);
-                    output.Replace(wxT("$(OutDir)"), id);
+                    output.Replace("$(IntermediateDirectory)", id);
+                    output.Replace("$(OutDir)", id);
 
                     // Compiler-related variables
 
                     wxString cFlags = bldConf->GetCCompileOptions();
-                    cFlags.Replace(wxT(";"), wxT(" "));
-                    output.Replace(wxT("$(CC)"), bldConf->GetCompiler()->GetTool("CC"));
-                    output.Replace(wxT("$(CFLAGS)"), cFlags);
+                    cFlags.Replace(";", " ");
+                    output.Replace("$(CC)", bldConf->GetCompiler()->GetTool("CC"));
+                    output.Replace("$(CFLAGS)", cFlags);
 
                     wxString cxxFlags = bldConf->GetCompileOptions();
-                    cxxFlags.Replace(wxT(";"), wxT(" "));
-                    output.Replace(wxT("$(CXX)"), bldConf->GetCompiler()->GetTool("CXX"));
-                    output.Replace(wxT("$(CXXFLAGS)"), cxxFlags);
+                    cxxFlags.Replace(";", " ");
+                    output.Replace("$(CXX)", bldConf->GetCompiler()->GetTool("CXX"));
+                    output.Replace("$(CXXFLAGS)", cxxFlags);
 
                     wxString ldFlags = bldConf->GetLinkOptions();
-                    ldFlags.Replace(wxT(";"), wxT(" "));
-                    output.Replace(wxT("$(LDFLAGS)"), ldFlags);
+                    ldFlags.Replace(";", " ");
+                    output.Replace("$(LDFLAGS)", ldFlags);
 
                     wxString asFlags = bldConf->GetAssmeblerOptions();
-                    asFlags.Replace(wxT(";"), wxT(" "));
-                    output.Replace(wxT("$(AS)"), bldConf->GetCompiler()->GetTool("AS"));
-                    output.Replace(wxT("$(ASFLAGS)"), asFlags);
+                    asFlags.Replace(";", " ");
+                    output.Replace("$(AS)", bldConf->GetCompiler()->GetTool("AS"));
+                    output.Replace("$(ASFLAGS)", asFlags);
 
                     wxString resFlags = bldConf->GetResCompileOptions();
-                    resFlags.Replace(wxT(";"), wxT(" "));
-                    output.Replace(wxT("$(RES)"), bldConf->GetCompiler()->GetTool("ResourceCompiler"));
-                    output.Replace(wxT("$(RESFLAGS)"), resFlags);
+                    resFlags.Replace(";", " ");
+                    output.Replace("$(RES)", bldConf->GetCompiler()->GetTool("ResourceCompiler"));
+                    output.Replace("$(RESFLAGS)", resFlags);
 
-                    output.Replace(wxT("$(AR)"), bldConf->GetCompiler()->GetTool("AR"));
+                    output.Replace("$(AR)", bldConf->GetCompiler()->GetTool("AR"));
 
-                    output.Replace(wxT("$(MAKE)"), bldConf->GetCompiler()->GetTool("MAKE"));
+                    output.Replace("$(MAKE)", bldConf->GetCompiler()->GetTool("MAKE"));
 
-                    output.Replace(wxT("$(IncludePath)"), bldConf->GetIncludePath());
-                    output.Replace(wxT("$(LibraryPath)"), bldConf->GetLibPath());
-                    output.Replace(wxT("$(ResourcePath)"), bldConf->GetResCmpIncludePath());
-                    output.Replace(wxT("$(LinkLibraries)"), bldConf->GetLibraries());
+                    output.Replace("$(IncludePath)", bldConf->GetIncludePath());
+                    output.Replace("$(LibraryPath)", bldConf->GetLibPath());
+                    output.Replace("$(ResourcePath)", bldConf->GetResCmpIncludePath());
+                    output.Replace("$(LinkLibraries)", bldConf->GetLibraries());
                 }
 
-                if(output.Find(wxT("$(ProjectFiles)")) != wxNOT_FOUND)
-                    output.Replace(wxT("$(ProjectFiles)"), proj->GetFilesAsString(false));
-
-                if(output.Find(wxT("$(ProjectFilesAbs)")) != wxNOT_FOUND)
-                    output.Replace(wxT("$(ProjectFilesAbs)"), proj->GetFilesAsString(true));
+                if(output.Find("$(ProjectFiles)") != wxNOT_FOUND) {
+                    output.Replace("$(ProjectFiles)", proj->GetFilesAsString(false));
+                }
+                if(output.Find("$(ProjectFilesAbs)") != wxNOT_FOUND) {
+                    output.Replace("$(ProjectFilesAbs)", proj->GetFilesAsString(true));
+                }
             }
         }
 
         if(fileName.IsEmpty() == false) {
             wxFileName fn(fileName);
 
-            output.Replace(wxT("$(CurrentFileName)"), fn.GetName());
+            output.Replace("$(CurrentFileName)", fn.GetName());
 
             wxString fpath(fn.GetPath());
-            fpath.Replace(wxT("\\"), wxT("/"));
-            output.Replace(wxT("$(CurrentFilePath)"), fpath);
-            output.Replace(wxT("$(CurrentFileExt)"), fn.GetExt());
+            fpath.Replace("\\", "/");
+            output.Replace("$(CurrentFilePath)", fpath);
+            output.Replace("$(CurrentFileExt)", fn.GetExt());
 
             wxString ffullpath(fn.GetFullPath());
-            ffullpath.Replace(wxT("\\"), wxT("/"));
-            output.Replace(wxT("$(CurrentFileFullPath)"), ffullpath);
-            output.Replace(wxT("$(CurrentFileFullName)"), fn.GetFullName());
+            ffullpath.Replace("\\", "/");
+            output.Replace("$(CurrentFileFullPath)", ffullpath);
+            output.Replace("$(CurrentFileFullName)", fn.GetFullName());
         }
 
         // exapnd common macros
         wxDateTime now = wxDateTime::Now();
-        output.Replace(wxT("$(User)"), wxGetUserName());
-        output.Replace(wxT("$(Date)"), now.FormatDate());
+        output.Replace("$(User)", wxGetUserName());
+        output.Replace("$(Date)", now.FormatDate());
 
         if(workspace) {
-            output.Replace(wxT("$(CodeLitePath)"), workspace->GetStartupDir());
+            output.Replace("$(CodeLitePath)", workspace->GetStartupDir());
         }
 
         // call the environment & workspace variables expand function
@@ -673,7 +678,7 @@ wxString DoExpandAllVariables(const wxString& expression, clCxxWorkspace* worksp
 
 bool WriteFileUTF8(const wxString& fileName, const wxString& content)
 {
-    wxFFile file(fileName, wxT("w+b"));
+    wxFFile file(fileName, "w+b");
     if(!file.IsOpened()) {
         return false;
     }
@@ -752,17 +757,17 @@ bool WriteFileWithBackup(const wxString& file_name, const wxString& content, boo
 {
     if(backup) {
         wxString backup_name(file_name);
-        backup_name << wxT(".bak");
+        backup_name << ".bak";
         if(!wxCopyFile(file_name, backup_name, true)) {
-            clLogMessage(wxString::Format(wxT("Failed to backup file %s, skipping it"), file_name.c_str()));
+            clLogMessage(wxString::Format("Failed to backup file %s, skipping it", file_name.c_str()));
             return false;
         }
     }
 
-    wxFFile file(file_name, wxT("wb"));
+    wxFFile file(file_name, "wb");
     if(file.IsOpened() == false) {
         // Nothing to be done
-        wxString msg = wxString::Format(wxT("Failed to open file %s"), file_name.c_str());
+        wxString msg = wxString::Format("Failed to open file %s", file_name.c_str());
         clLogMessage(msg);
         return false;
     }
@@ -825,19 +830,19 @@ wxString ArrayToSmiColonString(const wxArrayString& array)
         tmp.Trim().Trim(false);
         if(tmp.IsEmpty() == false) {
             result += NormalizePath(array.Item(i));
-            result += wxT(";");
+            result += ";";
         }
     }
-    return result.BeforeLast(wxT(';'));
+    return result.BeforeLast(';');
 }
 
-void StripSemiColons(wxString& str) { str.Replace(wxT(";"), wxT(" ")); }
+void StripSemiColons(wxString& str) { str.Replace(";", " "); }
 
 wxString NormalizePath(const wxString& path)
 {
     wxString normalized_path(path);
     normalized_path.Trim().Trim(false);
-    normalized_path.Replace(wxT("\\"), wxT("/"));
+    normalized_path.Replace("\\", "/");
     while(normalized_path.Replace("//", "/")) {}
     return normalized_path;
 }
@@ -905,10 +910,11 @@ void WrapInShell(wxString& cmd)
 {
     wxString command;
 #ifdef __WXMSW__
-    wxChar* shell = wxGetenv(wxT("COMSPEC"));
-    if(!shell)
-        shell = (wxChar*)wxT("CMD.EXE");
-    command << shell << wxT(" /C ");
+    wxString shell = wxGetenv("COMSPEC");
+    if(shell.IsEmpty()) {
+        shell = "CMD.EXE";
+    }
+    command << shell << " /C ";
     if(cmd.StartsWith("\"") && !cmd.EndsWith("\"")) {
         command << "\"" << cmd << "\"";
     } else {
@@ -916,10 +922,10 @@ void WrapInShell(wxString& cmd)
     }
     cmd = command;
 #else
-    command << wxT("/bin/sh -c '");
+    command << "/bin/sh -c '";
     // escape any single quoutes
     cmd.Replace("'", "\\'");
-    command << cmd << wxT("'");
+    command << cmd << "'";
     cmd = command;
 #endif
 }
@@ -931,17 +937,17 @@ wxString clGetUserName()
     // The wx doc says that 'name' may now be e.g. "Mr. John Smith"
     // So try to make it more suitable to be an extension
     name.MakeLower();
-    name.Replace(wxT(" "), wxT("_"));
+    name.Replace(" ", "_");
     for(size_t i = 0; i < name.Len(); ++i) {
         wxChar ch = name.GetChar(i);
-        if((ch < wxT('a') || ch > wxT('z')) && ch != wxT('_')) {
+        if((ch < 'a' || ch > 'z') && ch != '_') {
             // Non [a-z_] character: skip it
         } else {
             squashedname << ch;
         }
     }
 
-    return (squashedname.IsEmpty() ? wxString(wxT("someone")) : squashedname);
+    return (squashedname.IsEmpty() ? wxString("someone") : squashedname);
 }
 
 static void DoReadProjectTemplatesFromFolder(const wxString& folder, std::list<ProjectPtr>& list,
@@ -986,9 +992,9 @@ static void DoReadProjectTemplatesFromFolder(const wxString& folder, std::list<P
         ProjectPtr exeProj(new Project());
         ProjectPtr libProj(new Project());
         ProjectPtr dllProj(new Project());
-        libProj->Create(wxT("Static Library"), wxEmptyString, folder, PROJECT_TYPE_STATIC_LIBRARY);
-        dllProj->Create(wxT("Dynamic Library"), wxEmptyString, folder, PROJECT_TYPE_DYNAMIC_LIBRARY);
-        exeProj->Create(wxT("Executable"), wxEmptyString, folder, PROJECT_TYPE_EXECUTABLE);
+        libProj->Create("Static Library", wxEmptyString, folder, PROJECT_TYPE_STATIC_LIBRARY);
+        dllProj->Create("Dynamic Library", wxEmptyString, folder, PROJECT_TYPE_DYNAMIC_LIBRARY);
+        exeProj->Create("Executable", wxEmptyString, folder, PROJECT_TYPE_EXECUTABLE);
         list.push_back(libProj);
         list.push_back(dllProj);
         list.push_back(exeProj);
@@ -1207,8 +1213,8 @@ wxString wxImplode(const wxArrayString& arr, const wxString& glue)
 
 wxString wxShellExec(const wxString& cmd, const wxString& projectName)
 {
-    wxString filename = wxFileName::CreateTempFileName(wxT("clTempFile"));
-    wxString theCommand = wxString::Format(wxT("%s > \"%s\" 2>&1"), cmd.c_str(), filename.c_str());
+    wxString filename = wxFileName::CreateTempFileName("clTempFile");
+    wxString theCommand = wxString::Format("%s > \"%s\" 2>&1", cmd.c_str(), filename.c_str());
     WrapInShell(theCommand);
 
     wxArrayString dummy;
@@ -1217,7 +1223,7 @@ wxString wxShellExec(const wxString& cmd, const wxString& projectName)
     ProcUtils::SafeExecuteCommand(theCommand, dummy);
 
     wxString content;
-    wxFFile fp(filename, wxT("r"));
+    wxFFile fp(filename, "r");
     if(fp.IsOpened()) {
         fp.ReadAll(&content);
     }
@@ -1234,8 +1240,9 @@ bool wxIsFileSymlink(const wxFileName& filename)
     wxCharBuffer cb = filename.GetFullPath().mb_str(wxConvUTF8).data();
     struct stat stat_buff;
     // use lstat() otherwise, stat() will follow the actual file
-    if(::lstat(cb.data(), &stat_buff) < 0)
+    if(::lstat(cb.data(), &stat_buff) < 0) {
         return false;
+    }
     return S_ISLNK(stat_buff.st_mode);
 #endif
 }
@@ -1279,11 +1286,12 @@ int wxStringToInt(const wxString& str, int defval, int minval, int maxval)
         return defval;
     }
 
-    if(minval != -1 && v < minval)
+    if(minval != -1 && v < minval) {
         return defval;
-
-    if(maxval != -1 && v > maxval)
+    }
+    if(maxval != -1 && v > maxval) {
         return defval;
+    }
 
     return v;
 }
@@ -1574,7 +1582,7 @@ unsigned int clUTF8Length(const wchar_t* uptr, unsigned int tlen)
 
 wxString DbgPrependCharPtrCastIfNeeded(const wxString& expr, const wxString& exprType)
 {
-    static wxRegEx reConstArr(wxT("(const )?[ ]*(w)?char(_t)? *[\\[0-9\\]]*"));
+    static wxRegEx reConstArr("(const )?[ ]*(w)?char(_t)? *[\\[0-9\\]]*");
 
     bool arrayAsCharPtr = false;
     DebuggerInformation info;
@@ -1587,7 +1595,7 @@ wxString DbgPrependCharPtrCastIfNeeded(const wxString& expr, const wxString& exp
     wxString newExpr;
     if(arrayAsCharPtr && reConstArr.Matches(exprType)) {
         // array
-        newExpr << wxT("(char*)") << expr;
+        newExpr << "(char*)" << expr;
 
     } else {
         newExpr << expr;
@@ -1733,7 +1741,7 @@ static wxChar sPreviousChar(wxStyledTextCtrl* ctrl, int pos, int& foundPos, bool
 
     while(true) {
         ch = ctrl->GetCharAt(curpos);
-        if(ch == wxT('\t') || ch == wxT(' ') || ch == wxT('\r') || ch == wxT('\v') || ch == wxT('\n')) {
+        if(ch == '\t' || ch == ' ' || ch == '\r' || ch == '\v' || ch == '\n') {
             // if the caller is intrested in whitepsaces,
             // simply return it
             if(wantWhitespace) {
@@ -1743,8 +1751,9 @@ static wxChar sPreviousChar(wxStyledTextCtrl* ctrl, int pos, int& foundPos, bool
 
             long tmpPos = curpos;
             curpos = ctrl->PositionBefore(curpos);
-            if(curpos == 0 && tmpPos == curpos)
+            if(curpos == 0 && tmpPos == curpos) {
                 break;
+            }
         } else {
             foundPos = curpos;
             return ch;
@@ -1781,12 +1790,12 @@ wxString GetCppExpressionFromPos(long pos, wxStyledTextCtrl* ctrl, bool forCC)
         }
 
         switch(ch) {
-        case wxT(';'):
+        case ';':
             // dont include this token
             at = ctrl->PositionAfter(at);
             cont = false;
             break;
-        case wxT('-'):
+        case '-':
             if(prevGt) {
                 prevGt = false;
                 // if previous char was '>', we found an arrow so reduce the depth
@@ -1800,24 +1809,24 @@ wxString GetCppExpressionFromPos(long pos, wxStyledTextCtrl* ctrl, bool forCC)
                 }
             }
             break;
-        case wxT(' '):
-        case wxT('\n'):
-        case wxT('\v'):
-        case wxT('\t'):
-        case wxT('\r'):
+        case ' ':
+        case '\n':
+        case '\v':
+        case '\t':
+        case '\r':
             prevGt = false;
             if(depth <= 0) {
                 cont = false;
                 break;
             }
             break;
-        case wxT('{'):
-        case wxT('='):
+        case '{':
+        case '=':
             prevGt = false;
             cont = false;
             break;
-        case wxT('('):
-        case wxT('['):
+        case '(':
+        case '[':
             depth--;
             prevGt = false;
             if(depth < 0) {
@@ -1826,16 +1835,16 @@ wxString GetCppExpressionFromPos(long pos, wxStyledTextCtrl* ctrl, bool forCC)
                 cont = false;
             }
             break;
-        case wxT(','):
-        case wxT('*'):
-        case wxT('&'):
-        case wxT('!'):
-        case wxT('~'):
-        case wxT('+'):
-        case wxT('^'):
-        case wxT('|'):
-        case wxT('%'):
-        case wxT('?'):
+        case ',':
+        case '*':
+        case '&':
+        case '!':
+        case '~':
+        case '+':
+        case '^':
+        case '|':
+        case '%':
+        case '?':
             prevGt = false;
             if(depth <= 0) {
 
@@ -1844,11 +1853,11 @@ wxString GetCppExpressionFromPos(long pos, wxStyledTextCtrl* ctrl, bool forCC)
                 cont = false;
             }
             break;
-        case wxT('>'):
+        case '>':
             prevGt = true;
             depth++;
             break;
-        case wxT('<'):
+        case '<':
             prevGt = false;
             depth--;
             if(depth < 0) {
@@ -1858,8 +1867,8 @@ wxString GetCppExpressionFromPos(long pos, wxStyledTextCtrl* ctrl, bool forCC)
                 cont = false;
             }
             break;
-        case wxT(')'):
-        case wxT(']'):
+        case ')':
+        case ']':
             prevGt = false;
             depth++;
             break;
@@ -1869,8 +1878,9 @@ wxString GetCppExpressionFromPos(long pos, wxStyledTextCtrl* ctrl, bool forCC)
         }
     }
 
-    if(at < 0)
+    if(at < 0) {
         at = 0;
+    }
     wxString expr = ctrl->GetTextRange(at, pos);
     if(!forCC) {
         // If we do not require the expression for CodeCompletion
@@ -1886,7 +1896,7 @@ wxString GetCppExpressionFromPos(long pos, wxStyledTextCtrl* ctrl, bool forCC)
     while((type = sc.yylex()) != 0) {
         wxString token = _U(sc.YYText());
         expression += token;
-        expression += wxT(" ");
+        expression += " ";
     }
     return expression;
 }
@@ -1958,9 +1968,9 @@ void clRecalculateSTCHScrollBar(wxStyledTextCtrl* ctrl)
     int maxPixel = 0;
     int startLine = ctrl->GetFirstVisibleLine();
     int endLine = startLine + ctrl->LinesOnScreen();
-    if(endLine >= (ctrl->GetLineCount() - 1))
+    if(endLine >= (ctrl->GetLineCount() - 1)) {
         endLine--;
-
+    }
     for(int i = startLine; i <= endLine; i++) {
         int visibleLine = (int)ctrl->DocLineFromVisible(i);      // get actual visible line, folding may offset lines
         int endPosition = ctrl->GetLineEndPosition(visibleLine); // get character position from begin
@@ -1975,8 +1985,9 @@ void clRecalculateSTCHScrollBar(wxStyledTextCtrl* ctrl)
             maxPixel = curLen;
     }
 
-    if(maxPixel == 0)
+    if(maxPixel == 0) {
         maxPixel++; // make sure maxPixel is valid
+    }
 
     int currentLength = ctrl->GetScrollWidth(); // Get current scrollbar size
     if(currentLength != maxPixel) {
@@ -2083,9 +2094,9 @@ bool clFindExecutable(const wxString& name, wxFileName& exepath, const wxArraySt
 
 int clFindMenuItemPosition(wxMenu* menu, int menuItemId)
 {
-    if(!menu)
+    if(!menu) {
         return wxNOT_FOUND;
-
+    }
     const wxMenuItemList& list = menu->GetMenuItems();
     wxMenuItemList::const_iterator iter = list.begin();
     for(int pos = 0; iter != list.end(); ++iter, ++pos) {

--- a/Plugin/macromanager.cpp
+++ b/Plugin/macromanager.cpp
@@ -57,18 +57,19 @@ wxString MacroManager::Replace(const wxString& inString, const wxString& variabl
                                bool bIgnoreCase)
 {
     size_t flags = wxRE_DEFAULT;
-    if(bIgnoreCase)
+    if(bIgnoreCase) {
         flags |= wxRE_ICASE;
+    }
 
     wxString strRe1;
     wxString strRe2;
     wxString strRe3;
     wxString strRe4;
 
-    strRe1 << wxT("\\$\\((") << variableName << wxT(")\\)");
-    strRe2 << wxT("\\$\\{(") << variableName << wxT(")\\}");
-    strRe3 << wxT("\\$(") << variableName << wxT(")");
-    strRe4 << wxT("%(") << variableName << wxT(")%");
+    strRe1 << "\\$\\((" << variableName << ")\\)";
+    strRe2 << "\\$\\{(" << variableName << ")\\}";
+    strRe3 << "\\$(" << variableName << ")";
+    strRe4 << "%(" << variableName << ")%";
 
     wxRegEx reOne(strRe1, flags);   // $(variable)
     wxRegEx reTwo(strRe2, flags);   // ${variable}
@@ -103,10 +104,18 @@ bool MacroManager::FindVariable(const wxString& inString, wxString& name, wxStri
     wxString strRe3;
     wxString strRe4;
 
-    strRe1 << wxT("\\$\\((") << wxT("[a-z_0-9]+") << wxT(")\\)");
-    strRe2 << wxT("\\$\\{(") << wxT("[a-z_0-9]+") << wxT(")\\}");
-    strRe3 << wxT("\\$(") << wxT("[a-z_0-9]+") << wxT(")");
-    strRe4 << wxT("%(") << wxT("[a-z_0-9]+") << wxT(")%");
+    strRe1 << "\\$\\(("
+           << "[a-z_0-9]+"
+           << ")\\)";
+    strRe2 << "\\$\\{("
+           << "[a-z_0-9]+"
+           << ")\\}";
+    strRe3 << "\\$("
+           << "[a-z_0-9]+"
+           << ")";
+    strRe4 << "%("
+           << "[a-z_0-9]+"
+           << ")%";
 
     wxRegEx reOne(strRe1, flags);   // $(variable)
     wxRegEx reTwo(strRe2, flags);   // ${variable}
@@ -180,7 +189,7 @@ wxString MacroManager::DoExpand(const wxString& expression, IManager* manager, c
     while((retries < 5) && FindVariable(expandedString, dummyname, dummyname)) {
         ++retries;
         DollarEscaper de(expandedString);
-        expandedString.Replace(wxT("$(WorkspaceName)"), wspName);
+        expandedString.Replace("$(WorkspaceName)", wspName);
         expandedString.Replace("$(WorkspaceConfiguration)", wspConfig);
         expandedString.Replace("$(WorkspacePath)", wspPath);
         if(workspace) {
@@ -192,14 +201,15 @@ wxString MacroManager::DoExpand(const wxString& expression, IManager* manager, c
                 wxString project_name(proj->GetName());
 
                 // make sure that the project name does not contain any spaces
-                project_name.Replace(wxT(" "), wxT("_"));
+                project_name.Replace(" ", "_");
 
                 BuildConfigPtr bldConf = workspace->GetProjBuildConf(proj->GetName(), confToBuild);
                 if(bldConf) {
                     bool isCustom = bldConf->IsCustomBuild();
-                    expandedString.Replace(wxT("$(ProjectOutputFile)"), bldConf->GetOutputFileName());
+                    expandedString.Replace("$(OutputDirectory)", bldConf->GetOutputDirectory());
+                    expandedString.Replace("$(ProjectOutputFile)", bldConf->GetOutputFileName());
                     // An alias
-                    expandedString.Replace(wxT("$(OutputFile)"), bldConf->GetOutputFileName());
+                    expandedString.Replace("$(OutputFile)", bldConf->GetOutputFileName());
 
                     // When custom build project, use the working directory set in the
                     // custom build tab, otherwise use the project file's path
@@ -207,58 +217,60 @@ wxString MacroManager::DoExpand(const wxString& expression, IManager* manager, c
                     prjRunWd = bldConf->GetWorkingDirectory();
                 }
 
-                expandedString.Replace(wxT("$(ProjectWorkingDirectory)"), prjBuildWd);
-                expandedString.Replace(wxT("$(ProjectRunWorkingDirectory)"), prjRunWd);
-                expandedString.Replace(wxT("$(ProjectPath)"), proj->GetFileName().GetPath());
-                expandedString.Replace(wxT("$(WorkspacePath)"), workspace->GetWorkspaceFileName().GetPath());
-                expandedString.Replace(wxT("$(ProjectName)"), project_name);
+                expandedString.Replace("$(ProjectWorkingDirectory)", prjBuildWd);
+                expandedString.Replace("$(ProjectRunWorkingDirectory)", prjRunWd);
+                expandedString.Replace("$(ProjectPath)", proj->GetFileName().GetPath());
+                expandedString.Replace("$(WorkspacePath)", workspace->GetWorkspaceFileName().GetPath());
+                expandedString.Replace("$(ProjectName)", project_name);
 
                 if(bldConf) {
-                    expandedString.Replace(wxT("$(IntermediateDirectory)"), bldConf->GetIntermediateDirectory());
-                    expandedString.Replace(wxT("$(ConfigurationName)"), bldConf->GetName());
-                    expandedString.Replace(wxT("$(OutDir)"), bldConf->GetIntermediateDirectory());
+                    expandedString.Replace("$(IntermediateDirectory)", bldConf->GetIntermediateDirectory());
+                    expandedString.Replace("$(ConfigurationName)", bldConf->GetName());
+                    expandedString.Replace("$(OutDir)", bldConf->GetIntermediateDirectory());
 
                     // Compiler-related variables
 
                     wxString cFlags = bldConf->GetCCompileOptions();
-                    cFlags.Replace(wxT(";"), wxT(" "));
-                    expandedString.Replace(wxT("$(CC)"), bldConf->GetCompiler()->GetTool("CC"));
-                    expandedString.Replace(wxT("$(CFLAGS)"), cFlags);
+                    cFlags.Replace(";", " ");
+                    expandedString.Replace("$(CC)", bldConf->GetCompiler()->GetTool("CC"));
+                    expandedString.Replace("$(CFLAGS)", cFlags);
 
                     wxString cxxFlags = bldConf->GetCompileOptions();
-                    cxxFlags.Replace(wxT(";"), wxT(" "));
-                    expandedString.Replace(wxT("$(CXX)"), bldConf->GetCompiler()->GetTool("CXX"));
-                    expandedString.Replace(wxT("$(CXXFLAGS)"), cxxFlags);
+                    cxxFlags.Replace(";", " ");
+                    expandedString.Replace("$(CXX)", bldConf->GetCompiler()->GetTool("CXX"));
+                    expandedString.Replace("$(CXXFLAGS)", cxxFlags);
 
                     wxString ldFlags = bldConf->GetLinkOptions();
-                    ldFlags.Replace(wxT(";"), wxT(" "));
-                    expandedString.Replace(wxT("$(LDFLAGS)"), ldFlags);
+                    ldFlags.Replace(";", " ");
+                    expandedString.Replace("$(LDFLAGS)", ldFlags);
 
                     wxString asFlags = bldConf->GetAssmeblerOptions();
-                    asFlags.Replace(wxT(";"), wxT(" "));
-                    expandedString.Replace(wxT("$(AS)"), bldConf->GetCompiler()->GetTool("AS"));
-                    expandedString.Replace(wxT("$(ASFLAGS)"), asFlags);
+                    asFlags.Replace(";", " ");
+                    expandedString.Replace("$(AS)", bldConf->GetCompiler()->GetTool("AS"));
+                    expandedString.Replace("$(ASFLAGS)", asFlags);
 
                     wxString resFlags = bldConf->GetResCompileOptions();
-                    resFlags.Replace(wxT(";"), wxT(" "));
-                    expandedString.Replace(wxT("$(RES)"), bldConf->GetCompiler()->GetTool("ResourceCompiler"));
-                    expandedString.Replace(wxT("$(RESFLAGS)"), resFlags);
+                    resFlags.Replace(";", " ");
+                    expandedString.Replace("$(RES)", bldConf->GetCompiler()->GetTool("ResourceCompiler"));
+                    expandedString.Replace("$(RESFLAGS)", resFlags);
 
-                    expandedString.Replace(wxT("$(AR)"), bldConf->GetCompiler()->GetTool("AR"));
+                    expandedString.Replace("$(AR)", bldConf->GetCompiler()->GetTool("AR"));
 
-                    expandedString.Replace(wxT("$(MAKE)"), bldConf->GetCompiler()->GetTool("MAKE"));
+                    expandedString.Replace("$(MAKE)", bldConf->GetCompiler()->GetTool("MAKE"));
 
-                    expandedString.Replace(wxT("$(IncludePath)"), bldConf->GetIncludePath());
-                    expandedString.Replace(wxT("$(LibraryPath)"), bldConf->GetLibPath());
-                    expandedString.Replace(wxT("$(ResourcePath)"), bldConf->GetResCmpIncludePath());
-                    expandedString.Replace(wxT("$(LinkLibraries)"), bldConf->GetLibraries());
+                    expandedString.Replace("$(IncludePath)", bldConf->GetIncludePath());
+                    expandedString.Replace("$(LibraryPath)", bldConf->GetLibPath());
+                    expandedString.Replace("$(ResourcePath)", bldConf->GetResCmpIncludePath());
+                    expandedString.Replace("$(LinkLibraries)", bldConf->GetLibraries());
                 }
 
-                if(expandedString.Find(wxT("$(ProjectFiles)")) != wxNOT_FOUND)
-                    expandedString.Replace(wxT("$(ProjectFiles)"), proj->GetFilesAsString(false));
+                if(expandedString.Find("$(ProjectFiles)") != wxNOT_FOUND) {
+                    expandedString.Replace("$(ProjectFiles)", proj->GetFilesAsString(false));
+                }
 
-                if(expandedString.Find(wxT("$(ProjectFilesAbs)")) != wxNOT_FOUND)
-                    expandedString.Replace(wxT("$(ProjectFilesAbs)"), proj->GetFilesAsString(true));
+                if(expandedString.Find("$(ProjectFilesAbs)") != wxNOT_FOUND) {
+                    expandedString.Replace("$(ProjectFilesAbs)", proj->GetFilesAsString(true));
+                }
             }
         }
 
@@ -267,34 +279,34 @@ wxString MacroManager::DoExpand(const wxString& expression, IManager* manager, c
             if(editor) {
                 wxFileName fn(editor->GetFileName());
 
-                expandedString.Replace(wxT("$(CurrentFileName)"), fn.GetName());
+                expandedString.Replace("$(CurrentFileName)", fn.GetName());
 
                 wxString fpath(fn.GetPath());
-                fpath.Replace(wxT("\\"), wxT("/"));
-                expandedString.Replace(wxT("$(CurrentFilePath)"), fpath);
-                expandedString.Replace(wxT("$(CurrentFileExt)"), fn.GetExt());
-                expandedString.Replace(wxT("$(CurrentFileFullName)"), fn.GetFullName());
+                fpath.Replace("\\", "/");
+                expandedString.Replace("$(CurrentFilePath)", fpath);
+                expandedString.Replace("$(CurrentFileExt)", fn.GetExt());
+                expandedString.Replace("$(CurrentFileFullName)", fn.GetFullName());
 
                 wxString ffullpath(fn.GetFullPath());
-                ffullpath.Replace(wxT("\\"), wxT("/"));
-                expandedString.Replace(wxT("$(CurrentFileFullPath)"), ffullpath);
-                expandedString.Replace(wxT("$(CurrentSelection)"), editor->GetSelection());
-                if(expandedString.Find(wxT("$(CurrentSelectionRange)")) != wxNOT_FOUND) {
+                ffullpath.Replace("\\", "/");
+                expandedString.Replace("$(CurrentFileFullPath)", ffullpath);
+                expandedString.Replace("$(CurrentSelection)", editor->GetSelection());
+                if(expandedString.Find("$(CurrentSelectionRange)") != wxNOT_FOUND) {
                     int start = editor->GetSelectionStart(), end = editor->GetSelectionEnd();
 
-                    wxString output = wxString::Format(wxT("%i:%i"), start, end);
-                    expandedString.Replace(wxT("$(CurrentSelectionRange)"), output);
+                    wxString output = wxString::Format("%i:%i", start, end);
+                    expandedString.Replace("$(CurrentSelectionRange)", output);
                 }
             }
         }
 
         // exapand common macros
         wxDateTime now = wxDateTime::Now();
-        expandedString.Replace(wxT("$(User)"), wxGetUserName());
-        expandedString.Replace(wxT("$(Date)"), now.FormatDate());
+        expandedString.Replace("$(User)", wxGetUserName());
+        expandedString.Replace("$(Date)", now.FormatDate());
 
         if(manager && applyEnv) {
-            expandedString.Replace(wxT("$(CodeLitePath)"), manager->GetInstallDirectory());
+            expandedString.Replace("$(CodeLitePath)", manager->GetInstallDirectory());
 
             // Apply the environment and expand the variables
             EnvSetter es(NULL, NULL, project, confToBuild);

--- a/Plugin/macromanager.h
+++ b/Plugin/macromanager.h
@@ -47,6 +47,8 @@ public:
     /*
      * The following macro will be expanded into their real values:
      * $(ProjectPath)
+     * $(WorkspaceName)
+     * $(WorkspaceConfiguration)
      * $(WorkspacePath)
      * $(ProjectName)
      * $(IntermediateDirectory)
@@ -63,6 +65,7 @@ public:
      * $(Date)
      * $(CodeLitePath)
      * $(CurrentSelection)
+     * $(OutputDirectory)
      * $(ProjectOutputFile)
      * $(Selection)
      */

--- a/Plugin/macrosdlg.cpp
+++ b/Plugin/macrosdlg.cpp
@@ -70,77 +70,78 @@ void MacrosDlg::Initialize()
 
     switch(m_content) {
     case MacrosExternalTools:
-        AddMacro(wxT("$(CurrentSelection)"), _("Expands to the selected text in the active editor"));
-        AddMacro(wxT("$(CurrentSelectionRange)"),
+        AddMacro("$(CurrentSelection)", _("Expands to the selected text in the active editor"));
+        AddMacro("$(CurrentSelectionRange)",
                  _("Expands to the selected text range in bytes from beginning of file, eg. 150:200"));
-        AddMacro(wxT("$(ProjectOutputFile)"), _("Expands to the project binary output file"));
-        AddMacro(wxT("$(ProjectWorkingDirectory)"), _("Expands to the project's build working directory"));
-        AddMacro(wxT("$(ProjectRunWorkingDirectory)"), _("Expands to the project's run working directory"));
+        AddMacro("$(ProjectOutputFile)", _("Expands to the project binary output file"));
+        AddMacro("$(ProjectWorkingDirectory)", _("Expands to the project's build working directory"));
+        AddMacro("$(ProjectRunWorkingDirectory)", _("Expands to the project's run working directory"));
     // fall ...
     case MacrosProject:
-        AddMacro(wxT("$(ProjectPath)"), _("Expands to project's path"));
-        AddMacro(wxT("$(WorkspacePath)"), _("Expands to workspace's path"));
-        AddMacro(wxT("$(WorkspaceConfiguration)"), _("Expands to the workspace selected configuration"));
-        AddMacro(wxT("$(ProjectName)"), _("Expands to the current project name as appears in the 'File View'"));
-        AddMacro(wxT("$(IntermediateDirectory)"),
+        AddMacro("$(ProjectPath)", _("Expands to project's path"));
+        AddMacro("$(WorkspacePath)", _("Expands to workspace's path"));
+        AddMacro("$(WorkspaceConfiguration)", _("Expands to the workspace selected configuration"));
+        AddMacro("$(ProjectName)", _("Expands to the current project name as appears in the 'File View'"));
+        AddMacro("$(IntermediateDirectory)",
                  _("Expands to the current project intermediate directory path, as set in the project settings"));
-        AddMacro(wxT("$(ConfigurationName)"), _("Expands to the current project selected configuration"));
-        AddMacro(wxT("$(OutDir)"), _("An alias to $(IntermediateDirectory)"));
-        AddMacro(wxT("$(CurrentFileName)"), _("Expands to current file name (without extension and path)"));
-        AddMacro(wxT("$(CurrentFilePath)"), _("Expands to current file path"));
-        AddMacro(wxT("$(CurrentFileFullPath)"), _("Expands to current file full path (path and full name)"));
-        AddMacro(wxT("$(CurrentFileFullName)"), _("Expands to current file full name (name and extension)"));
-        AddMacro(wxT("$(User)"), _("Expands to logged-in user as defined by the OS"));
-        AddMacro(wxT("$(Date)"), _("Expands to current date"));
-        AddMacro(wxT("$(CodeLitePath)"),
+        AddMacro("$(ConfigurationName)", _("Expands to the current project selected configuration"));
+        AddMacro("$(OutDir)", _("An alias to $(IntermediateDirectory)"));
+        AddMacro("$(CurrentFileName)", _("Expands to current file name (without extension and path)"));
+        AddMacro("$(CurrentFilePath)", _("Expands to current file path"));
+        AddMacro("$(CurrentFileFullPath)", _("Expands to current file full path (path and full name)"));
+        AddMacro("$(CurrentFileFullName)", _("Expands to current file full name (name and extension)"));
+        AddMacro("$(User)", _("Expands to logged-in user as defined by the OS"));
+        AddMacro("$(Date)", _("Expands to current date"));
+        AddMacro("$(CodeLitePath)",
                  _("Expands to CodeLite's startup directory on (e.g. on Unix it expands to ~/.codelite/)"));
         AddMacro(
-            wxT("$(ProjectFiles)"),
+            "$(ProjectFiles)",
             _("A space delimited string containing all of the project files in a relative path to the project file"));
-        AddMacro(wxT("$(ProjectFilesAbs)"),
+        AddMacro("$(ProjectFilesAbs)",
                  _("A space delimited string containing all of the project files in an absolute path"));
-        AddMacro(wxT("`expression`"), _("backticks: evaluates the expression inside the backticks into a string"));
-        AddMacro(wxT("$(OutputFile)"), _("The output file"));
+        AddMacro("`expression`", _("backticks: evaluates the expression inside the backticks into a string"));
+        AddMacro("$(OutputDirectory)", _("The directory part of $(OutputFile)"));
+        AddMacro("$(OutputFile)", _("The output file"));
         break;
 
     case MacrosCompiler:
-        AddMacro(wxT("$(CXX)"), _("Expands to the compiler name as set in the Tools tab"));
-        AddMacro(wxT("$(SourceSwitch)"), _("Expands to the source switch (usually, -c)"));
-        AddMacro(wxT("$(FileFullPath)"), _("The file full path (includes path+name+extension)"));
-        AddMacro(wxT("$(FileFullName)"), _("The file full name (includes name+extension)"));
-        AddMacro(wxT("$(FileName)"), _("The file name (name only)"));
-        AddMacro(wxT("$(FilePath)"), _("The file's path with UNIX slashes, including terminating separator"));
-        AddMacro(wxT("$(CXXFLAGS)"), _("Expands to the compiler options as set in the project settings"));
-        AddMacro(wxT("$(RcCompilerName)"), _("Expands to the resource compiler name"));
-        AddMacro(wxT("$(IntermediateDirectory)"),
+        AddMacro("$(CXX)", _("Expands to the compiler name as set in the Tools tab"));
+        AddMacro("$(SourceSwitch)", _("Expands to the source switch (usually, -c)"));
+        AddMacro("$(FileFullPath)", _("The file full path (includes path+name+extension)"));
+        AddMacro("$(FileFullName)", _("The file full name (includes name+extension)"));
+        AddMacro("$(FileName)", _("The file name (name only)"));
+        AddMacro("$(FilePath)", _("The file's path with UNIX slashes, including terminating separator"));
+        AddMacro("$(CXXFLAGS)", _("Expands to the compiler options as set in the project settings"));
+        AddMacro("$(RcCompilerName)", _("Expands to the resource compiler name"));
+        AddMacro("$(IntermediateDirectory)",
                  _("Expands to the current project intermediate directory path, as set in the project settings"));
-        AddMacro(wxT("$(ConfigurationName)"), _("Expands to the current project selected configuration"));
-        AddMacro(wxT("$(OutDir)"), _("An alias to $(IntermediateDirectory)"));
-        AddMacro(wxT("$(LinkerName)"), _("Expands to the linker name as set in the Tools tab"));
-        AddMacro(wxT("$(AR)"), _("Expands to the archive tool (e.g. ar) name as set in the Tools tab"));
-        AddMacro(wxT("$(SharedObjectLinkerName)"),
-                 _("Expands to the shared object linker name as set in the Tools tab"));
-        AddMacro(wxT("$(ObjectSuffix)"), _("Objects suffix (usually set to .o)"));
-        AddMacro(wxT("$(ObjectName)"), _("The object name (without the suffix)"));
-        AddMacro(wxT("$(DependSuffix)"), _("Objects suffix (usually set to .o.d)"));
-        AddMacro(wxT("$(PreprocessSuffix)"), _("Objects suffix (usually set to .o.i)"));
-        AddMacro(wxT("$(IncludeSwitch)"), _("The compiler include switch"));
-        AddMacro(wxT("$(LibrarySwitch)"), _("The library switch (e.g. -l)"));
-        AddMacro(wxT("$(OutputSwitch)"), _("The output switch (e.g. -o)"));
-        AddMacro(wxT("$(LibraryPathSwitch)"), _("Library switch (e.g. -L)"));
-        AddMacro(wxT("$(PreprocessorSwitch)"), _("Preprocessor switch (e.g. -D)"));
-        AddMacro(wxT("$(Preprocessors)"), _("Expands to all preprocessors set in the project setting where each entry "
-                                            "is prefixed with $(PreprocessorSwitch)"));
-        AddMacro(wxT("$(ArchiveOutputSwitch)"), _("Archive switch, usually not needed (VC compiler sets it to /OUT:"));
-        AddMacro(wxT("$(PreprocessOnlySwitch)"), _("The compiler preprocess-only switch (e.g. -E)"));
-        AddMacro(wxT("$(LinkOptions)"), _("The linker options as set in the project settings"));
-        AddMacro(wxT("$(IncludePath)"), _("All include paths prefixed with $(IncludeSwitch)"));
-        AddMacro(wxT("$(RcIncludePath)"), _("Resource compiler include path as set in the project settings"));
-        AddMacro(wxT("$(Libs)"), _("List of libraries to link with. Each library is prefixed with $(LibrarySwitch)"));
-        AddMacro(wxT("$(LibPath)"),
+        AddMacro("$(ConfigurationName)", _("Expands to the current project selected configuration"));
+        AddMacro("$(OutDir)", _("An alias to $(IntermediateDirectory)"));
+        AddMacro("$(LinkerName)", _("Expands to the linker name as set in the Tools tab"));
+        AddMacro("$(AR)", _("Expands to the archive tool (e.g. ar) name as set in the Tools tab"));
+        AddMacro("$(SharedObjectLinkerName)", _("Expands to the shared object linker name as set in the Tools tab"));
+        AddMacro("$(ObjectSuffix)", _("Objects suffix (usually set to .o)"));
+        AddMacro("$(ObjectName)", _("The object name (without the suffix)"));
+        AddMacro("$(DependSuffix)", _("Objects suffix (usually set to .o.d)"));
+        AddMacro("$(PreprocessSuffix)", _("Objects suffix (usually set to .o.i)"));
+        AddMacro("$(IncludeSwitch)", _("The compiler include switch"));
+        AddMacro("$(LibrarySwitch)", _("The library switch (e.g. -l)"));
+        AddMacro("$(OutputSwitch)", _("The output switch (e.g. -o)"));
+        AddMacro("$(LibraryPathSwitch)", _("Library switch (e.g. -L)"));
+        AddMacro("$(PreprocessorSwitch)", _("Preprocessor switch (e.g. -D)"));
+        AddMacro("$(Preprocessors)", _("Expands to all preprocessors set in the project setting where each entry "
+                                       "is prefixed with $(PreprocessorSwitch)"));
+        AddMacro("$(ArchiveOutputSwitch)", _("Archive switch, usually not needed (VC compiler sets it to /OUT:"));
+        AddMacro("$(PreprocessOnlySwitch)", _("The compiler preprocess-only switch (e.g. -E)"));
+        AddMacro("$(LinkOptions)", _("The linker options as set in the project settings"));
+        AddMacro("$(IncludePath)", _("All include paths prefixed with $(IncludeSwitch)"));
+        AddMacro("$(RcIncludePath)", _("Resource compiler include path as set in the project settings"));
+        AddMacro("$(Libs)", _("List of libraries to link with. Each library is prefixed with $(LibrarySwitch)"));
+        AddMacro("$(LibPath)",
                  _("List of library paths to link with. Each library is prefixed with $(LibraryPathSwitch)"));
-        AddMacro(wxT("$(ProjectOutputFile)"), _("The output file"));
-        AddMacro(wxT("$(OutputFile)"), _("The output file, same as $(ProjectOutputFile)"));
+        AddMacro("$(OutputDirectory)", _("The directory part of $(ProjectOutputFile)"));
+        AddMacro("$(ProjectOutputFile)", _("The output file"));
+        AddMacro("$(OutputFile)", _("The output file, same as $(ProjectOutputFile)"));
         break;
     }
 
@@ -181,11 +182,11 @@ void MacrosDlg::OnCopy(wxCommandEvent& e)
         if(wxTheClipboard->Open()) {
             wxTheClipboard->UsePrimarySelection(false);
             if(!wxTheClipboard->SetData(new wxTextDataObject(value))) {
-                // wxPrintf(wxT("Failed to insert data %s to clipboard"), textToCopy.GetData());
+                // wxPrintf("Failed to insert data %s to clipboard", textToCopy.GetData());
             }
             wxTheClipboard->Close();
         } else {
-            wxPrintf(wxT("Failed to open the clipboard"));
+            wxPrintf("Failed to open the clipboard");
         }
 #endif
     }


### PR DESCRIPTION
Currently, the GNU make generator ignores user's `$(IntermediateDirectory)` / `$(OutputFile)` settings and forces you to use `build-$(WorkspaceConfiguration)` directory.
I don't know if this was the intended design (since the old generator wasn't like this) but I think it'd be nice if it's customizable.

Summary of changes:
  * Use `$(IntermediateDirectory)` for intermediate build files.
    The macro will use relative path in order to minimize problems with GNU make's space handling.
  * Add `$(OutputDirectory)` macro that returns the directory part of `$(OutputFile)`.
    This was originally added for internal mkdir purpose, but it can also be used in pre/post build step etc.
  * `$(WorkspaceConfiguration)` is no longer an alias to *each project*'s `$(ConfigurationName)`.
    This makes a contradiction with macro dialog's help and confusing.
  * Respect `mkdir` field from build settings.
  * NMake generator: update default `$(IntermediateDirectory)` and `$(OutputFile)` location to follow MSVC style.

To preserve backward-compatibility, the `$(IntermediateDirectory)` and `$(OutputFile)` will use `build-$(WorkspaceConfiguration)` directory if set blank.