### PR TITLE
Windows resource (.rc) fix for wxWidgets 3.1.6

### DIFF
--- a/LiteEditor/code_parser.rc
+++ b/LiteEditor/code_parser.rc
@@ -25,7 +25,8 @@
 
 aaaaa ICON "res/codelite-logo.ico"
 #include "wx/msw/wx.rc"
-#if WIN64
+#include "wx/version.h"
+#if defined(WIN64) && !wxCHECK_VERSION(3, 1, 6)
 1 24 "wx/msw/amd64.manifest"
 #else
 1 24 "wx/msw/wx.manifest"

--- a/Runtime/templates/projects/executable-wx-dialog/win_resources.rc
+++ b/Runtime/templates/projects/executable-wx-dialog/win_resources.rc
@@ -1,5 +1,6 @@
 #include "wx/msw/wx.rc"
-#ifdef WIN64
+#include "wx/version.h"
+#if defined(WIN64) && !wxCHECK_VERSION(3, 1, 6)
 1 24 "wx/msw/amd64.manifest"
 #else
 1 24 "wx/msw/wx.manifest"

--- a/Runtime/templates/projects/executable-wx-frame/win_resources.rc
+++ b/Runtime/templates/projects/executable-wx-frame/win_resources.rc
@@ -1,5 +1,6 @@
 #include "wx/msw/wx.rc"
-#ifdef WIN64
+#include "wx/version.h"
+#if defined(WIN64) && !wxCHECK_VERSION(3, 1, 6)
 1 24 "wx/msw/amd64.manifest"
 #else
 1 24 "wx/msw/wx.manifest"

--- a/Runtime/templates/projects/executable-wxcrafter-dialog/win_resources.rc
+++ b/Runtime/templates/projects/executable-wxcrafter-dialog/win_resources.rc
@@ -1,5 +1,6 @@
 #include "wx/msw/wx.rc"
-#ifdef WIN64
+#include "wx/version.h"
+#if defined(WIN64) && !wxCHECK_VERSION(3, 1, 6)
 1 24 "wx/msw/amd64.manifest"
 #else
 1 24 "wx/msw/wx.manifest"

--- a/Runtime/templates/projects/executable-wxcrafter-frame/win_resources.rc
+++ b/Runtime/templates/projects/executable-wxcrafter-frame/win_resources.rc
@@ -1,5 +1,6 @@
 #include "wx/msw/wx.rc"
-#ifdef WIN64
+#include "wx/version.h"
+#if defined(WIN64) && !wxCHECK_VERSION(3, 1, 6)
 1 24 "wx/msw/amd64.manifest"
 #else
 1 24 "wx/msw/wx.manifest"

--- a/codelite-cli/codelite-client/win_resources.rc
+++ b/codelite-cli/codelite-client/win_resources.rc
@@ -1,5 +1,6 @@
 #include "wx/msw/wx.rc"
-#ifdef WIN64
+#include "wx/version.h"
+#if defined(WIN64) && !wxCHECK_VERSION(3, 1, 6)
 1 24 "wx/msw/amd64.manifest"
 #else
 1 24 "wx/msw/wx.manifest"

--- a/codelite-generate-themes/codelite-generate-themes/resources.rc
+++ b/codelite-generate-themes/codelite-generate-themes/resources.rc
@@ -1,5 +1,6 @@
 #include "wx/msw/wx.rc"
-#ifdef WIN64
+#include "wx/version.h"
+#if defined(WIN64) && !wxCHECK_VERSION(3, 1, 6)
 1 24 "wx/msw/amd64.manifest"
 #else
 1 24 "wx/msw/wx.manifest"

--- a/codelite_terminal/win_resources.rc
+++ b/codelite_terminal/win_resources.rc
@@ -1,6 +1,7 @@
 aaaaaaaaaaa ICON  terminal.ico
 #include "wx/msw/wx.rc"
-#if WIN64
+#include "wx/version.h"
+#if defined(WIN64) && !wxCHECK_VERSION(3, 1, 6)
 1 24 "wx/msw/amd64.manifest"
 #else
 1 24 "wx/msw/wx.manifest"

--- a/sdk/wxsqlite3/src/wxsqlite3_resourecs.rc
+++ b/sdk/wxsqlite3/src/wxsqlite3_resourecs.rc
@@ -1,5 +1,6 @@
 #include "wx/msw/wx.rc"
-#if WIN64
+#include "wx/version.h"
+#if defined(WIN64) && !wxCHECK_VERSION(3, 1, 6)
 1 24 "wx/msw/amd64.manifest"
 #else
 1 24 "wx/msw/wx.manifest"

--- a/wxcrafter/resources/wxcapp_resources.rc
+++ b/wxcrafter/resources/wxcapp_resources.rc
@@ -1,6 +1,7 @@
 bbbbb ICON "resources/wxc-logo.ico"
 #include "wx/msw/wx.rc"
-#if WIN64
+#include "wx/version.h"
+#if defined(WIN64) && !wxCHECK_VERSION(3, 1, 6)
 1 24 "wx/msw/amd64.manifest"
 #else
 1 24 "wx/msw/wx.manifest"


### PR DESCRIPTION
`wx/msw/amd64.manifest` has been [removed](https://github.com/wxWidgets/wxWidgets/commit/77d892612640a23c17debdac579c4afcbb2b4afd) since wxWidgets 3.1.6.