### PR TITLE
Fixes for wxWidgets with STL

### DIFF
--- a/CodeLite/JSON.cpp
+++ b/CodeLite/JSON.cpp
@@ -804,12 +804,3 @@ JSONItem& JSONItem::addProperty(const wxString& name, const std::vector<int>& ar
     }
     return *this;
 }
-
-JSONItem& JSONItem::addProperty(const wxString& name, const wxVector<int>& arr_int)
-{
-    std::vector<int> V;
-    V.reserve(arr_int.size());
-
-    V.insert(V.end(), arr_int.begin(), arr_int.end());
-    return addProperty(name, V);
-}

--- a/CodeLite/JSON.h
+++ b/CodeLite/JSON.h
@@ -41,6 +41,7 @@
 #endif
 #include "macros.h"
 #include <vector>
+#include <type_traits>
 // clang-format on
 
 //////////////////////////////////////////////////////////////////////////
@@ -164,7 +165,11 @@ public:
     JSONItem& addProperty(const wxString& name, cJSON* pjson);
     JSONItem& addProperty(const wxString& name, const wxFileName& filename);
     JSONItem& addProperty(const wxString& name, const std::vector<int>& arr_int);
-    JSONItem& addProperty(const wxString& name, const wxVector<int>& arr_int);
+    template<class T = int>
+    typename std::enable_if<!std::is_same<wxVector<T>, std::vector<T>>::value,
+                            JSONItem&>::type addProperty(const wxString& name, const wxVector<T>& arr_int) {
+	return addProperty(name, std::vector<T>(arr_int.begin(), arr_int.end()));
+    }
 
 #if wxUSE_GUI
     JSONItem& addProperty(const wxString& name, const wxSize& sz);

--- a/LiteEditor/quickfindbar.cpp
+++ b/LiteEditor/quickfindbar.cpp
@@ -775,7 +775,7 @@ void QuickFindBar::DoReplaceAll(bool selectionOnly)
     bool isUTF8 = false;
 
     wxString input_buffer = m_sci->GetText();
-    unsigned int utfLen = ::clUTF8Length(input_buffer, input_buffer.length());
+    unsigned int utfLen = ::clUTF8Length(input_buffer.ToStdWstring().c_str(), input_buffer.length());
     isUTF8 = (utfLen != input_buffer.length());
 
     if(!IsReplacementRegex() && !isUTF8) {

--- a/LiteEditor/replaceinfilespanel.cpp
+++ b/LiteEditor/replaceinfilespanel.cpp
@@ -311,7 +311,7 @@ void ReplaceInFilesPanel::OnReplace(wxCommandEvent& e)
 
         wxString replaceText = DoGetReplaceWith(res);
         int replaceLenInChars = (int)replaceText.Len();
-        int replaceLen = (int)::clUTF8Length(replaceText, replaceLenInChars);
+        int replaceLen = (int)::clUTF8Length(replaceText.ToStdWstring().c_str(), replaceLenInChars);
 
         // extract originally matched text for safety check later
         wxString text = res.GetPattern().Mid(res.GetColumnInChars() - deltaInChars, res.GetLenInChars());

--- a/ctagsd/tests/tester.hpp
+++ b/ctagsd/tests/tester.hpp
@@ -131,6 +131,13 @@ public:
         }                                                                                                \
     }
 
+static int strcmp(const wxString& str, const char* expc) {
+    return strcmp(str.ToStdString().c_str(), expc);
+}
+static int strcmp(const wxString& str, const wxString& expc) {
+    return strcmp(str.ToStdString().c_str(), expc.ToStdString().c_str());
+}
+
 #define CHECK_STRING(str, expcStr)                                                                             \
     {                                                                                                          \
         ++m_testCount;                                                                                         \


### PR DESCRIPTION
The codebase has problems when wxWidget was built with `wxUSE_STL==1`. In particular,
* `wxVector` is then an alias for `std::vector`, which means that you can't have override methods for each of these types (resolved with `enable_if`)
* `wxString` behaves different with regard to some automatic conversions (resolved by using explicit conversions)
