### PR TITLE
Fixed wrong version for SEMIBOLD

### DIFF
--- a/Plugin/clButtonBase.cpp
+++ b/Plugin/clButtonBase.cpp
@@ -15,6 +15,8 @@
 #define TEXT_SPACER FromDIP(5)
 #else
 #define TEXT_SPACER 5
+#endif
+#if !wxCHECK_VERSION(3, 1, 2)
 #define SetFractionalPointSize SetPointSize
 #define wxFONTWEIGHT_SEMIBOLD wxFONTWEIGHT_BOLD
 #endif


### PR DESCRIPTION
`SetFractionalPointSize` and `wxFONTWEIGHT_SEMIBOLD` were introduced in 3.1.2 not 3.1.0