### PR TITLE
Respect user-supplied/alternate wx-config

### DIFF
--- a/codelite-cli/CMakeLists.txt
+++ b/codelite-cli/CMakeLists.txt
@@ -22,7 +22,11 @@ if(APPLE)
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
-set(CL_WX_CONFIG "wx-config")
+
+if(NOT CL_WX_CONFIG)
+    set(CL_WX_CONFIG "wx-config")
+endif
+
 # we need wxWidgets flags to be set only for the c++ files, so we do it like this
 # by setting the CMAKE_CXX_FLAGS
 if(NOT MINGW)

--- a/ctagsd/CMakeLists.txt
+++ b/ctagsd/CMakeLists.txt
@@ -20,7 +20,11 @@ if(APPLE)
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
-set(CL_WX_CONFIG "wx-config")
+
+if(NOT CL_WX_CONFIG)
+    set(CL_WX_CONFIG "wx-config")
+endif()
+
 # we need wxWidgets flags to be set only for the c++ files, so we do it like this
 # by setting the CMAKE_CXX_FLAGS
 if(NOT MINGW)


### PR DESCRIPTION
User-supplied/alternate wx-config is not respected by ctagsd and codelite-cli subsystems