### PR TITLE
Several bug fixes 6

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,4 @@
+If:
+  PathMatch: .*\.h
+CompileFlags:
+  Add: -xc++

--- a/LiteEditor/frame.h
+++ b/LiteEditor/frame.h
@@ -42,21 +42,21 @@
 #include "mainbook.h"
 #include "output_pane.h"
 #include "tags_options_dlg.h"
-#include "wx/aui/aui.h"
-#include "wx/choice.h"
-#include "wx/combobox.h"
-#include "wx/frame.h"
-#include "wx/timer.h"
 #include "wxCustomControls.hpp"
 
 #include <set>
+#include <wx/aui/aui.h>
+#include <wx/choice.h>
 #include <wx/cmndata.h>
+#include <wx/combobox.h>
 #include <wx/dcbuffer.h>
+#include <wx/frame.h>
 #include <wx/html/htmlwin.h>
 #include <wx/infobar.h>
 #include <wx/minifram.h>
 #include <wx/process.h>
 #include <wx/splash.h>
+#include <wx/timer.h>
 
 // forward decls
 class OnSysColoursChanged;
@@ -91,6 +91,8 @@ struct StartPageData {
 
 class clMainFrame : public wxFrame
 {
+    enum class ePostBuildEndAction { kNone, kRunProject, kRebuildProject };
+
     MainBook* m_mainBook;
     static clMainFrame* m_theFrame;
     clDockingManager m_mgr;
@@ -101,7 +103,7 @@ class clMainFrame : public wxFrame
     std::map<int, wxString> m_viewAsMap;
     TagsOptionsData m_tagsOptionsData;
     DebuggerPane* m_debuggerPane;
-    bool m_buildAndRun;
+    ePostBuildEndAction m_postBuildEndAction;
     GeneralInfo m_frameGeneralInfo;
     std::map<int, wxString> m_toolbars;
     std::map<int, wxString> m_panes;
@@ -304,10 +306,22 @@ public:
     void OnSingleInstanceRaise(clCommandEvent& e);
 
     /**
-     * @brief rebuild the give project
+     * @brief build the given project
+     * @param projectName
+     */
+    void BuildProject(const wxString& projectName);
+
+    /**
+     * @brief rebuild the given project
      * @param projectName
      */
     void RebuildProject(const wxString& projectName);
+
+    /**
+     * @brief execute a built program without attaching a debugger
+     * @param promptToBuild
+     */
+    void ExecuteNoDebug(bool promptToBuild);
 
     /**
      * @brief handle custom build targets events

--- a/Plugin/builder_NMake.cpp
+++ b/Plugin/builder_NMake.cpp
@@ -1326,9 +1326,7 @@ void BuilderNMake::CreateConfigsVariables(ProjectPtr proj, BuildConfigPtr bldCon
         wxString rcBuildOpts = bldConf->GetResCompileOptions();
         rcBuildOpts.Replace(";", " ");
         text << "RcCmpOptions           =" << rcBuildOpts << "\n";
-        wxString rcCompilerstr(cmp->GetTool("ResourceCompiler"));
-        rcCompilerstr.Replace("/", "\\");
-        text << "RcCompilerName         =" << rcCompilerstr << "\n";
+        text << "RcCompilerName         =" << cmp->GetTool("ResourceCompiler") << "\n";
     }
 
     wxString linkOpt = bldConf->GetLinkOptions();

--- a/Plugin/clFileSystemWorkspace.cpp
+++ b/Plugin/clFileSystemWorkspace.cpp
@@ -30,12 +30,12 @@
 #include "macros.h"
 #include "processreaderthread.h"
 #include "shell_command.h"
+#include "wxStringHash.h"
 
 #include <thread>
 #include <wx/msgdlg.h>
 #include <wx/tokenzr.h>
 #include <wx/xrc/xmlres.h>
-#include <wxStringHash.h>
 
 #define CHECK_ACTIVE_CONFIG()                \
     if(!GetSettings().GetSelectedConfig()) { \
@@ -363,8 +363,9 @@ void clFileSystemWorkspace::DoOpen()
 
 void clFileSystemWorkspace::DoClose()
 {
-    if(!m_isLoaded)
+    if(!m_isLoaded) {
         return;
+    }
 
     // Store the session
     clGetManager()->StoreWorkspaceSession(m_filename);
@@ -969,8 +970,9 @@ void clFileSystemWorkspace::OnDebug(clDebugEvent& event)
     // Fire "starting" event
     clDebugEvent eventStarting(wxEVT_DEBUG_STARTING);
     eventStarting.SetClientData(&session_info);
-    if(EventNotifier::Get()->ProcessEvent(eventStarting))
+    if(EventNotifier::Get()->ProcessEvent(eventStarting)) {
         return;
+    }
 
     // Check if any plugins provided us with new breakpoints
     if(!eventStarting.GetBreakpoints().empty()) {

--- a/Plugin/clFileSystemWorkspaceConfig.cpp
+++ b/Plugin/clFileSystemWorkspaceConfig.cpp
@@ -170,9 +170,11 @@ static wxArrayString GetExtraFlags(CompilerPtr compiler)
 {
     wxArrayString flags;
     if(compiler->HasMetadata()) {
-        flags.Add("-target");
         auto md = compiler->GetMetadata();
-        flags.Add(md.GetTarget());
+        if(!md.GetTarget().IsEmpty()) {
+            flags.Add("-target");
+            flags.Add(md.GetTarget());
+        }
     }
     return flags;
 }

--- a/Plugin/macrosdlg.cpp
+++ b/Plugin/macrosdlg.cpp
@@ -131,7 +131,7 @@ void MacrosDlg::Initialize()
         AddMacro("$(PreprocessorSwitch)", _("Preprocessor switch (e.g. -D)"));
         AddMacro("$(Preprocessors)", _("Expands to all preprocessors set in the project setting where each entry "
                                        "is prefixed with $(PreprocessorSwitch)"));
-        AddMacro("$(ArchiveOutputSwitch)", _("Archive switch, usually not needed (VC compiler sets it to /OUT:"));
+        AddMacro("$(ArchiveOutputSwitch)", _("Archive switch, usually not needed (VC compiler sets it to /OUT:)"));
         AddMacro("$(PreprocessOnlySwitch)", _("The compiler preprocess-only switch (e.g. -E)"));
         AddMacro("$(LinkOptions)", _("The linker options as set in the project settings"));
         AddMacro("$(IncludePath)", _("All include paths prefixed with $(IncludeSwitch)"));


### PR DESCRIPTION
1. Macros: Fix typo (add a missing brace).

2. `compile_flags.txt`: `-target` must not be empty.
Despite of the fix add7432, the `-target` value can still be empty, which breaks `clangd` code completion.

3. NMake Generator: Fix `rc.exe` invocation error.
Don't replace `rc.exe /nologo` with `rc.exe \nologo`, which isn't a valid option.
(This value is normally just `rc.exe /nologo` as we invoke it on vcvars\* environment.)

4. Filesystem Workspace: Make `Build and Run Project` and `Rebuild Project` work with filesystem workspace.
This reuses the existing event handlers to avoid duplicated implementation code.

5. Add `.clangd` file.
This would reduce code completion errors in \*.h header file when working with CodeLite source tree, as it gets parsed as C instead of C++.