### PR TITLE
Fix ctagsd default ignore_spec settings

### DIFF
--- a/ctagsd/lib/Settings.hpp
+++ b/ctagsd/lib/Settings.hpp
@@ -15,7 +15,7 @@ class CTagsdSettings
     vector<pair<wxString, wxString>> m_tokens;
     vector<pair<wxString, wxString>> m_types;
     wxString m_codelite_indexer;
-    wxString m_ignore_spec = ".git/;.svn/;/build/;/build-;CPack_Packages/;CMakeFiles/";
+    wxString m_ignore_spec = "/.git/;/.svn/;/build/;/build-;/CPack_Packages/;/CMakeFiles/";
     size_t m_limit_results = 150;
     wxString m_settings_dir;
 


### PR DESCRIPTION
Any path containing a matching ignore spec above the root path would make an erroneous match as function filter_non_important_files() uses Contains() on the full file path
Make the ignore specs precise - add path separators on both sides of .git and .svn etc

This fixes issue #2956