### PR TITLE
Ensure that .ctagsd directory is excluded

### DIFF
--- a/Plugin/clFileSystemWorkspace.cpp
+++ b/Plugin/clFileSystemWorkspace.cpp
@@ -189,7 +189,7 @@ void clFileSystemWorkspace::CacheFiles(bool force)
         [=](const wxString& rootFolder) {
             clFilesScanner fs;
             std::vector<wxString> files;
-            wxStringSet_t excludeFolders = { ".git", ".svn", ".codelite" };
+            wxStringSet_t excludeFolders = { ".git", ".svn", ".codelite", ".ctagsd" };
 
             wxString excludePaths = GetExcludeFolders();
             wxArrayString paths = StringUtils::BuildArgv(excludePaths);


### PR DESCRIPTION
Found a missing exclude spec during my bug-hunt.

Internal files below .ctagsd was included in the `file_list.txt`