### PR TITLE
Reduce the use of `using namespace std;`

### DIFF
--- a/CodeLite/CTags.cpp
+++ b/CodeLite/CTags.cpp
@@ -19,10 +19,11 @@ void WrapInShell(wxString& cmd)
 {
     wxString command;
 #ifdef __WXMSW__
-    wxChar* shell = wxGetenv(wxT("COMSPEC"));
-    if(!shell)
-        shell = (wxChar*)wxT("CMD.EXE");
-    command << shell << wxT(" /C ");
+    wxString shell = wxGetenv("COMSPEC");
+    if(shell.IsEmpty()) {
+        shell = "CMD.EXE";
+    }
+    command << shell << " /C ";
     if(cmd.StartsWith("\"") && !cmd.EndsWith("\"")) {
         command << "\"" << cmd << "\"";
     } else {
@@ -30,10 +31,10 @@ void WrapInShell(wxString& cmd)
     }
     cmd = command;
 #else
-    command << wxT("/bin/sh -c '");
+    command << "/bin/sh -c '";
     // escape any single quoutes
     cmd.Replace("'", "\\'");
-    command << cmd << wxT("'");
+    command << cmd << "'";
     cmd = command;
 #endif
 }
@@ -69,7 +70,7 @@ bool CTags::DoGenerate(const wxString& filesContent, const wxString& codelite_in
 
     // prepare the options file
     // one option per line
-    vector<wxString> options_arr;
+    std::vector<wxString> options_arr;
     options_arr.reserve(500);
     wxString fields_cxx = "--fields-c++=+{template}+{properties}";
     if(is_macrodef_supported) {
@@ -144,8 +145,8 @@ bool CTags::DoGenerate(const wxString& filesContent, const wxString& codelite_in
     return true;
 }
 
-size_t CTags::ParseFiles(const vector<wxString>& files, const wxString& codelite_indexer,
-                         const wxStringMap_t& macro_table, vector<TagEntryPtr>& tags)
+size_t CTags::ParseFiles(const std::vector<wxString>& files, const wxString& codelite_indexer,
+                         const wxStringMap_t& macro_table, std::vector<TagEntryPtr>& tags)
 {
     wxString filesList;
     for(const auto& file : files) {
@@ -206,13 +207,13 @@ size_t CTags::ParseFiles(const vector<wxString>& files, const wxString& codelite
 }
 
 size_t CTags::ParseFile(const wxString& file, const wxString& codelite_indexer, const wxStringMap_t& macro_table,
-                        vector<TagEntryPtr>& tags)
+                        std::vector<TagEntryPtr>& tags)
 {
     return ParseFiles({ file }, codelite_indexer, macro_table, tags);
 }
 
 size_t CTags::ParseBuffer(const wxFileName& filename, const wxString& buffer, const wxString& codelite_indexer,
-                          const wxStringMap_t& macro_table, vector<TagEntryPtr>& tags)
+                          const wxStringMap_t& macro_table, std::vector<TagEntryPtr>& tags)
 {
     // create a temporary file with the content we want to parse
     clTempFile temp_file("cpp");
@@ -227,7 +228,7 @@ size_t CTags::ParseBuffer(const wxFileName& filename, const wxString& buffer, co
 }
 
 size_t CTags::ParseLocals(const wxFileName& filename, const wxString& buffer, const wxString& codelite_indexer,
-                          const wxStringMap_t& macro_table, vector<TagEntryPtr>& tags)
+                          const wxStringMap_t& macro_table, std::vector<TagEntryPtr>& tags)
 {
     wxString content;
     {
@@ -269,13 +270,14 @@ size_t CTags::ParseLocals(const wxFileName& filename, const wxString& buffer, co
 
 void CTags::Initialise(const wxString& codelite_indexer)
 {
-    if(is_initialised)
+    if(is_initialised) {
         return;
+    }
 
     is_initialised = true;
     // check whether we have `macrodef` supported
     wxString output;
-    vector<wxString> command = { codelite_indexer, "--list-fields=c++" };
+    std::vector<wxString> command = { codelite_indexer, "--list-fields=c++" };
     auto process = ::CreateAsyncProcess(nullptr, command, IProcessCreateSync, wxEmptyString, nullptr, wxEmptyString);
     if(process) {
         process->WaitForTerminate(output);

--- a/CodeLite/CTags.hpp
+++ b/CodeLite/CTags.hpp
@@ -10,7 +10,6 @@
 #include <wx/filename.h>
 #include <wx/textfile.h>
 
-using namespace std;
 class WXDLLIMPEXP_CL CTags
 {
 protected:
@@ -34,25 +33,25 @@ public:
     /**
      * @brief given a list of files, generate an output tags file and place it under 'path'
      */
-    static size_t ParseFiles(const vector<wxString>& files, const wxString& codelite_indexer,
-                             const wxStringMap_t& macro_table, vector<TagEntryPtr>& tags);
+    static size_t ParseFiles(const std::vector<wxString>& files, const wxString& codelite_indexer,
+                             const wxStringMap_t& macro_table, std::vector<TagEntryPtr>& tags);
 
     /**
      * @brief given a list of files, generate an output tags file and place it under 'path'
      */
     static size_t ParseFile(const wxString& file, const wxString& codelite_indexer, const wxStringMap_t& macro_table,
-                            vector<TagEntryPtr>& tags);
+                            std::vector<TagEntryPtr>& tags);
 
     /**
      * @brief run codelite-indexer on a buffer and return list of tags
      */
     static size_t ParseBuffer(const wxFileName& filename, const wxString& buffer, const wxString& codelite_indexer,
-                              const wxStringMap_t& macro_table, vector<TagEntryPtr>& tags);
+                              const wxStringMap_t& macro_table, std::vector<TagEntryPtr>& tags);
     /**
      * @brief parse list of local variables from a given source file
      */
     static size_t ParseLocals(const wxFileName& filename, const wxString& buffer, const wxString& codelite_indexer,
-                              const wxStringMap_t& macro_table, vector<TagEntryPtr>& tags);
+                              const wxStringMap_t& macro_table, std::vector<TagEntryPtr>& tags);
 };
 
 #endif // CTAGSGENERATOR_HPP

--- a/CodeLite/CompletionHelper.cpp
+++ b/CodeLite/CompletionHelper.cpp
@@ -7,7 +7,6 @@
 #include <vector>
 #include <wx/regex.h>
 
-using namespace std;
 namespace
 {
 #define PREPEND_STRING(tokn) expression.insert(expression.begin(), text)
@@ -28,14 +27,14 @@ wxString wrap_lines(const wxString& str)
     int curLineBytes(0);
     wxString::const_iterator iter = str.begin();
     for(; iter != str.end(); iter++) {
-        if(*iter == wxT('\t')) {
-            wrappedString << wxT(" ");
+        if(*iter == '\t') {
+            wrappedString << " ";
 
-        } else if(*iter == wxT('\n')) {
-            wrappedString << wxT("\n");
+        } else if(*iter == '\n') {
+            wrappedString << "\n";
             curLineBytes = 0;
 
-        } else if(*iter == wxT('\r')) {
+        } else if(*iter == '\r') {
             // Skip it
 
         } else {
@@ -46,8 +45,8 @@ wxString wrap_lines(const wxString& str)
         if(curLineBytes == MAX_TIP_LINE_SIZE) {
 
             // Wrap the lines
-            if(wrappedString.IsEmpty() == false && wrappedString.Last() != wxT('\n')) {
-                wrappedString << wxT("\n");
+            if(wrappedString.IsEmpty() == false && wrappedString.Last() != '\n') {
+                wrappedString << "\n";
             }
             curLineBytes = 0;
         }
@@ -69,7 +68,7 @@ wxString CompletionHelper::get_expression(const wxString& file_content, bool for
     tokenizer.Reset(file_content);
 
     CxxLexerToken token;
-    vector<pair<wxString, int>> tokens;
+    std::vector<std::pair<wxString, int>> tokens;
     tokens.reserve(10000);
 
     while(tokenizer.NextToken(token)) {
@@ -99,7 +98,7 @@ wxString CompletionHelper::get_expression(const wxString& file_content, bool for
         }
     }
 
-    vector<wxString> expression;
+    std::vector<wxString> expression;
     std::vector<int> types;
     int depth = 0;
     cont = true;
@@ -480,8 +479,8 @@ bool CompletionHelper::is_cxx_keyword(const wxString& word)
     return words.count(word) != 0;
 }
 
-vector<wxString> CompletionHelper::split_function_signature(const wxString& signature, wxString* return_value,
-                                                            size_t flags) const
+std::vector<wxString> CompletionHelper::split_function_signature(const wxString& signature, wxString* return_value,
+                                                                 size_t flags) const
 {
     // ---------------------------------------------------------------------------------------------
     // ----------------macros start-------------------------------------------------------------------
@@ -518,11 +517,11 @@ vector<wxString> CompletionHelper::split_function_signature(const wxString& sign
 
     wxString cur_func_param;
     wxString* current_param = &cur_func_param;
-    vector<wxString> args;
-    vector<wxString> func_args;
+    std::vector<wxString> args;
+    std::vector<wxString> func_args;
     int depth = 0;
 
-    vector<int> types;
+    std::vector<int> types;
     // search for the first opening brace
     while(tokenizer.NextToken(token)) {
         if(token.GetType() == '(') {
@@ -966,7 +965,7 @@ wxString CompletionHelper::normalize_function(const TagEntry* tag, size_t flags)
     wxString name = tag->GetName();
     wxString signature = tag->GetSignature();
     fullname << name << "(";
-    vector<wxString> args = split_function_signature(signature, &return_value, flags);
+    std::vector<wxString> args = split_function_signature(signature, &return_value, flags);
     wxString funcsig;
     for(const wxString& arg : args) {
         funcsig << arg << ", ";

--- a/CodeLite/CompletionHelper.hpp
+++ b/CodeLite/CompletionHelper.hpp
@@ -4,14 +4,13 @@
 #include "CxxTokenizer.h"
 #include "codelite_exports.h"
 #include "entry.h"
+#include "istorage.h"
 
 #include <functional>
-#include <istorage.h>
 #include <vector>
 #include <wx/filename.h>
 #include <wx/string.h>
 
-using namespace std;
 class WXDLLIMPEXP_CL CompletionHelper
 {
 public:
@@ -44,8 +43,8 @@ public:
                                                                     CompletionHelper::STRIP_NO_NAME);
     wxString get_expression(const wxString& file_content, bool for_calltip, wxString* last_word = nullptr) const;
     wxString truncate_file_to_location(const wxString& file_content, size_t line, size_t column, size_t flags) const;
-    vector<wxString> split_function_signature(const wxString& signature, wxString* return_value,
-                                              size_t flags = CompletionHelper::STRIP_DEFAULT) const;
+    std::vector<wxString> split_function_signature(const wxString& signature, wxString* return_value,
+                                                   size_t flags = CompletionHelper::STRIP_DEFAULT) const;
     static bool is_cxx_keyword(const wxString& word);
 
     /**

--- a/CodeLite/CxxCodeCompletion.hpp
+++ b/CodeLite/CxxCodeCompletion.hpp
@@ -11,30 +11,28 @@
 #include <vector>
 #include <wx/string.h>
 
-using namespace std;
-
 class CxxCodeCompletion;
 
 struct TemplateManager {
     CxxCodeCompletion* m_completer = nullptr;
-    vector<wxStringMap_t> m_table;
+    std::vector<wxStringMap_t> m_table;
 
     TemplateManager(CxxCodeCompletion* completer)
         : m_completer(completer)
     {
     }
     void clear();
-    void add_placeholders(const wxStringMap_t& table, const vector<wxString>& visible_scopes);
-    wxString resolve(const wxString& name, const vector<wxString>& visible_scopes) const;
-    typedef shared_ptr<TemplateManager> ptr_t;
+    void add_placeholders(const wxStringMap_t& table, const std::vector<wxString>& visible_scopes);
+    wxString resolve(const wxString& name, const std::vector<wxString>& visible_scopes) const;
+    typedef std::shared_ptr<TemplateManager> ptr_t;
 };
 
 // internal to this TU
 struct FileScope {
 private:
-    unordered_map<wxString, TagEntryPtr> static_members;      // static members (`string Foo::m_str`)
-    unordered_map<wxString, TagEntryPtr> function_parameters; // function parameters
-    vector<wxString> local_scopes;
+    std::unordered_map<wxString, TagEntryPtr> static_members;      // static members (`string Foo::m_str`)
+    std::unordered_map<wxString, TagEntryPtr> function_parameters; // function parameters
+    std::vector<wxString> local_scopes;
 
 public:
     void clear()
@@ -54,7 +52,7 @@ public:
 
     bool is_static_member(const wxString& name) const { return static_members.count(name); }
     bool is_function_parameter(const wxString& name) const { return function_parameters.count(name); }
-    void set_function_parameters(const vector<TagEntryPtr>& params)
+    void set_function_parameters(const std::vector<TagEntryPtr>& params)
     {
         function_parameters.reserve(params.size());
         for(auto t : params) {
@@ -81,9 +79,9 @@ public:
      * @brief return all function paramters that match the filter
      * if filter is empty, return all of the parameters
      */
-    vector<TagEntryPtr> get_function_parameters(const wxString& filter) const
+    std::vector<TagEntryPtr> get_function_parameters(const wxString& filter) const
     {
-        vector<TagEntryPtr> tags;
+        std::vector<TagEntryPtr> tags;
         tags.reserve(function_parameters.size());
 
         wxString lowercase_filter = filter.Lower();
@@ -97,7 +95,7 @@ public:
         return tags;
     }
 
-    const vector<wxString>& get_file_scopes() const { return local_scopes; }
+    const std::vector<wxString>& get_file_scopes() const { return local_scopes; }
     void set_file_scopes(const wxStringSet_t& scopes)
     {
         local_scopes.clear();
@@ -147,7 +145,7 @@ private:
 
 private:
     ITagsStoragePtr m_lookup;
-    unordered_map<wxString, CxxCodeCompletion::__local> m_locals;
+    std::unordered_map<wxString, CxxCodeCompletion::__local> m_locals;
     FileScope m_file_only_tags;
     wxString m_filename;
     int m_line_number = 0;
@@ -155,10 +153,10 @@ private:
     TagEntryPtr m_current_container_tag;
     size_t m_recurse_protector = 0;
     bool m_text_parsed = false;
-    vector<pair<wxString, wxString>>
+    std::vector<std::pair<wxString, wxString>>
         m_types_table; // helper table to solve what we cant (usually the limitations are coming from ctags)
     wxStringMap_t m_macros_table_map;
-    vector<pair<wxString, wxString>> m_macros_table;
+    std::vector<std::pair<wxString, wxString>> m_macros_table;
     TemplateManager::ptr_t m_template_manager;
     bool m_first_time = true;
     wxString m_codelite_indexer;
@@ -167,26 +165,28 @@ private:
     /**
      * @brief prepend scope to the list of scopes. Place it first
      */
-    void prepend_scope(vector<wxString>& scopes, const wxString& scope) const;
+    void prepend_scope(std::vector<wxString>& scopes, const wxString& scope) const;
     /**
      * @brief prepend the file specific scopes + global scope (if missing) to the requested visible scopes
      */
-    vector<wxString> prepend_extra_scopes(const vector<wxString>& visible_scopes);
+    std::vector<wxString> prepend_extra_scopes(const std::vector<wxString>& visible_scopes);
 
-    TagEntryPtr lookup_symbol(CxxExpression& curexpr, const vector<wxString>& visible_scopes, TagEntryPtr parent);
-    TagEntryPtr lookup_symbol_by_kind(const wxString& name, const vector<wxString>& visible_scopes,
-                                      const vector<wxString>& kinds);
-    TagEntryPtr lookup_operator_arrow(TagEntryPtr parent, const vector<wxString>& visible_scopes);
-    TagEntryPtr lookup_subscript_operator(TagEntryPtr parent, const vector<wxString>& visible_scopes);
+    TagEntryPtr lookup_symbol(CxxExpression& curexpr, const std::vector<wxString>& visible_scopes, TagEntryPtr parent);
+    TagEntryPtr lookup_symbol_by_kind(const wxString& name, const std::vector<wxString>& visible_scopes,
+                                      const std::vector<wxString>& kinds);
+    TagEntryPtr lookup_operator_arrow(TagEntryPtr parent, const std::vector<wxString>& visible_scopes);
+    TagEntryPtr lookup_subscript_operator(TagEntryPtr parent, const std::vector<wxString>& visible_scopes);
 
     TagEntryPtr lookup_child_symbol(TagEntryPtr parent, TemplateManager::ptr_t template_manager,
-                                    const wxString& child_symbol, const vector<wxString>& visible_scopes,
-                                    const vector<wxString>& kinds);
+                                    const wxString& child_symbol, const std::vector<wxString>& visible_scopes,
+                                    const std::vector<wxString>& kinds);
 
     wxString typedef_from_tag(TagEntryPtr tag) const;
-    void shrink_scope(const wxString& text, unordered_map<wxString, __local>* locals, FileScope* file_tags) const;
-    TagEntryPtr resolve_expression(CxxExpression& curexp, TagEntryPtr parent, const vector<wxString>& visible_scopes);
-    TagEntryPtr resolve_compound_expression(vector<CxxExpression>& expression, const vector<wxString>& visible_scopes,
+    void shrink_scope(const wxString& text, std::unordered_map<wxString, __local>* locals, FileScope* file_tags) const;
+    TagEntryPtr resolve_expression(CxxExpression& curexp, TagEntryPtr parent,
+                                   const std::vector<wxString>& visible_scopes);
+    TagEntryPtr resolve_compound_expression(std::vector<CxxExpression>& expression,
+                                            const std::vector<wxString>& visible_scopes,
                                             const CxxExpression& orig_expression);
 
     const wxStringMap_t& get_tokens_map() const;
@@ -198,45 +198,45 @@ private:
     /**
      * @brief apply user hacks
      */
-    bool resolve_user_type(const wxString& type, const vector<wxString>& visible_scopes, wxString* resolved) const;
+    bool resolve_user_type(const wxString& type, const std::vector<wxString>& visible_scopes, wxString* resolved) const;
 
-    vector<wxString> update_visible_scope(const vector<wxString>& curscopes, TagEntryPtr tag);
-    void update_template_table(TagEntryPtr resolved, CxxExpression& curexpr, const vector<wxString>& visible_scopes,
-                               wxStringSet_t& visited);
+    std::vector<wxString> update_visible_scope(const std::vector<wxString>& curscopes, TagEntryPtr tag);
+    void update_template_table(TagEntryPtr resolved, CxxExpression& curexpr,
+                               const std::vector<wxString>& visible_scopes, wxStringSet_t& visited);
 
-    size_t parse_locals(const wxString& text, unordered_map<wxString, __local>* locals) const;
+    size_t parse_locals(const wxString& text, std::unordered_map<wxString, __local>* locals) const;
 
     /**
      * @brief given `parent` node, return list of all its parents, in order
      * of inheritance. the list contains the `parent` itself as the first entry
      */
-    vector<TagEntryPtr> get_scopes(TagEntryPtr parent, const vector<wxString>& visible_scopes);
+    std::vector<TagEntryPtr> get_scopes(TagEntryPtr parent, const std::vector<wxString>& visible_scopes);
 
-    vector<TagEntryPtr> get_children_of_scope(TagEntryPtr parent, const vector<wxString>& kinds, const wxString& filter,
-                                              const vector<wxString>& visible_scopes);
+    std::vector<TagEntryPtr> get_children_of_scope(TagEntryPtr parent, const std::vector<wxString>& kinds,
+                                                   const wxString& filter, const std::vector<wxString>& visible_scopes);
 
     /**
      * @brief return parsable pattern from a tag
      */
     wxString normalize_pattern(TagEntryPtr tag) const;
 
-    size_t get_anonymous_tags(const wxString& name, const wxArrayString& kinds, vector<TagEntryPtr>& tags) const;
-    size_t get_keywords_tags(const wxString& name, vector<TagEntryPtr>& tags);
+    size_t get_anonymous_tags(const wxString& name, const wxArrayString& kinds, std::vector<TagEntryPtr>& tags) const;
+    size_t get_keywords_tags(const wxString& name, std::vector<TagEntryPtr>& tags);
 
-    TagEntryPtr on_method(CxxExpression& curexp, TagEntryPtr tag, const vector<wxString>& visible_scopes);
-    TagEntryPtr on_typedef(CxxExpression& curexp, TagEntryPtr tag, const vector<wxString>& visible_scopes);
-    TagEntryPtr on_member(CxxExpression& curexp, TagEntryPtr tag, const vector<wxString>& visible_scopes);
-    TagEntryPtr on_static_local(CxxExpression& curexp, const vector<wxString>& visible_scopes);
-    TagEntryPtr on_local(CxxExpression& curexp, const vector<wxString>& visible_scopes);
-    TagEntryPtr on_parameter(CxxExpression& curexp, const vector<wxString>& visible_scopes);
-    TagEntryPtr on_this(CxxExpression& curexp, const vector<wxString>& visible_scopes);
+    TagEntryPtr on_method(CxxExpression& curexp, TagEntryPtr tag, const std::vector<wxString>& visible_scopes);
+    TagEntryPtr on_typedef(CxxExpression& curexp, TagEntryPtr tag, const std::vector<wxString>& visible_scopes);
+    TagEntryPtr on_member(CxxExpression& curexp, TagEntryPtr tag, const std::vector<wxString>& visible_scopes);
+    TagEntryPtr on_static_local(CxxExpression& curexp, const std::vector<wxString>& visible_scopes);
+    TagEntryPtr on_local(CxxExpression& curexp, const std::vector<wxString>& visible_scopes);
+    TagEntryPtr on_parameter(CxxExpression& curexp, const std::vector<wxString>& visible_scopes);
+    TagEntryPtr on_this(CxxExpression& curexp, const std::vector<wxString>& visible_scopes);
 
     /**
      * @brief similar to CxxExpression::from_expression however, this method also passes
      * the result tokens in the pre_processor() code to replace any macros before serving them
      * for processing
      */
-    vector<CxxExpression> from_expression(const wxString& expression, CxxRemainder* remainder);
+    std::vector<CxxExpression> from_expression(const wxString& expression, CxxRemainder* remainder);
     /**
      * @brief attempt to perform simple substituation of `name` with
      * a matached entry from the `m_macros_table_map`
@@ -246,23 +246,23 @@ private:
     /**
      * @brief return the direct parents of a tag
      */
-    vector<TagEntryPtr> get_parents_of_tag_no_recurse(TagEntryPtr parent, TemplateManager::ptr_t template_manager,
-                                                      const vector<wxString>& visible_scopes);
+    std::vector<TagEntryPtr> get_parents_of_tag_no_recurse(TagEntryPtr parent, TemplateManager::ptr_t template_manager,
+                                                           const std::vector<wxString>& visible_scopes);
 
-    TagEntryPtr find_scope_tag(CxxExpression& curexp, const vector<wxString>& visible_scopes);
-    bool is_scope_tag(CxxExpression& curexp, const vector<wxString>& visible_scopes)
+    TagEntryPtr find_scope_tag(CxxExpression& curexp, const std::vector<wxString>& visible_scopes);
+    bool is_scope_tag(CxxExpression& curexp, const std::vector<wxString>& visible_scopes)
     {
         return find_scope_tag(curexp, visible_scopes);
     }
-    TagEntryPtr find_scope_tag_externvar(CxxExpression& curexp, const vector<wxString>& visible_scopes);
-    TagEntryPtr on_extern_var(CxxExpression& curexp, TagEntryPtr var, const vector<wxString>& visible_scopes);
+    TagEntryPtr find_scope_tag_externvar(CxxExpression& curexp, const std::vector<wxString>& visible_scopes);
+    TagEntryPtr on_extern_var(CxxExpression& curexp, TagEntryPtr var, const std::vector<wxString>& visible_scopes);
 
 public:
-    typedef shared_ptr<CxxCodeCompletion> ptr_t;
+    typedef std::shared_ptr<CxxCodeCompletion> ptr_t;
 
 public:
     CxxCodeCompletion(ITagsStoragePtr lookup, const wxString& codelite_indexer,
-                      const unordered_map<wxString, TagEntryPtr>& unit_tests_db);
+                      const std::unordered_map<wxString, TagEntryPtr>& unit_tests_db);
     CxxCodeCompletion(ITagsStoragePtr lookup, const wxString& codelite_indexer);
     ~CxxCodeCompletion();
 
@@ -277,7 +277,7 @@ public:
     /**
      * @brief sort input list of tags to a reasonable order
      */
-    void sort_tags(const vector<TagEntryPtr>& tags, vector<TagEntryPtr>& sorted_tags, bool include_ctor_dtor,
+    void sort_tags(const std::vector<TagEntryPtr>& tags, std::vector<TagEntryPtr>& sorted_tags, bool include_ctor_dtor,
                    const wxStringSet_t& visible_files);
 
     /**
@@ -293,12 +293,12 @@ public:
     /**
      * @brief set the typedef helper table
      */
-    void set_types_table(const vector<pair<wxString, wxString>>& t) { m_types_table = t; }
+    void set_types_table(const std::vector<std::pair<wxString, wxString>>& t) { m_types_table = t; }
 
     /**
      * @brief set macros table
      */
-    void set_macros_table(const vector<pair<wxString, wxString>>& t);
+    void set_macros_table(const std::vector<std::pair<wxString, wxString>>& t);
 
     /**
      * @brief replace the text
@@ -315,13 +315,13 @@ public:
      * `get`
      * @return a tag representing the scope
      */
-    TagEntryPtr code_complete(const wxString& expression, const vector<wxString>& visible_scopes,
+    TagEntryPtr code_complete(const wxString& expression, const std::vector<wxString>& visible_scopes,
                               CxxRemainder* remainder = nullptr);
 
     /**
      * @brief search the database for list of constructors
      */
-    size_t get_class_constructors(TagEntryPtr tag, vector<TagEntryPtr>& tags);
+    size_t get_class_constructors(TagEntryPtr tag, std::vector<TagEntryPtr>& tags);
 
     /**
      * @brief word completion. differ from code_complete by the expression. code_complete is called when user hit
@@ -329,47 +329,47 @@ public:
      * @return list of tags matches the context and filter placed in: `candidates`
      */
     size_t word_complete(const wxString& filepath, int line, const wxString& expression, const wxString& text,
-                         const vector<wxString>& visible_scopes, bool exact_match, vector<TagEntryPtr>& candidates,
-                         const wxStringSet_t& visible_files = {});
+                         const std::vector<wxString>& visible_scopes, bool exact_match,
+                         std::vector<TagEntryPtr>& candidates, const wxStringSet_t& visible_files = {});
     /**
      * return list of files for completion based on the prefix typed
      */
-    size_t get_file_completions(const wxString& user_typed, vector<TagEntryPtr>& files, const wxString& suffix);
+    size_t get_file_completions(const wxString& user_typed, std::vector<TagEntryPtr>& files, const wxString& suffix);
     /**
      * @brief return the local variables available for the current scope (passed in the c-tor)
      */
-    vector<TagEntryPtr> get_locals(const wxString& filter) const;
+    std::vector<TagEntryPtr> get_locals(const wxString& filter) const;
 
     /**
      * @brief return list local functions
      */
-    size_t get_local_tags(const wxString& filter, const wxStringSet_t& kinds, vector<TagEntryPtr>& tags) const;
+    size_t get_local_tags(const wxString& filter, const wxStringSet_t& kinds, std::vector<TagEntryPtr>& tags) const;
 
     /**
      * @brief return list of completions filtered by name for a given parent
      */
     size_t get_completions(TagEntryPtr parent, const wxString& operand_string, const wxString& filter,
-                           vector<TagEntryPtr>& candidates, const vector<wxString>& visible_scopes,
+                           std::vector<TagEntryPtr>& candidates, const std::vector<wxString>& visible_scopes,
                            size_t limit = (size_t)-1);
     /**
      * @brief return children tag of the current scope and any other relevant scopes
      * this method calls internally to `determine_current_scope()`
      * so make sure you called `set_text` with file and line number
      */
-    size_t get_children_of_current_scope(const vector<wxString>& kinds, const wxString& filter,
-                                         const vector<wxString>& visible_scopes,
-                                         vector<TagEntryPtr>* current_scope_children,
-                                         vector<TagEntryPtr>* other_scopes_children,
-                                         vector<TagEntryPtr>* global_scope_children);
+    size_t get_children_of_current_scope(const std::vector<wxString>& kinds, const wxString& filter,
+                                         const std::vector<wxString>& visible_scopes,
+                                         std::vector<TagEntryPtr>* current_scope_children,
+                                         std::vector<TagEntryPtr>* other_scopes_children,
+                                         std::vector<TagEntryPtr>* global_scope_children);
 
     /**
      * return list of completion for non expression attempt
      */
-    size_t get_word_completions(const CxxRemainder& remainder, vector<TagEntryPtr>& candidates,
-                                const vector<wxString>& visible_scopes, const wxStringSet_t& visible_files);
+    size_t get_word_completions(const CxxRemainder& remainder, std::vector<TagEntryPtr>& candidates,
+                                const std::vector<wxString>& visible_scopes, const wxStringSet_t& visible_files);
 
     size_t find_definition(const wxString& filepath, int line, const wxString& expr, const wxString& text,
-                           const vector<wxString>& visible_scopes, vector<TagEntryPtr>& matches);
+                           const std::vector<wxString>& visible_scopes, std::vector<TagEntryPtr>& matches);
 };
 
 #endif // CXXCODECOMPLETION_HPP

--- a/CodeLite/CxxExpression.cpp
+++ b/CodeLite/CxxExpression.cpp
@@ -8,7 +8,7 @@ CxxExpression::CxxExpression() {}
 
 CxxExpression::~CxxExpression() {}
 
-vector<CxxExpression> CxxExpression::from_expression(const wxString& expression, CxxRemainder* remainder)
+std::vector<CxxExpression> CxxExpression::from_expression(const wxString& expression, CxxRemainder* remainder)
 {
     CxxTokenizer tokenizer;
     CxxLexerToken tk;
@@ -19,7 +19,7 @@ vector<CxxExpression> CxxExpression::from_expression(const wxString& expression,
         tokenizer.Reset(cast_type);
     }
 
-    vector<CxxExpression> arr;
+    std::vector<CxxExpression> arr;
     CxxExpression curexpr;
 
     while(tokenizer.NextToken(tk)) {
@@ -388,7 +388,7 @@ void CxxExpression::parse_template_placeholders(const wxString& expr)
 wxStringMap_t CxxExpression::get_template_placeholders_map() const
 {
     wxStringMap_t M;
-    size_t count = min(m_template_placeholder_list.size(), m_template_init_list.size());
+    size_t count = std::min(m_template_placeholder_list.size(), m_template_init_list.size());
     for(size_t i = 0; i < count; i++) {
         M.insert({ m_template_placeholder_list[i], m_template_init_list[i] });
     }
@@ -416,7 +416,7 @@ void CxxExpression::set_operand(int op)
 }
 
 // class ContextManager : public Singleton<ContextManager>, OtherClass, SecondClass<wxString, wxArrayString> {
-vector<wxString> CxxExpression::split_subclass_expression(const wxString& subclass_pattern)
+std::vector<wxString> CxxExpression::split_subclass_expression(const wxString& subclass_pattern)
 {
     CxxLexerToken token;
     CxxTokenizer tokenizer;
@@ -431,7 +431,7 @@ vector<wxString> CxxExpression::split_subclass_expression(const wxString& subcla
     }
 
     // Check for possible
-    vector<wxString> result;
+    std::vector<wxString> result;
     wxString curexpr;
 
     int depth = 0;
@@ -482,4 +482,4 @@ vector<wxString> CxxExpression::split_subclass_expression(const wxString& subcla
     return result;
 }
 
-void CxxExpression::set_subscript_params(const vector<wxArrayString>& params) { m_subscript_params = params; }
+void CxxExpression::set_subscript_params(const std::vector<wxArrayString>& params) { m_subscript_params = params; }

--- a/CodeLite/CxxExpression.hpp
+++ b/CodeLite/CxxExpression.hpp
@@ -9,8 +9,6 @@
 #include <vector>
 #include <wx/string.h>
 
-using namespace std;
-
 /// A remainder is the part of an expression chain that was not processed.
 /// Consider the following simple expression:
 ///
@@ -33,11 +31,11 @@ private:
     wxString m_type_name;
     wxArrayString m_scopes; // potential scopes for the type
     int m_operand = 0;
-    wxString m_operand_string;                 // string representation for the operand
-    wxArrayString m_template_init_list;        // template init list vector<wxString> -> `wxString`
-    wxArrayString m_template_placeholder_list; // template placeholders (e.g. `T`)
-    vector<wxArrayString> m_subscript_params;  // subscript operator params
-    wxArrayString m_func_call_params;          // function params
+    wxString m_operand_string;                     // string representation for the operand
+    wxArrayString m_template_init_list;            // template init list vector<wxString> -> `wxString`
+    wxArrayString m_template_placeholder_list;     // template placeholders (e.g. `T`)
+    std::vector<wxArrayString> m_subscript_params; // subscript operator params
+    wxArrayString m_func_call_params;              // function params
     size_t m_flags = 0;
 
 public:
@@ -87,8 +85,8 @@ public:
 
     const wxString& operand_string() const;
     const wxArrayString& template_init_list() const { return m_template_init_list; }
-    const vector<wxArrayString>& subscript_params() const { return m_subscript_params; }
-    void set_subscript_params(const vector<wxArrayString>& params);
+    const std::vector<wxArrayString>& subscript_params() const { return m_subscript_params; }
+    void set_subscript_params(const std::vector<wxArrayString>& params);
     const wxArrayString& func_call_params() const { return m_func_call_params; }
     bool is_auto() const { return m_flags & FLAGS_AUTO; }
     bool is_this() const { return m_flags & FLAGS_THIS; }
@@ -97,8 +95,8 @@ public:
     /// `class ContextManager : public Singleton<ContextManager>, OtherClass, SecondClass<wxString, wxArrayString>`
     /// returns:
     /// {"Singleton<ContextManager>", "OtherClass", "SecondClass<wxString, wxArrayString>"}
-    static vector<wxString> split_subclass_expression(const wxString& subclass_pattern);
-    static vector<CxxExpression> from_expression(const wxString& expression, CxxRemainder* remainder);
+    static std::vector<wxString> split_subclass_expression(const wxString& subclass_pattern);
+    static std::vector<CxxExpression> from_expression(const wxString& expression, CxxRemainder* remainder);
 
     /**
      * should the code completion check for subscript operator overloading?

--- a/CodeLite/CxxLexerAPI.cpp
+++ b/CodeLite/CxxLexerAPI.cpp
@@ -4,17 +4,16 @@
 
 #include <unordered_set>
 
-using namespace std;
 namespace
 {
-unordered_set<int> set_number_tokens = {
+std::unordered_set<int> set_number_tokens = {
     T_DEC_NUMBER,
     T_OCTAL_NUMBER,
     T_HEX_NUMBER,
     T_FLOAT_NUMBER,
 };
 
-unordered_set<int> set_pp_tokens = {
+std::unordered_set<int> set_pp_tokens = {
     T_PP_DEFINE,       T_PP_DEFINED,
     T_PP_IF,           T_PP_IFNDEF,
     T_PP_IFDEF,        T_PP_ELSE,
@@ -31,17 +30,17 @@ unordered_set<int> set_pp_tokens = {
     T_PP_LTEQ,
 };
 
-unordered_set<int> set_operators_tokens = {
+std::unordered_set<int> set_operators_tokens = {
     T_DOT_STAR,   T_DOUBLE_COLONS, T_ARROW,     T_ARROW_STAR, T_PLUS_PLUS, T_MINUS_MINUS, T_LS,          T_LE,
     T_GE,         T_EQUAL,         T_NOT_EQUAL, T_AND_AND,    T_OR_OR,     T_STAR_EQUAL,  T_SLASH_EQUAL, T_DIV_EQUAL,
     T_PLUS_EQUAL, T_MINUS_EQUAL,   T_LS_ASSIGN, T_RS_ASSIGN,  T_AND_EQUAL, T_POW_EQUAL,   T_OR_EQUAL,    T_3_DOTS,
 };
 
-unordered_set<int> set_builtin_types = {
+std::unordered_set<int> set_builtin_types = {
     T_BOOL, T_CHAR,  T_CHAR16_T, T_CHAR32_T, T_DOUBLE, T_FLOAT,   T_INT,
     T_LONG, T_SHORT, T_SIGNED,   T_UNSIGNED, T_VOID,   T_WCHAR_T,
 };
-unordered_set<int> set_keywords_tokens = {
+std::unordered_set<int> set_keywords_tokens = {
     T_ALIGNAS,     T_ALIGNOF,      T_AND,          T_AND_EQ,
     T_ASM,         T_AUTO,         T_BITAND,       T_BITOR,
     T_BREAK,       T_CASE,         T_CATCH,

--- a/CodeLite/FontUtils.cpp
+++ b/CodeLite/FontUtils.cpp
@@ -1,8 +1,7 @@
 #include "FontUtils.hpp"
 
-#include <wxStringHash.h>
+#include "wxStringHash.h"
 
-using namespace std;
 namespace FontUtils
 {
 #ifdef __WXMSW__
@@ -17,10 +16,10 @@ constexpr int DEFAULT_FONT_SIZE = 14;
 #endif
 
 #ifdef __WXMSW__
-const unordered_set<wxString> words = { "SemiBold", "Semibold", "Extended", "Semi Bold", "Semi bold" };
+const std::unordered_set<wxString> words = { "SemiBold", "Semibold", "Extended", "Semi Bold", "Semi bold" };
 #endif
 
-unordered_map<wxString, wxString> fixed_fonts_cache;
+std::unordered_map<wxString, wxString> fixed_fonts_cache;
 
 const wxString& GetFontInfo(const wxFont& font) { return GetFontInfo(font.GetNativeFontInfoDesc()); }
 

--- a/CodeLite/LSP/GotoDefinitionRequest.cpp
+++ b/CodeLite/LSP/GotoDefinitionRequest.cpp
@@ -23,7 +23,7 @@ void LSP::GotoDefinitionRequest::OnResponse(const LSP::ResponseMessage& response
         return;
     }
 
-    vector<LSP::Location> locations;
+    std::vector<LSP::Location> locations;
     if(result.isArray()) {
         int count = result.arraySize();
         locations.reserve(count);
@@ -38,8 +38,9 @@ void LSP::GotoDefinitionRequest::OnResponse(const LSP::ResponseMessage& response
         locations.push_back(loc);
     }
 
-    if(locations.empty())
+    if(locations.empty()) {
         return;
+    }
 
     // Fire an event with the matching location
     LSPEvent definitionEvent(wxEVT_LSP_DEFINITION);

--- a/CodeLite/StringUtils.cpp
+++ b/CodeLite/StringUtils.cpp
@@ -2,8 +2,6 @@
 
 #include <vector>
 
-using namespace std;
-
 std::string StringUtils::ToStdString(const wxString& str)
 {
     const char* data = str.mb_str(wxConvUTF8).data();
@@ -114,7 +112,7 @@ void StringUtils::DisableMarkdownStyling(wxString& buffer)
 
 namespace
 {
-int get_current_state(const vector<int>& states)
+int get_current_state(const std::vector<int>& states)
 {
     if(states.empty()) {
         return ARGV_STATE_NORMAL;
@@ -122,7 +120,7 @@ int get_current_state(const vector<int>& states)
     return states[0];
 }
 
-int get_prev_state(const vector<int>& states)
+int get_prev_state(const std::vector<int>& states)
 {
     if(states.size() < 2) {
         return ARGV_STATE_NORMAL;
@@ -130,15 +128,15 @@ int get_prev_state(const vector<int>& states)
     return states[1];
 }
 
-void push_state(vector<int>& states, int state) { states.insert(states.begin(), state); }
-void pop_state(vector<int>& states) { states.erase(states.begin()); }
+void push_state(std::vector<int>& states, int state) { states.insert(states.begin(), state); }
+void pop_state(std::vector<int>& states) { states.erase(states.begin()); }
 } // namespace
 
 char** StringUtils::BuildArgv(const wxString& str, int& argc)
 {
     std::vector<wxString> A;
     int dollar_paren_depth = 0;
-    vector<int> states = { ARGV_STATE_NORMAL };
+    std::vector<int> states = { ARGV_STATE_NORMAL };
     wxString curstr;
     for(wxChar ch : str) {
         switch(get_current_state(states)) {

--- a/CodeLite/Trie.hpp
+++ b/CodeLite/Trie.hpp
@@ -5,7 +5,6 @@
 #include <vector>
 #include <wx/string.h>
 
-using namespace std;
 class TrieTree;
 typedef TrieTree TreeNode;
 class TrieTree

--- a/CodeLite/asyncprocess.h
+++ b/CodeLite/asyncprocess.h
@@ -28,6 +28,7 @@
 
 #include "codelite_exports.h"
 #include "macros.h"
+
 #include <functional>
 #include <map>
 #include <vector>
@@ -37,7 +38,6 @@
 #include <wx/utils.h>
 
 class ProcessReaderThread;
-using namespace std;
 typedef std::vector<std::pair<wxString, wxString>> clEnvList_t;
 enum IProcessCreateFlags {
     IProcessCreateDefault = (1 << 0),           // Default: create process with no console window
@@ -244,7 +244,7 @@ WXDLLIMPEXP_CL IProcess* CreateAsyncProcess(wxEvtHandler* parent, const wxArrayS
  * @brief a wrapper for the variant that accepts wxArrayString.
  * This is because wxArrayString does not allow initializer list
  */
-WXDLLIMPEXP_CL IProcess* CreateAsyncProcess(wxEvtHandler* parent, const vector<wxString>& args,
+WXDLLIMPEXP_CL IProcess* CreateAsyncProcess(wxEvtHandler* parent, const std::vector<wxString>& args,
                                             size_t flags = IProcessCreateDefault,
                                             const wxString& workingDir = wxEmptyString,
                                             const clEnvList_t* env = nullptr,
@@ -269,7 +269,7 @@ WXDLLIMPEXP_CL IProcess* CreateSyncProcess(const wxString& cmd, size_t flags = I
  * @param workingDir set the working directory of the executed process
  * @param env
  */
-WXDLLIMPEXP_CL void CreateAsyncProcessCB(const wxString& cmd, function<void(const wxString&)> cb,
+WXDLLIMPEXP_CL void CreateAsyncProcessCB(const wxString& cmd, std::function<void(const wxString&)> cb,
                                          size_t flags = IProcessCreateDefault,
                                          const wxString& workingDir = wxEmptyString, const clEnvList_t* env = nullptr);
 

--- a/CodeLite/clWildMatch.cpp
+++ b/CodeLite/clWildMatch.cpp
@@ -6,7 +6,7 @@
 
 namespace
 {
-void split_mask(const wxString& maskString, vector<_Mask>& includeMask, vector<_Mask>& excludeMask)
+void split_mask(const wxString& maskString, std::vector<_Mask>& includeMask, std::vector<_Mask>& excludeMask)
 {
     // wxString lcMask = maskString.Lower();
     wxArrayString masks = ::wxStringTokenize(maskString, ";,", wxTOKEN_STRTOK);
@@ -27,7 +27,7 @@ void split_mask(const wxString& maskString, vector<_Mask>& includeMask, vector<_
 clFileExtensionMatcher::clFileExtensionMatcher(const wxString& mask)
     : m_mask(mask)
 {
-    vector<_Mask> dummy;
+    std::vector<_Mask> dummy;
     wxArrayString masks = ::wxStringTokenize(m_mask, ";,", wxTOKEN_STRTOK);
     for(wxString& mask : masks) {
         mask.Replace("*", wxEmptyString);
@@ -57,7 +57,7 @@ bool clFileExtensionMatcher::matches(const wxString& filename) const
 clPathExcluder::clPathExcluder(const wxString& mask)
     : m_mask(mask)
 {
-    vector<_Mask> dummy;
+    std::vector<_Mask> dummy;
     split_mask(m_mask, m_exclude_mask, dummy);
 }
 

--- a/CodeLite/clWildMatch.hpp
+++ b/CodeLite/clWildMatch.hpp
@@ -18,11 +18,10 @@ struct _Mask {
     }
 };
 
-using namespace std;
 class WXDLLIMPEXP_CL clFileExtensionMatcher
 {
     wxString m_mask;
-    vector<_Mask> m_include_mask;
+    std::vector<_Mask> m_include_mask;
     bool m_always_matches = false;
 
 public:
@@ -35,7 +34,7 @@ public:
 class WXDLLIMPEXP_CL clPathExcluder
 {
     wxString m_mask;
-    vector<_Mask> m_exclude_mask;
+    std::vector<_Mask> m_exclude_mask;
 
 public:
     clPathExcluder(const wxString& mask);

--- a/CodeLite/entry.cpp
+++ b/CodeLite/entry.cpp
@@ -112,7 +112,7 @@ void TagEntry::Create(const wxString& fileName, const wxString& name, int lineNu
     wxString path;
 
     // Check if we can get full name (including path)
-    static vector<wxString> scope_fields = { "class", "struct", "namespace", "interface", "enum", "function" };
+    static std::vector<wxString> scope_fields = { "class", "struct", "namespace", "interface", "enum", "function" };
     for(const wxString& scope_field : scope_fields) {
         path = GetExtField(scope_field);
         if(!path.IsEmpty()) {
@@ -147,8 +147,9 @@ void TagEntry::Create(const wxString& fileName, const wxString& name, int lineNu
     }
 
     // If there is no path, path is set to name
-    if(GetPath().IsEmpty())
+    if(GetPath().IsEmpty()) {
         SetPath(GetName());
+    }
 
     // Get the parent name
     StringTokenizer tok(GetPath(), "::");
@@ -179,8 +180,9 @@ void TagEntry::Print()
 
     std::cout << " ---- Ext fields: ---- " << std::endl;
     wxStringMap_t::const_iterator iter = m_extFields.begin();
-    for(; iter != m_extFields.end(); iter++)
+    for(; iter != m_extFields.end(); iter++) {
         std::cout << iter->first << ":\t\t" << iter->second << std::endl;
+    }
     std::cout << "======================================" << std::endl;
 }
 
@@ -364,17 +366,17 @@ void TagEntry::FromLine(const wxString& line)
 
 bool TagEntry::IsConstructor() const
 {
-    if(GetKind() != "function" && GetKind() != "prototype")
+    if(GetKind() != "function" && GetKind() != "prototype") {
         return false;
-
+    }
     return GetName() == GetScope();
 }
 
 bool TagEntry::IsDestructor() const
 {
-    if(GetKind() != "function" && GetKind() != "prototype")
+    if(GetKind() != "function" && GetKind() != "prototype") {
         return false;
-
+    }
     return GetName().StartsWith("~");
 }
 

--- a/CodeLite/ssh_account_info.cpp
+++ b/CodeLite/ssh_account_info.cpp
@@ -24,6 +24,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 #include "ssh_account_info.h"
+
 #include "xor_string.h"
 
 SSHAccountInfo::SSHAccountInfo()
@@ -36,9 +37,9 @@ SSHAccountInfo::~SSHAccountInfo() {}
 
 SSHAccountInfo& SSHAccountInfo::operator=(const SSHAccountInfo& other)
 {
-    if(&other == this)
+    if(&other == this) {
         return *this;
-
+    }
     m_accountName = other.m_accountName;
     m_username = other.m_username;
     m_password = other.m_password;
@@ -83,7 +84,7 @@ void SSHAccountInfo::AddBookmark(const wxString& location)
     }
 }
 
-SSHAccountInfo::Vect_t SSHAccountInfo::Load(const function<bool(const SSHAccountInfo&)>& matcher)
+SSHAccountInfo::Vect_t SSHAccountInfo::Load(const std::function<bool(const SSHAccountInfo&)>& matcher)
 {
     wxFileName jsonfile(clStandardPaths::Get().GetUserDataDir(), "sftp-settings.conf");
     jsonfile.AppendDir("config");

--- a/CodeLite/ssh_account_info.h
+++ b/CodeLite/ssh_account_info.h
@@ -28,10 +28,10 @@
 
 #include "cl_config.h" // Base class: clConfigItem
 #include "codelite_exports.h"
+
 #include <functional>
 #include <vector>
 
-using namespace std;
 class WXDLLIMPEXP_CL SSHAccountInfo : public clConfigItem
 {
     wxString m_accountName;
@@ -72,7 +72,7 @@ public:
      * @brief read list of accounts from the JSON file
      * @param matcher a callback that allows the user to filter matches
      */
-    static SSHAccountInfo::Vect_t Load(const function<bool(const SSHAccountInfo&)>& matcher = nullptr);
+    static SSHAccountInfo::Vect_t Load(const std::function<bool(const SSHAccountInfo&)>& matcher = nullptr);
     /**
      * @brief load a specific account from configuration
      */

--- a/CodeLite/tags_options_data.cpp
+++ b/CodeLite/tags_options_data.cpp
@@ -38,8 +38,6 @@ wxString TagsOptionsData::CLANG_CACHE_ON_FILE_LOAD = "On File Load";
 
 size_t TagsOptionsData::CURRENT_VERSION = 7100;
 
-using namespace std;
-
 static bool _IsValidCppIndetifier(const wxString& id)
 {
     if(id.IsEmpty()) {
@@ -633,8 +631,9 @@ JSONItem TagsOptionsData::ToJSON() const
 wxString TagsOptionsData::DoJoinArray(const wxArrayString& arr) const
 {
     wxString s;
-    for(size_t i = 0; i < arr.GetCount(); ++i)
+    for(size_t i = 0; i < arr.GetCount(); ++i) {
         s << arr.Item(i) << "\n";
+    }
 
     if(s.IsEmpty() == false) {
         s.RemoveLast();

--- a/FileGrep/FileGrep/main.cpp
+++ b/FileGrep/FileGrep/main.cpp
@@ -1,72 +1,75 @@
+#include <algorithm>
+#include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <string.h>
-#include <iostream>
-#include <algorithm>
-
-using namespace std;
+#include <sys/stat.h>
+#include <sys/types.h>
 
 // templated version of my_equal so it could work with both char and wchar_t
-template<typename charT>
-struct my_equal {
-    my_equal( const std::locale& loc ) : loc_(loc) {}
-    bool operator()(charT ch1, charT ch2) {
-        return std::toupper(ch1, loc_) == std::toupper(ch2, loc_);
+template <typename charT> struct my_equal {
+    my_equal(const std::locale& loc)
+        : loc_(loc)
+    {
     }
+    bool operator()(charT ch1, charT ch2) { return std::toupper(ch1, loc_) == std::toupper(ch2, loc_); }
+
 private:
     const std::locale& loc_;
 };
 
 // find substring (case insensitive)
-int ci_find_substr( const std::string& str1, const std::string& str2, const std::locale& loc = std::locale() )
+int ci_find_substr(const std::string& str1, const std::string& str2, const std::locale& loc = std::locale())
 {
-    std::string::const_iterator it = std::search( str1.begin(), str1.end(), str2.begin(), str2.end(), my_equal<std::string::value_type>(loc) );
-    if ( it != str1.end() ) return it - str1.begin();
-    else return -1; // not found
+    std::string::const_iterator it =
+        std::search(str1.begin(), str1.end(), str2.begin(), str2.end(), my_equal<std::string::value_type>(loc));
+    if(it != str1.end()) {
+        return it - str1.begin();
+    } else {
+        return -1; // not found
+    }
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-	FILE* fp  = NULL;
-	FILE* ofp = NULL;
-	
-	if(argc < 2) {
-		printf("usage: %s <filename> <filter>\n", argv[0]);
-		return 1;
-	}
-	
-	if(argc <3) {
-		// no filter?
-		// do nothing
-		return 0;
-	}
-	
-	fp = fopen(argv[1], "r");
-	if(!fp) {
-		return 2;
-	}
-	
-	char out_file_name[1024];
-	sprintf(out_file_name, "%s.tmp_result", argv[1]);
-	ofp = fopen(out_file_name, "w");
-	
-	char line[2048];
-	memset(line, 0, sizeof(line));
-	while( fgets(line, sizeof(line), fp) ) {
-		if(ci_find_substr(line, argv[2]) != -1) {
-			// we got a match
-			fwrite(line, sizeof(char), strlen(line), ofp);
-		}
-		memset(line, 0, sizeof(line));
-	}
-	
-	// read the file content and close the file
-	fclose(fp);
-	fclose(ofp);
-	
-	remove(argv[1]);
-	rename(out_file_name, argv[1]);
-	return 0;
+    FILE* fp = NULL;
+    FILE* ofp = NULL;
+
+    if(argc < 2) {
+        printf("usage: %s <filename> <filter>\n", argv[0]);
+        return 1;
+    }
+
+    if(argc < 3) {
+        // no filter?
+        // do nothing
+        return 0;
+    }
+
+    fp = fopen(argv[1], "r");
+    if(!fp) {
+        return 2;
+    }
+
+    char out_file_name[1024];
+    sprintf(out_file_name, "%s.tmp_result", argv[1]);
+    ofp = fopen(out_file_name, "w");
+
+    char line[2048];
+    memset(line, 0, sizeof(line));
+    while(fgets(line, sizeof(line), fp)) {
+        if(ci_find_substr(line, argv[2]) != -1) {
+            // we got a match
+            fwrite(line, sizeof(char), strlen(line), ofp);
+        }
+        memset(line, 0, sizeof(line));
+    }
+
+    // read the file content and close the file
+    fclose(fp);
+    fclose(ofp);
+
+    remove(argv[1]);
+    rename(out_file_name, argv[1]);
+    return 0;
 }

--- a/Gizmos/gizmos.cpp
+++ b/Gizmos/gizmos.cpp
@@ -41,17 +41,17 @@
 #include "newplugindata.h"
 #include "newwxprojectdlg.h"
 #include "workspace.h"
-#include "wx/ffile.h"
 
 #include <algorithm>
 #include <wx/app.h>
+#include <wx/ffile.h>
 #include <wx/log.h>
 #include <wx/menu.h>
 #include <wx/msgdlg.h>
 #include <wx/xrc/xmlres.h>
 
-static wxString MI_NEW_CODELITE_PLUGIN = wxT("Create new CodeLite plugin...");
-static wxString MI_NEW_NEW_CLASS = wxT("Create new C++ class...");
+static wxString MI_NEW_CODELITE_PLUGIN = "Create new CodeLite plugin...";
+static wxString MI_NEW_NEW_CLASS = "Create new C++ class...";
 
 enum { ID_MI_NEW_WX_PROJECT = 9000, ID_MI_NEW_CODELITE_PLUGIN, ID_MI_NEW_NEW_CLASS };
 
@@ -69,11 +69,11 @@ CL_PLUGIN_API IPlugin* CreatePlugin(IManager* manager)
 CL_PLUGIN_API PluginInfo* GetPluginInfo()
 {
     static PluginInfo info;
-    info.SetAuthor(wxT("Eran Ifrah"));
-    info.SetName(wxT("Wizards"));
+    info.SetAuthor("Eran Ifrah");
+    info.SetName("Wizards");
     info.SetDescription(_("Wizards Plugin - a collection of useful wizards for C++:\nnew Class Wizard, new wxWidgets "
                           "Wizard, new Plugin Wizard"));
-    info.SetVersion(wxT("v1.1"));
+    info.SetVersion("v1.1");
     return &info;
 }
 
@@ -92,37 +92,40 @@ struct ascendingSortOp {
 //-------------------------------------
 static void ExpandVariables(wxString& content, const NewWxProjectInfo& info)
 {
-    content.Replace(wxT("$(ProjectName)"), info.GetName());
+    content.Replace("$(ProjectName)", info.GetName());
     wxString projname = info.GetName();
     projname.MakeLower();
 
-    wxString appfilename = projname + wxT("_app");
-    wxString framefilename = projname + wxT("_frame");
+    wxString appfilename = projname + "_app";
+    wxString framefilename = projname + "_frame";
 
-    content.Replace(wxT("$(MainFile)"), projname);
-    content.Replace(wxT("$(AppFile)"), appfilename);
-    content.Replace(wxT("$(MainFrameFile)"), framefilename);
-    content.Replace(wxT("$(Unicode)"), info.GetFlags() & wxWidgetsUnicode ? wxT("yes") : wxT("no"));
-    content.Replace(wxT("$(Static)"), info.GetFlags() & wxWidgetsStatic ? wxT("yes") : wxT("no"));
-    content.Replace(wxT("$(Universal)"), info.GetFlags() & wxWidgetsUniversal ? wxT("yes") : wxT("no"));
-    content.Replace(wxT("$(WinResFlag)"), info.GetFlags() & wxWidgetsWinRes ? wxT("yes") : wxT("no"));
-    content.Replace(wxT("$(MWindowsFlag)"), info.GetFlags() & wxWidgetsSetMWindows ? wxT("-mwindows") : wxEmptyString);
-    content.Replace(wxT("$(PCHFlag)"), info.GetFlags() & wxWidgetsPCH ? wxT("WX_PRECOMP") : wxEmptyString);
-    content.Replace(wxT("$(PCHCmpOptions)"),
-                    info.GetFlags() & wxWidgetsPCH ? wxT("-Winvalid-pch;-include wx_pch.h") : wxEmptyString);
-    content.Replace(wxT("$(PCHFileName)"), info.GetFlags() & wxWidgetsPCH ? wxT("wx_pch.h") : wxEmptyString);
+    content.Replace("$(MainFile)", projname);
+    content.Replace("$(AppFile)", appfilename);
+    content.Replace("$(MainFrameFile)", framefilename);
+    content.Replace("$(Unicode)", info.GetFlags() & wxWidgetsUnicode ? "yes" : "no");
+    content.Replace("$(Static)", info.GetFlags() & wxWidgetsStatic ? "yes" : "no");
+    content.Replace("$(Universal)", info.GetFlags() & wxWidgetsUniversal ? "yes" : "no");
+    content.Replace("$(WinResFlag)", info.GetFlags() & wxWidgetsWinRes ? "yes" : "no");
+    content.Replace("$(MWindowsFlag)", info.GetFlags() & wxWidgetsSetMWindows ? "-mwindows" : "");
+    content.Replace("$(PCHFlag)", info.GetFlags() & wxWidgetsPCH ? "WX_PRECOMP" : "");
+    content.Replace("$(PCHCmpOptions)", info.GetFlags() & wxWidgetsPCH ? "-Winvalid-pch;-include wx_pch.h" : "");
+    content.Replace("$(PCHFileName)", info.GetFlags() & wxWidgetsPCH ? "wx_pch.h" : "");
 
-    if(info.GetFlags() & wxWidgetsWinRes)
-        content.Replace(wxT("$(WinResFile)"), wxT("<File Name=\"resources.rc\" />"));
-    if(info.GetFlags() & wxWidgetsPCH)
-        content.Replace(wxT("$(PCHFile)"), wxT("<File Name=\"wx_pch.h\" />"));
+    if(info.GetFlags() & wxWidgetsWinRes) {
+        content.Replace("$(WinResFile)", "<File Name=\"resources.rc\" />");
+    }
+    if(info.GetFlags() & wxWidgetsPCH) {
+        content.Replace("$(PCHFile)", "<File Name=\"wx_pch.h\" />");
+    }
 
     wxString othersettings;
-    if(info.GetVersion() != wxT("Default"))
-        othersettings << wxT("--version=") << info.GetVersion();
-    if(!info.GetPrefix().IsEmpty())
-        othersettings << wxT(" --prefix=") << info.GetPrefix();
-    content.Replace(wxT("$(Other)"), othersettings);
+    if(info.GetVersion() != "Default") {
+        othersettings << "--version=" << info.GetVersion();
+    }
+    if(!info.GetPrefix().IsEmpty()) {
+        othersettings << " --prefix=" << info.GetPrefix();
+    }
+    content.Replace("$(Other)", othersettings);
 
     // create the application class name
     wxString initial = appfilename.Mid(0, 1);
@@ -133,8 +136,8 @@ static void ExpandVariables(wxString& content, const NewWxProjectInfo& info)
     wxString framename(projname);
     wxString appname(projname);
 
-    framename << wxT("Frame");
-    appname << wxT("App");
+    framename << "Frame";
+    appname << "App";
 
     initial = framename.Mid(0, 1);
     initial.MakeUpper();
@@ -144,14 +147,14 @@ static void ExpandVariables(wxString& content, const NewWxProjectInfo& info)
     initial.MakeUpper();
     appname.SetChar(0, initial.GetChar(0));
 
-    content.Replace(wxT("$(AppName)"), appname);
-    content.Replace(wxT("$(MainFrameName)"), framename);
+    content.Replace("$(AppName)", appname);
+    content.Replace("$(MainFrameName)", framename);
 }
 
 static void WriteFile(const wxString& fileName, const wxString& content)
 {
     wxFFile file;
-    if(!file.Open(fileName, wxT("w+b"))) {
+    if(!file.Open(fileName, "w+b")) {
         return;
     }
 
@@ -162,7 +165,7 @@ static void WriteFile(const wxString& fileName, const wxString& content)
 static void WriteNamespacesDeclaration(const wxArrayString& namespacesList, wxString& buffer)
 {
     for(unsigned int i = 0; i < namespacesList.Count(); i++) {
-        buffer << wxT("namespace ") << namespacesList[i] << wxT("\n{\n\n");
+        buffer << "namespace " << namespacesList[i] << "\n{\n\n";
     }
 }
 
@@ -170,7 +173,7 @@ WizardsPlugin::WizardsPlugin(IManager* manager)
     : IPlugin(manager)
 {
     m_longName = _("Wizards Plugin - a collection of useful utils for C++");
-    m_shortName = wxT("Wizards");
+    m_shortName = "Wizards";
 }
 
 WizardsPlugin::~WizardsPlugin() {}
@@ -247,7 +250,7 @@ void WizardsPlugin::DoCreateNewPlugin()
     if(wiz.Run(data)) {
         // load the template file and replace all variables with the
         // actual values provided by user
-        wxString filename(m_mgr->GetStartupDirectory() + wxT("/templates/gizmos/liteeditor-plugin.project.wizard"));
+        wxString filename(m_mgr->GetStartupDirectory() + "/templates/gizmos/liteeditor-plugin.project.wizard");
         wxString content;
         if(!ReadFileWithConversion(filename, content)) {
             return;
@@ -256,13 +259,13 @@ void WizardsPlugin::DoCreateNewPlugin()
         // Convert the paths provided by user to relative paths
         wxFileName fn(data.GetCodelitePath(), "");
         if(!fn.MakeRelativeTo(wxFileName(data.GetProjectPath()).GetPath())) {
-            clLogMessage(wxT("Warning: Failed to convert paths to relative path."));
+            clLogMessage("Warning: Failed to convert paths to relative path.");
         }
 
 #ifdef __WXMSW__
-        wxString dllExt(wxT("dll"));
+        wxString dllExt("dll");
 #else
-        wxString dllExt(wxT("so"));
+        wxString dllExt("so");
 #endif
 
         wxString clpath = fn.GetFullPath();
@@ -272,13 +275,13 @@ void WizardsPlugin::DoCreateNewPlugin()
             clpath.RemoveLast();
         }
 
-        content.Replace(wxT("$(CodeLitePath)"), clpath);
-        content.Replace(wxT("$(DllExt)"), dllExt);
-        content.Replace(wxT("$(PluginName)"), data.GetPluginName());
+        content.Replace("$(CodeLitePath)", clpath);
+        content.Replace("$(DllExt)", dllExt);
+        content.Replace("$(PluginName)", data.GetPluginName());
         wxString baseFileName = data.GetPluginName();
         baseFileName.MakeLower();
-        content.Replace(wxT("$(BaseFileName)"), baseFileName);
-        content.Replace(wxT("$(ProjectName)"), data.GetPluginName());
+        content.Replace("$(BaseFileName)", baseFileName);
+        content.Replace("$(ProjectName)", data.GetPluginName());
 
         // save the file to the disk
         wxString projectFileName;
@@ -288,7 +291,7 @@ void WizardsPlugin::DoCreateNewPlugin()
             ::wxMkdir(wxFileName(data.GetProjectPath()).GetPath());
         }
         wxFFile file;
-        if(!file.Open(projectFileName, wxT("w+b"))) {
+        if(!file.Open(projectFileName, "w+b")) {
             return;
         }
 
@@ -307,7 +310,7 @@ void WizardsPlugin::DoCreateNewPlugin()
         //---------------------------------------------------------------
 
         // Generate the source files
-        filename = m_mgr->GetStartupDirectory() + wxT("/templates/gizmos/plugin.cpp.wizard");
+        filename = m_mgr->GetStartupDirectory() + "/templates/gizmos/plugin.cpp.wizard";
         content.Clear();
         if(!ReadFileWithConversion(filename, content)) {
             wxMessageBox(_("Failed to load wizard's file 'plugin.cpp.wizard'"), _("CodeLite"), wxICON_WARNING | wxOK);
@@ -315,11 +318,11 @@ void WizardsPlugin::DoCreateNewPlugin()
         }
 
         // Expand macros
-        content.Replace(wxT("$(PluginName)"), data.GetPluginName());
-        content.Replace(wxT("$(BaseFileName)"), baseFileName);
-        content.Replace(wxT("$(PluginShortName)"), data.GetPluginName());
-        content.Replace(wxT("$(PluginLongName)"), data.GetPluginDescription());
-        content.Replace(wxT("$(UserName)"), wxGetUserName().c_str());
+        content.Replace("$(PluginName)", data.GetPluginName());
+        content.Replace("$(BaseFileName)", baseFileName);
+        content.Replace("$(PluginShortName)", data.GetPluginName());
+        content.Replace("$(PluginLongName)", data.GetPluginDescription());
+        content.Replace("$(UserName)", wxGetUserName().c_str());
 
         // Notify the formatter plugin to format the plugin source files
         clSourceFormatEvent evtFormat(wxEVT_FORMAT_STRING);
@@ -329,12 +332,12 @@ void WizardsPlugin::DoCreateNewPlugin()
         content = evtFormat.GetFormattedString();
 
         // Write it down
-        file.Open(srcFile.GetFullPath(), wxT("w+b"));
+        file.Open(srcFile.GetFullPath(), "w+b");
         file.Write(content);
         file.Close();
 
         // create the header file
-        filename = m_mgr->GetStartupDirectory() + wxT("/templates/gizmos/plugin.h.wizard");
+        filename = m_mgr->GetStartupDirectory() + "/templates/gizmos/plugin.h.wizard";
         content.Clear();
         if(!ReadFileWithConversion(filename, content)) {
             wxMessageBox(_("Failed to load wizard's file 'plugin.h.wizard'"), _("CodeLite"), wxICON_WARNING | wxOK);
@@ -342,11 +345,11 @@ void WizardsPlugin::DoCreateNewPlugin()
         }
 
         // Expand macros
-        content.Replace(wxT("$(PluginName)"), data.GetPluginName());
-        content.Replace(wxT("$(BaseFileName)"), baseFileName);
-        content.Replace(wxT("$(PluginShortName)"), data.GetPluginName());
-        content.Replace(wxT("$(PluginLongName)"), data.GetPluginDescription());
-        content.Replace(wxT("$(UserName)"), wxGetUserName().c_str());
+        content.Replace("$(PluginName)", data.GetPluginName());
+        content.Replace("$(BaseFileName)", baseFileName);
+        content.Replace("$(PluginShortName)", data.GetPluginName());
+        content.Replace("$(PluginLongName)", data.GetPluginDescription());
+        content.Replace("$(UserName)", wxGetUserName().c_str());
 
         // format the content
         evtFormat.SetString(content);
@@ -354,7 +357,7 @@ void WizardsPlugin::DoCreateNewPlugin()
         content = evtFormat.GetString();
 
         // Write it down
-        file.Open(headerFile.GetFullPath(), wxT("w+b"));
+        file.Open(headerFile.GetFullPath(), "w+b");
         file.Write(content);
         file.Close();
 
@@ -418,15 +421,15 @@ void WizardsPlugin::CreateClass(NewClassInfo& info)
     // Use the preference for the target VirtualDir, not the active project, in case the user perversely adds to an
     // inactive one.
     OptionsConfigPtr options = EditorConfigST::Get()->GetOptions(); // Globals first
-    wxString TargetProj = info.virtualDirectory.BeforeFirst(wxT(':'));
+    wxString TargetProj = info.virtualDirectory.BeforeFirst(':');
     if(!TargetProj.empty()) {
         clCxxWorkspaceST::Get()->GetLocalWorkspace()->GetOptions(options,
                                                                  TargetProj); // Then override with any local ones
     }
 
-    wxString separator(wxT("\t"));
+    wxString separator("\t");
     if(!options->GetIndentUsesTabs()) {
-        separator = wxString(wxT(' '), wxMax(1, options->GetTabWidth()));
+        separator = wxString(' ', wxMax(1, options->GetTabWidth()));
     }
 
     wxString blockGuard(info.blockGuard);
@@ -434,13 +437,13 @@ void WizardsPlugin::CreateClass(NewClassInfo& info)
         // use the name instead
         blockGuard = info.name;
         blockGuard.MakeUpper();
-        blockGuard << (info.hppHeader ? wxT("_HPP") : wxT("_H"));
+        blockGuard << (info.hppHeader ? "_HPP" : "_H");
     }
 
-    wxString headerExt = (info.hppHeader ? wxT(".hpp") : wxT(".h"));
+    wxString headerExt = (info.hppHeader ? ".hpp" : ".h");
 
     wxString srcFile;
-    srcFile << info.path << wxFileName::GetPathSeparator() << info.fileName << wxT(".cpp");
+    srcFile << info.path << wxFileName::GetPathSeparator() << info.fileName << ".cpp";
 
     wxString hdrFile;
     hdrFile << info.path << wxFileName::GetPathSeparator() << info.fileName << headerExt;
@@ -455,16 +458,17 @@ void WizardsPlugin::CreateClass(NewClassInfo& info)
     if(info.usePragmaOnce) {
         header << "#pragma once\n\n";
     } else {
-        header << wxT("#ifndef ") << blockGuard << wxT("\n");
-        header << wxT("#define ") << blockGuard << wxT("\n");
-        header << wxT("\n");
+        header << "#ifndef " << blockGuard << "\n";
+        header << "#define " << blockGuard << "\n";
+        header << "\n";
     }
 
     wxString closeMethod;
-    if(info.isInline)
-        closeMethod << wxT('\n') << separator << wxT("{\n") << separator << wxT("}\n");
-    else
-        closeMethod = wxT(";\n");
+    if(info.isInline) {
+        closeMethod << '\n' << separator << "{\n" << separator << "}\n";
+    } else {
+        closeMethod = ";\n";
+    }
 
     // Add include for base classes
     if(!info.parents.name.empty()) {
@@ -473,10 +477,9 @@ void WizardsPlugin::CreateClass(NewClassInfo& info)
         // Include the header name only (no paths)
         wxFileName includeFileName(pi.fileName);
         if(!pi.fileName.IsEmpty()) {
-            header << wxT("#include \"") << includeFileName.GetFullName() << wxT("\" // Base class: ") << pi.name
-                   << wxT("\n");
+            header << "#include \"" << includeFileName.GetFullName() << "\" // Base class: " << pi.name << "\n";
         }
-        header << wxT("\n");
+        header << "\n";
     }
 
     // Open namespace
@@ -484,69 +487,69 @@ void WizardsPlugin::CreateClass(NewClassInfo& info)
         WriteNamespacesDeclaration(info.namespacesList, header);
     }
 
-    header << wxT("class ") << info.name;
+    header << "class " << info.name;
     if(!info.isInheritable) {
-        header << wxT(" final");
+        header << " final";
     }
 
     if(!info.parents.name.empty()) {
-        header << wxT(" : ");
+        header << " : ";
         const ClassParentInfo& pi = info.parents;
-        header << pi.access << wxT(" ") << pi.name;
+        header << pi.access << " " << pi.name;
     }
-    header << wxT("\n{\n");
+    header << "\n{\n";
     if(info.isSingleton) {
-        header << separator << wxT("static ") << info.name << wxT("* ms_instance;\n\n");
+        header << separator << "static " << info.name << "* ms_instance;\n\n";
     }
 
     if(!info.isAssignable || !info.isMovable) {
-        header << wxT("private:\n");
+        header << "private:\n";
         if(!info.isAssignable) {
             // prohibit use of copy constructor & assignment operator
-            header << separator << info.name << wxT("(const ") << info.name << wxT("&) = delete;\n");
-            header << separator << info.name << wxT("& operator=(const ") << info.name << wxT("&) = delete;\n");
+            header << separator << info.name << "(const " << info.name << "&) = delete;\n";
+            header << separator << info.name << "& operator=(const " << info.name << "&) = delete;\n";
         }
         if(!info.isMovable) {
             // prohibit use of move constructor & move assignment operator
-            header << separator << info.name << wxT("(") << info.name << wxT("&&) = delete;\n");
-            header << separator << info.name << wxT("& operator=(") << info.name << wxT("&&) = delete;\n");
+            header << separator << info.name << "(" << info.name << "&&) = delete;\n";
+            header << separator << info.name << "& operator=(" << info.name << "&&) = delete;\n";
         }
-        header << wxT("\n");
+        header << "\n";
     }
 
     if(info.isSingleton) {
-        header << wxT("public:\n");
-        header << separator << wxT("static ") << info.name << wxT("* Instance();\n");
-        header << separator << wxT("static void Release();\n\n");
+        header << "public:\n";
+        header << separator << "static " << info.name << "* Instance();\n";
+        header << separator << "static void Release();\n\n";
 
-        header << wxT("private:\n");
-        header << separator << info.name << wxT("();\n");
+        header << "private:\n";
+        header << separator << info.name << "();\n";
 
         if(info.isVirtualDtor) {
-            header << separator << wxT("virtual ~") << info.name << wxT("();\n\n");
+            header << separator << "virtual ~" << info.name << "();\n\n";
         } else {
-            header << separator << wxT('~') << info.name << wxT("();\n\n");
+            header << separator << '~' << info.name << "();\n\n";
         }
     } else {
-        header << wxT("public:\n");
-        header << separator << info.name << wxT("()") << closeMethod;
+        header << "public:\n";
+        header << separator << info.name << "()" << closeMethod;
         if(info.isVirtualDtor) {
-            header << separator << wxT("virtual ~") << info.name << wxT("()") << closeMethod << wxT("\n");
+            header << separator << "virtual ~" << info.name << "()" << closeMethod << "\n";
         } else {
-            header << separator << wxT('~') << info.name << wxT("()") << closeMethod << wxT("\n");
+            header << separator << '~' << info.name << "()" << closeMethod << "\n";
         }
     }
 
-    header << wxT("};\n\n");
+    header << "};\n\n";
 
     // Close namespaces
     for(unsigned int i = 0; i < info.namespacesList.Count(); i++) {
-        header << wxT("}\n\n");
+        header << "}\n\n";
     }
 
     if(!info.usePragmaOnce) {
         // Close the block guard
-        header << wxT("#endif // ") << blockGuard << wxT("\n");
+        header << "#endif // " << blockGuard << "\n";
     }
 
     FileUtils::WriteFileContent(hdrFile, header);
@@ -566,37 +569,36 @@ void WizardsPlugin::CreateClass(NewClassInfo& info)
             }
         }
 
-        cpp << wxT("#include \"") << info.fileName << headerExt << wxT("\"\n");
+        cpp << "#include \"" << info.fileName << headerExt << "\"\n";
 
         if(info.isSingleton) {
-            cpp << wxT("\n") << nsPrefix << info.name << wxT("* ") << nsPrefix << info.name
-                << wxT("::ms_instance{ nullptr };\n\n");
+            cpp << "\n" << nsPrefix << info.name << "* " << nsPrefix << info.name << "::ms_instance{ nullptr };\n\n";
         } else {
             cpp << "\n";
         }
 
         // ctor/dtor
-        cpp << nsPrefix << info.name << wxT("::") << info.name << wxT("()\n");
-        cpp << wxT("{\n}\n\n");
-        cpp << nsPrefix << info.name << wxT("::~") << info.name << wxT("()\n");
-        cpp << wxT("{\n}\n\n");
+        cpp << nsPrefix << info.name << "::" << info.name << "()\n";
+        cpp << "{\n}\n\n";
+        cpp << nsPrefix << info.name << "::~" << info.name << "()\n";
+        cpp << "{\n}\n\n";
 
         // Prepend the ns to the class name (we do this after the ctor/dtor impl)
         info.name.Prepend(nsPrefix);
 
         if(info.isSingleton) {
-            cpp << info.name << wxT("* ") << info.name << wxT("::Instance()\n");
-            cpp << wxT("{\n");
-            cpp << separator << wxT("if (ms_instance == nullptr) {\n");
-            cpp << separator << separator << wxT("ms_instance = new ") << info.name << wxT("{};\n");
-            cpp << separator << wxT("}\n");
-            cpp << separator << wxT("return ms_instance;\n");
-            cpp << wxT("}\n\n");
-            cpp << wxT("void ") << info.name << wxT("::Release()\n");
-            cpp << wxT("{\n");
-            cpp << separator << wxT("delete ms_instance;\n");
-            cpp << separator << wxT("ms_instance = nullptr;\n");
-            cpp << wxT("}\n\n");
+            cpp << info.name << "* " << info.name << "::Instance()\n";
+            cpp << "{\n";
+            cpp << separator << "if (ms_instance == nullptr) {\n";
+            cpp << separator << separator << "ms_instance = new " << info.name << "{};\n";
+            cpp << separator << "}\n";
+            cpp << separator << "return ms_instance;\n";
+            cpp << "}\n\n";
+            cpp << "void " << info.name << "::Release()\n";
+            cpp << "{\n";
+            cpp << separator << "delete ms_instance;\n";
+            cpp << separator << "ms_instance = nullptr;\n";
+            cpp << "}\n\n";
         }
 
         FileUtils::WriteFileContent(srcFile, cpp);
@@ -606,8 +608,9 @@ void WizardsPlugin::CreateClass(NewClassInfo& info)
     if(clCxxWorkspaceST::Get()->IsOpen()) {
         // We have a .cpp and an .h file, and there may well be a :src and an :include folder available
         // So try to place the files appropriately. If that fails, dump both in the selected folder
-        if(!m_mgr->AddFilesToVirtualFolderIntelligently(info.virtualDirectory, paths))
+        if(!m_mgr->AddFilesToVirtualFolderIntelligently(info.virtualDirectory, paths)) {
             m_mgr->AddFilesToVirtualFolder(info.virtualDirectory, paths);
+        }
     }
 
     // Open the newly created classes in codelite
@@ -645,7 +648,7 @@ void WizardsPlugin::GizmosRemoveDuplicates(std::vector<TagEntryPtr>& src, std::v
 
         wxString signature = src.at(i)->GetSignature();
         wxString key = m_mgr->GetTagsManager()->NormalizeFunctionSig(signature, 0);
-        int hasDefaultValues = signature.Find(wxT("="));
+        int hasDefaultValues = signature.Find("=");
 
         key.Prepend(src.at(i)->GetName());
         if(uniqueSet.find(key) != uniqueSet.end()) {
@@ -717,7 +720,7 @@ void WizardsPlugin::OnFolderContentMenu(clContextMenuEvent& event)
     }
 }
 
-bool WizardsPlugin::BulkRead(vector<pair<wxString, wxString*>>& files, const wxString& path_prefix) const
+bool WizardsPlugin::BulkRead(std::vector<std::pair<wxString, wxString*>>& files, const wxString& path_prefix) const
 {
     for(size_t i = 0; i < files.size(); ++i) {
         if(!FileUtils::ReadFileContent(path_prefix + files[i].first, *files[i].second)) {
@@ -727,7 +730,8 @@ bool WizardsPlugin::BulkRead(vector<pair<wxString, wxString*>>& files, const wxS
     return true;
 }
 
-bool WizardsPlugin::BulkWrite(const vector<pair<wxString, wxString>>& files, const wxString& path_prefix) const
+bool WizardsPlugin::BulkWrite(const std::vector<std::pair<wxString, wxString>>& files,
+                              const wxString& path_prefix) const
 {
 
     for(size_t i = 0; i < files.size(); ++i) {

--- a/Gizmos/gizmos.h
+++ b/Gizmos/gizmos.h
@@ -28,9 +28,9 @@
 #include "newclassdlg.h"
 #include "newwxprojectinfo.h"
 #include "plugin.h"
+
 #include <vector>
 
-using namespace std;
 class WizardsPlugin : public IPlugin
 {
     void CreateClass(NewClassInfo& info);
@@ -48,14 +48,16 @@ protected:
      * @param path_prefix prepend this prefix to each file before reading it
      * @return false if we failed to read one or more files. In addition, both vectors size must me the same
      */
-    bool BulkRead(vector<pair<wxString, wxString*>>& files, const wxString& path_prefix = wxEmptyString) const;
+    bool BulkRead(std::vector<std::pair<wxString, wxString*>>& files,
+                  const wxString& path_prefix = wxEmptyString) const;
     /**
      * @brief read the contet of multiple files to the file system
      * @param files vector of pairs {`file-name` -> `file-content`}
      * @param path_prefix prepend this prefix to each file before reading it
      * @return false if we failed to write one or more files. In addition, both vectors size must me the same
      */
-    bool BulkWrite(const vector<pair<wxString, wxString>>& files, const wxString& path_prefix = wxEmptyString) const;
+    bool BulkWrite(const std::vector<std::pair<wxString, wxString>>& files,
+                   const wxString& path_prefix = wxEmptyString) const;
 
 public:
     WizardsPlugin(IManager* manager);

--- a/LanguageServer/LSPOutlineViewDlg.cpp
+++ b/LanguageServer/LSPOutlineViewDlg.cpp
@@ -12,11 +12,11 @@
 
 namespace
 {
-const wxString FUNCTION_SYMBOL = wxT("\u2A10");
-const wxString CLASS_SYMBOL = wxT("\u2394");
-const wxString VARIABLE_SYMBOL = wxT("\u2027");
-const wxString MODULE_SYMBOL = wxT("{}");
-const wxString ENUMERATOR_SYMBOL = wxT("#");
+const wxString FUNCTION_SYMBOL = "\u2A10";
+const wxString CLASS_SYMBOL = "\u2394";
+const wxString VARIABLE_SYMBOL = "\u2027";
+const wxString MODULE_SYMBOL = "{}";
+const wxString ENUMERATOR_SYMBOL = "#";
 } // namespace
 
 LSPOutlineViewDlg::LSPOutlineViewDlg(wxWindow* parent)
@@ -54,7 +54,7 @@ void LSPOutlineViewDlg::DoInitialise()
     wxColour module_colour = lexer->GetProperty(wxSTC_P_STRING).GetFgColour();
     wxColour function_colour = lexer->GetProperty(wxSTC_P_DEFNAME).GetFgColour();
     wxColour operator_colour = lexer->GetProperty(wxSTC_P_OPERATOR).GetFgColour();
-    vector<pair<wxString, int>> containers;
+    std::vector<std::pair<wxString, int>> containers;
 
     clAnsiEscapeCodeColourBuilder builder;
     for(const SymbolInformation& si : m_symbols) {
@@ -229,7 +229,7 @@ void LSPOutlineViewDlg::OnListKeyDown(wxKeyEvent& event)
     }
 }
 
-void LSPOutlineViewDlg::SetSymbols(const vector<SymbolInformation>& symbols)
+void LSPOutlineViewDlg::SetSymbols(const std::vector<SymbolInformation>& symbols)
 {
     m_symbols = symbols;
     DoInitialise();

--- a/LanguageServer/LSPOutlineViewDlg.h
+++ b/LanguageServer/LSPOutlineViewDlg.h
@@ -6,12 +6,11 @@
 
 #include <vector>
 
-using namespace std;
 using namespace LSP;
 
 class LSPOutlineViewDlg : public LSPOutlineViewDlgBase
 {
-    vector<SymbolInformation> m_symbols;
+    std::vector<SymbolInformation> m_symbols;
 
 private:
     void DoSelectionActivate();
@@ -23,7 +22,7 @@ public:
     LSPOutlineViewDlg(wxWindow* parent);
     virtual ~LSPOutlineViewDlg();
 
-    void SetSymbols(const vector<SymbolInformation>& symbols);
+    void SetSymbols(const std::vector<SymbolInformation>& symbols);
 
 protected:
     virtual void OnListKeyDown(wxKeyEvent& event);

--- a/LiteEditor/context_cpp.cpp
+++ b/LiteEditor/context_cpp.cpp
@@ -33,7 +33,6 @@
 #include "SelectProjectsDlg.h"
 #include "ServiceProviderManager.h"
 #include "addincludefiledlg.h"
-#include "algorithm"
 #include "browse_record.h"
 #include "buildtabsettingsdata.h"
 #include "clEditorStateLocker.h"
@@ -75,15 +74,15 @@
 #include "setters_getters_dlg.h"
 #include "symbols_dialog.h"
 #include "workspacetab.h"
-#include "wx/regex.h"
-#include "wx/tokenzr.h"
-#include "wx/xrc/xmlres.h"
 #include "wxCodeCompletionBoxManager.h"
 
+#include <algorithm>
 #include <wx/choicdlg.h>
 #include <wx/file.h>
 #include <wx/progdlg.h>
 #include <wx/regex.h>
+#include <wx/tokenzr.h>
+#include <wx/xrc/xmlres.h>
 
 //#define __PERFORMANCE
 #include "performance.h"
@@ -114,7 +113,7 @@ static bool IsHeader(const wxString& ext)
 {
     wxString e(ext);
     e = e.MakeLower();
-    return e == wxT("hpp") || e == wxT("h") || e == wxT("hxx");
+    return e == "hpp" || e == "h" || e == "hxx";
 }
 
 #define VALIDATE_PROJECT(ctrl)        \
@@ -193,7 +192,7 @@ ContextCpp::ContextCpp(clEditor* container)
 }
 
 ContextCpp::ContextCpp()
-    : ContextBase(wxT("c++"))
+    : ContextBase("c++")
     , m_rclickMenu(NULL)
 {
     EventNotifier::Get()->Connect(wxEVT_CC_SHOW_QUICK_NAV_MENU,
@@ -234,8 +233,9 @@ bool ContextCpp::GetHoverTip(int pos)
     int word_start = rCtrl.WordStartPosition(pos, true);
 
     // get the expression we are standing on it
-    if(IsCommentOrString(pos))
+    if(IsCommentOrString(pos)) {
         return false;
+    }
 
     // get the token
     wxString word = rCtrl.GetTextRange(word_start, end);
@@ -244,8 +244,9 @@ bool ContextCpp::GetHoverTip(int pos)
     }
 
     int foundPos(wxNOT_FOUND);
-    if(rCtrl.PreviousChar(word_start, foundPos) == wxT('~'))
-        word.Prepend(wxT("~"));
+    if(rCtrl.PreviousChar(word_start, foundPos) == '~') {
+        word.Prepend("~");
+    }
 
     // get the expression we are hovering over
     wxString expr = GetExpression(end, false);
@@ -263,8 +264,9 @@ bool ContextCpp::GetHoverTip(int pos)
     if(tips.size() > 0) {
 
         tooltip << tips[0];
-        for(size_t i = 1; i < tips.size(); i++)
-            tooltip << wxT("\n") << tips[i];
+        for(size_t i = 1; i < tips.size(); i++) {
+            tooltip << "\n" << tips[i];
+        }
 
         // cancel any old calltip and display the new one
         rCtrl.DoCancelCalltip();
@@ -283,65 +285,63 @@ bool ContextCpp::GetHoverTip(int pos)
 wxString ContextCpp::GetFileImageString(const wxString& ext)
 {
     if(IsSource(ext)) {
-        return wxT("?15");
+        return "?15";
     }
     if(IsHeader(ext)) {
-        return wxT("?16");
+        return "?16";
     }
-    return wxT("?17");
+    return "?17";
 }
 
 wxString ContextCpp::GetImageString(const TagEntry& entry)
 {
-    if(entry.GetKind() == wxT("class"))
-        return wxT("?1");
-
-    if(entry.GetKind() == wxT("struct"))
-        return wxT("?2");
-
-    if(entry.GetKind() == wxT("namespace"))
-        return wxT("?3");
-
-    if(entry.GetKind() == wxT("variable"))
-        return wxT("?4");
-
-    if(entry.GetKind() == wxT("typedef"))
-        return wxT("?5");
-
-    if(entry.GetKind() == wxT("member") && entry.GetAccess().Contains(wxT("private")))
-        return wxT("?6");
-
-    if(entry.GetKind() == wxT("member") && entry.GetAccess().Contains(wxT("public")))
-        return wxT("?7");
-
-    if(entry.GetKind() == wxT("member") && entry.GetAccess().Contains(wxT("protected")))
-        return wxT("?8");
-
+    if(entry.GetKind() == "class") {
+        return "?1";
+    }
+    if(entry.GetKind() == "struct") {
+        return "?2";
+    }
+    if(entry.GetKind() == "namespace") {
+        return "?3";
+    }
+    if(entry.GetKind() == "variable") {
+        return "?4";
+    }
+    if(entry.GetKind() == "typedef") {
+        return "?5";
+    }
+    if(entry.GetKind() == "member" && entry.GetAccess().Contains("private")) {
+        return "?6";
+    }
+    if(entry.GetKind() == "member" && entry.GetAccess().Contains("public")) {
+        return "?7";
+    }
+    if(entry.GetKind() == "member" && entry.GetAccess().Contains("protected")) {
+        return "?8";
+    }
     // member with no access? (maybe part of namespace??)
-    if(entry.GetKind() == wxT("member"))
-        return wxT("?7");
-
-    if((entry.GetKind() == wxT("function") || entry.GetKind() == wxT("prototype")) &&
-       entry.GetAccess().Contains(wxT("private")))
-        return wxT("?9");
-
-    if((entry.GetKind() == wxT("function") || entry.GetKind() == wxT("prototype")) &&
-       (entry.GetAccess().Contains(wxT("public")) || entry.GetAccess().IsEmpty()))
-        return wxT("?10");
-
-    if((entry.GetKind() == wxT("function") || entry.GetKind() == wxT("prototype")) &&
-       entry.GetAccess().Contains(wxT("protected")))
-        return wxT("?11");
-
-    if(entry.GetKind() == wxT("macro"))
-        return wxT("?12");
-
-    if(entry.GetKind() == wxT("enum"))
-        return wxT("?13");
-
-    if(entry.GetKind() == wxT("enumerator"))
-        return wxT("?14");
-
+    if(entry.GetKind() == "member") {
+        return "?7";
+    }
+    if((entry.GetKind() == "function" || entry.GetKind() == "prototype") && entry.GetAccess().Contains("private")) {
+        return "?9";
+    }
+    if((entry.GetKind() == "function" || entry.GetKind() == "prototype") &&
+       (entry.GetAccess().Contains("public") || entry.GetAccess().IsEmpty())) {
+        return "?10";
+    }
+    if((entry.GetKind() == "function" || entry.GetKind() == "prototype") && entry.GetAccess().Contains("protected")) {
+        return "?11";
+    }
+    if(entry.GetKind() == "macro") {
+        return "?12";
+    }
+    if(entry.GetKind() == "enum") {
+        return "?13";
+    }
+    if(entry.GetKind() == "enumerator") {
+        return "?14";
+    }
     return wxEmptyString;
 }
 
@@ -353,12 +353,12 @@ void ContextCpp::AutoIndent(const wxChar& nChar)
         return;
     }
 
-    if(rCtrl.GetLineIndentation(rCtrl.GetCurrentLine()) && nChar == wxT('\n')) {
+    if(rCtrl.GetLineIndentation(rCtrl.GetCurrentLine()) && nChar == '\n') {
         return;
     }
 
     int curpos = rCtrl.GetCurrentPos();
-    if(IsComment(curpos) && nChar == wxT('\n')) {
+    if(IsComment(curpos) && nChar == '\n') {
         AutoAddComment();
         return;
     }
@@ -369,7 +369,7 @@ void ContextCpp::AutoIndent(const wxChar& nChar)
     }
 
     int line = rCtrl.LineFromPosition(curpos);
-    if(nChar == wxT('\n')) {
+    if(nChar == '\n') {
 
         int prevpos(wxNOT_FOUND);
         int foundPos(wxNOT_FOUND);
@@ -382,11 +382,11 @@ void ContextCpp::AutoIndent(const wxChar& nChar)
         if(line) {
             wxString lineStr = rCtrl.GetLine(line - 1);
             lineStr.Trim().Trim(false);
-            isPreLinePreProcessLine = lineStr.StartsWith(wxT("#"));
+            isPreLinePreProcessLine = lineStr.StartsWith("#");
         }
 
         // user hit ENTER after 'else'
-        if(word == wxT("else") && !isPreLinePreProcessLine) {
+        if(word == "else" && !isPreLinePreProcessLine) {
             int prevLine = rCtrl.LineFromPosition(prevpos);
             rCtrl.SetLineIndentation(line, rCtrl.GetIndent() + rCtrl.GetLineIndentation(prevLine));
             rCtrl.SetCaretAt(rCtrl.GetLineIndentPosition(line));
@@ -395,18 +395,18 @@ void ContextCpp::AutoIndent(const wxChar& nChar)
         }
 
         // User typed 'ENTER' immediatly after closing brace ')'
-        if(prevpos != wxNOT_FOUND && ch == wxT(')')) {
+        if(prevpos != wxNOT_FOUND && ch == ')') {
 
             long openBracePos(wxNOT_FOUND);
             int posWordBeforeOpenBrace(wxNOT_FOUND);
 
-            if(rCtrl.MatchBraceBack(wxT(')'), prevpos, openBracePos)) {
+            if(rCtrl.MatchBraceBack(')', prevpos, openBracePos)) {
                 rCtrl.PreviousChar(openBracePos, posWordBeforeOpenBrace);
                 if(posWordBeforeOpenBrace != wxNOT_FOUND) {
                     word = rCtrl.PreviousWord(posWordBeforeOpenBrace, foundPos);
 
                     // c++ expression with single line and should be treated separatly
-                    if(word == wxT("if") || word == wxT("while") || word == wxT("for")) {
+                    if(word == "if" || word == "while" || word == "for") {
                         int prevLine = rCtrl.LineFromPosition(prevpos);
                         rCtrl.SetLineIndentation(line, rCtrl.GetIndent() + rCtrl.GetLineIndentation(prevLine));
                         rCtrl.SetCaretAt(rCtrl.GetLineIndentPosition(line));
@@ -418,7 +418,7 @@ void ContextCpp::AutoIndent(const wxChar& nChar)
         }
 
         // User typed 'ENTER' immediatly after colons ':'
-        if(prevpos != wxNOT_FOUND && ch == wxT(':')) {
+        if(prevpos != wxNOT_FOUND && ch == ':') {
             int posWordBeforeColons(wxNOT_FOUND);
 
             rCtrl.PreviousChar(prevpos, posWordBeforeColons);
@@ -427,7 +427,7 @@ void ContextCpp::AutoIndent(const wxChar& nChar)
                 int prevLine = rCtrl.LineFromPosition(posWordBeforeColons);
                 wxUnusedVar(prevLine);
                 // If we found one of the following keywords, un-indent their line by (foldLevel - 1)*indentSize
-                if(word == wxT("public") || word == wxT("private") || word == wxT("protected")) {
+                if(word == "public" || word == "private" || word == "protected") {
 
                     ContextBase::AutoIndent(nChar);
 
@@ -448,7 +448,7 @@ void ContextCpp::AutoIndent(const wxChar& nChar)
         }
 
         // use the previous line indentation level
-        if(prevpos == wxNOT_FOUND || ch != wxT('{') || IsCommentOrString(prevpos)) {
+        if(prevpos == wxNOT_FOUND || ch != '{' || IsCommentOrString(prevpos)) {
             ContextBase::AutoIndent(nChar);
             return;
         }
@@ -458,23 +458,25 @@ void ContextCpp::AutoIndent(const wxChar& nChar)
         rCtrl.SetLineIndentation(line, rCtrl.GetIndent() + rCtrl.GetLineIndentation(prevLine));
         rCtrl.SetCaretAt(rCtrl.GetLineIndentPosition(line));
 
-    } else if(nChar == wxT('}')) {
+    } else if(nChar == '}') {
 
         long matchPos = wxNOT_FOUND;
-        if(!rCtrl.MatchBraceBack(wxT('}'), rCtrl.PositionBefore(curpos), matchPos))
+        if(!rCtrl.MatchBraceBack('}', rCtrl.PositionBefore(curpos), matchPos)) {
             return;
+        }
         int secondLine = rCtrl.LineFromPosition(matchPos);
-        if(secondLine == line)
+        if(secondLine == line) {
             return;
+        }
         rCtrl.SetLineIndentation(line, rCtrl.GetLineIndentation(secondLine));
 
-    } else if(nChar == wxT('{')) {
+    } else if(nChar == '{') {
         wxString lineString = rCtrl.GetLine(line);
         lineString.Trim().Trim(false);
 
         int matchPos = wxNOT_FOUND;
         wxChar previousChar = rCtrl.PreviousChar(rCtrl.PositionBefore(curpos), matchPos);
-        if(previousChar != wxT('{') && lineString == wxT("{")) {
+        if(previousChar != '{' && lineString == "{") {
             // indent this line accroding to the previous line
             int line = rCtrl.LineFromPosition(rCtrl.GetCurrentPos());
             rCtrl.SetLineIndentation(line, rCtrl.GetLineIndentation(line - 1));
@@ -578,7 +580,7 @@ void ContextCpp::AddMenuDynamicContent(wxMenu* menu)
     if(IsIncludeStatement(line, &fileName)) {
 
         PrependMenuItemSeparator(menu);
-        menuItemText << _("Open Include File \"") << fileName << wxT("\"");
+        menuItemText << _("Open Include File \"") << fileName << "\"";
 
         PrependMenuItem(menu, menuItemText, wxCommandEventHandler(ContextCpp::OnContextOpenDocument),
                         XRCID("open_include_file"));
@@ -598,7 +600,7 @@ void ContextCpp::AddMenuDynamicContent(wxMenu* menu)
             PrependMenuItem(menu, menuItemText, XRCID("add_forward_decl"));
 
             menuItemText.Clear();
-            menuItemText << _("Add Include File for \"") << word << wxT("\"");
+            menuItemText << _("Add Include File for \"") << word << "\"";
             PrependMenuItem(menu, menuItemText, XRCID("add_include_file"));
 
             m_selectedWord = word;
@@ -615,8 +617,9 @@ void ContextCpp::OnAddForwardDecl(wxCommandEvent& e)
     // get expression
     int pos = rCtrl.GetCurrentPos();
 
-    if(IsCommentOrString(pos))
+    if(IsCommentOrString(pos)) {
         return;
+    }
 
     // get the scope
     wxString text = rCtrl.GetTextRange(0, rCtrl.GetCurrentPos());
@@ -652,8 +655,9 @@ void ContextCpp::OnAddIncludeFile(wxCommandEvent& e)
     // get expression
     int pos = rCtrl.GetCurrentPos();
 
-    if(IsCommentOrString(pos))
+    if(IsCommentOrString(pos)) {
         return;
+    }
 
     int word_end = rCtrl.WordEndPosition(pos, true);
     wxString expr = GetExpression(word_end, false);
@@ -689,25 +693,27 @@ bool ContextCpp::IsIncludeStatement(const wxString& line, wxString* fileName, wx
     // completion list
     tmpLine = tmpLine.Trim();
     tmpLine = tmpLine.Trim(false);
-    tmpLine.Replace(wxT("\t"), wxT(" "));
+    tmpLine.Replace("\t", " ");
 
-    static wxRegEx reIncludeFile(wxT("include *[\\\"\\<]{1}([a-zA-Z0-9_/\\.\\+\\-]*)"));
-    if(tmpLine.StartsWith(wxT("#"), &tmpLine1)) {
+    static wxRegEx reIncludeFile("include *[\\\"\\<]{1}([a-zA-Z0-9_/\\.\\+\\-]*)");
+    if(tmpLine.StartsWith("#", &tmpLine1)) {
         if(reIncludeFile.Matches(tmpLine1)) {
             if(fileNameUpToCaret) {
                 // 'line' contains the entire current line
                 // we want the part up until the caret
                 int caretpos = GetCtrl().GetCurrentPos();
                 int lineStartPos = GetCtrl().PositionFromLine(GetCtrl().GetCurrentLine());
-                if(lineStartPos > caretpos)
+                if(lineStartPos > caretpos) {
                     return false;
+                }
 
                 wxString partialLine = GetCtrl().GetTextRange(lineStartPos, caretpos);
 
                 // Get the partial file name (up to the caret)
                 size_t where = partialLine.find_first_of("<\"");
-                if(where == wxString::npos)
+                if(where == wxString::npos) {
                     return false;
+                }
                 ++where; // Skip the < or " character found
 
                 partialLine = partialLine.Mid(where);
@@ -747,8 +753,9 @@ void ContextCpp::DisplayFilesCompletionBox(const wxString& word)
         wxStringSet_t matches;
         for(size_t i = 0; i < files.GetCount(); ++i) {
             wxFileName fn(files.Item(i));
-            if(matches.count(files.Item(i)))
+            if(matches.count(files.Item(i))) {
                 continue; // we already have this file in the list, don't add another one
+            }
             matches.insert(files.Item(i));
 
             int imgID = 0;
@@ -821,9 +828,10 @@ void ContextCpp::SwapFiles(const wxFileName& fileName)
         file_to_open = ::wxGetSingleChoice(_("Multiple candidates found. Select a file to open:"),
                                            _("Swap Header/Source Implementation"), fileArr, 0);
 
-        if(file_to_open.IsEmpty())
+        if(file_to_open.IsEmpty()) {
             // Cancel clicked
             return;
+        }
 
         TryOpenFile(file_to_open, false);
         return;
@@ -971,8 +979,9 @@ bool ContextCpp::TryOpenFile(const wxFileName& fileName, bool lookInEntireWorksp
                                                            (enum OF_extra)(OF_PlaceNextToCurrent | OF_AddJump));
     }
 
-    if(!lookInEntireWorkspace)
+    if(!lookInEntireWorkspace) {
         return false;
+    }
 
     // ok, the file does not exist in the current directory, try to find elsewhere
     // whithin the workspace files
@@ -1006,7 +1015,7 @@ void ContextCpp::DoMakeDoxyCommentString(DoxygenComment& dc, const wxString& blo
     CHECK_JS_RETURN_VOID();
     clEditor& editor = GetCtrl();
     CommentConfigData data;
-    EditorConfigST::Get()->ReadObject(wxT("CommentConfigData"), &data);
+    EditorConfigST::Get()->ReadObject("CommentConfigData", &data);
 
     wxString blockStart = blockPrefix;
     blockStart << "\n";
@@ -1025,19 +1034,19 @@ void ContextCpp::DoMakeDoxyCommentString(DoxygenComment& dc, const wxString& blo
     funcPattern.Replace("\\", sKeywordPrefix);
 
     // replace $(Name) here **before** the call to ExpandAllVariables()
-    classPattern.Replace(wxT("$(Name)"), dc.name);
-    funcPattern.Replace(wxT("$(Name)"), dc.name);
+    classPattern.Replace("$(Name)", dc.name);
+    funcPattern.Replace("$(Name)", dc.name);
 
     classPattern = ExpandAllVariables(classPattern, clCxxWorkspaceST::Get(), editor.GetProjectName(), wxEmptyString,
                                       editor.GetFileName().GetFullPath());
     funcPattern = ExpandAllVariables(funcPattern, clCxxWorkspaceST::Get(), editor.GetProjectName(), wxEmptyString,
                                      editor.GetFileName().GetFullPath());
 
-    dc.comment.Replace(wxT("$(ClassPattern)"), classPattern);
-    dc.comment.Replace(wxT("$(FunctionPattern)"), funcPattern);
+    dc.comment.Replace("$(ClassPattern)", classPattern);
+    dc.comment.Replace("$(FunctionPattern)", funcPattern);
 
     // close the comment
-    dc.comment << wxT(" */\n");
+    dc.comment << " */\n";
     dc.comment.Prepend(blockStart);
 }
 
@@ -1050,7 +1059,7 @@ void ContextCpp::OnInsertDoxyComment(wxCommandEvent& event)
     VALIDATE_WORKSPACE();
 
     CommentConfigData data;
-    EditorConfigST::Get()->ReadObject(wxT("CommentConfigData"), &data);
+    EditorConfigST::Get()->ReadObject("CommentConfigData", &data);
 
     // We decide whether to use @ or \ based on the current class pattern
     wxChar keyPrefix = data.IsUseQtStyle() ? '\\' : '@';
@@ -1084,8 +1093,9 @@ void ContextCpp::OnInsertDoxyComment(wxCommandEvent& event)
         // get doxygen comment based on file and line
         DoxygenComment dc = TagsManagerST::Get()->DoCreateDoxygenComment(t, keyPrefix);
         // do we have a comment?
-        if(dc.comment.IsEmpty())
+        if(dc.comment.IsEmpty()) {
             return;
+        }
 
         DoMakeDoxyCommentString(dc, data.GetCommentBlockPrefix(), keyPrefix);
         // To make the doxy block fit in, we need to prepend each line
@@ -1169,8 +1179,8 @@ void ContextCpp::OnGenerateSettersGetters(wxCommandEvent& event)
         TagsManagerST::Get()->ParseBuffer(editor.GetText(), editor.GetFileName().GetFullPath());
 
     // filter all tags that are do not belong to the current scope
-    vector<TagEntryPtr> function_tags; // both prototypes + definitions
-    vector<TagEntryPtr> member_tags;   // member variables
+    std::vector<TagEntryPtr> function_tags; // both prototypes + definitions
+    std::vector<TagEntryPtr> member_tags;   // member variables
     for(TagEntryPtr tag : tags) {
         if(tag->GetScope() == scopeName) {
             if(tag->GetKind() == "member") {
@@ -1301,11 +1311,12 @@ void ContextCpp::OnDbgDwellEnd(wxStyledTextEvent& event)
 
 void ContextCpp::OnDbgDwellStart(wxStyledTextEvent& event)
 {
-    static wxRegEx reCppIndentifier(wxT("[a-zA-Z_][a-zA-Z0-9_]*"));
+    static wxRegEx reCppIndentifier("[a-zA-Z_][a-zA-Z0-9_]*");
 
     // the tip is already up
-    if(ManagerST::Get()->GetDebuggerTip() && ManagerST::Get()->GetDebuggerTip()->IsShown())
+    if(ManagerST::Get()->GetDebuggerTip() && ManagerST::Get()->GetDebuggerTip()->IsShown()) {
         return;
+    }
 
     // We disply the tooltip only if the control key is down
     DebuggerInformation info;
@@ -1316,8 +1327,9 @@ void ContextCpp::OnDbgDwellStart(wxStyledTextEvent& event)
     }
 
     DebuggerMgr::Get().GetDebuggerInformation(dbgr->GetName(), info);
-    if(info.showTooltipsOnlyWithControlKeyIsDown && wxGetMouseState().ControlDown() == false)
+    if(info.showTooltipsOnlyWithControlKeyIsDown && wxGetMouseState().ControlDown() == false) {
         return;
+    }
 
     wxString word;
     clEditor& ctrl = GetCtrl();
@@ -1434,8 +1446,9 @@ void ContextCpp::OnMoveImpl(wxCommandEvent& e)
     // get the scope
     wxString word = rCtrl.GetTextRange(word_start, word_end);
 
-    if(word.IsEmpty())
+    if(word.IsEmpty()) {
         return;
+    }
 
     int line = rCtrl.LineFromPosition(rCtrl.GetCurrentPosition()) + 1;
 
@@ -1446,7 +1459,7 @@ void ContextCpp::OnMoveImpl(wxCommandEvent& e)
     // get the scope name from the text
     wxString scopeName = TagsManagerST::Get()->GetScopeName(scopeText);
     if(scopeName.IsEmpty()) {
-        scopeName = wxT("<global>");
+        scopeName = "<global>";
     }
 
     // Find the tag
@@ -1476,10 +1489,10 @@ void ContextCpp::OnMoveImpl(wxCommandEvent& e)
     // create the functions body
     wxString body = TagsManagerST::Get()->FormatFunction(tag, FunctionFormat_Impl);
     // remove the empty content provided by this function
-    body = body.BeforeLast(wxT('{'));
+    body = body.BeforeLast('{');
     body = body.Trim().Trim(false);
-    body.Prepend(wxT("\n"));
-    body << content << wxT("\n");
+    body.Prepend("\n");
+    body << content << "\n";
 
     wxString targetFile;
     FindSwappedFile(rCtrl.GetFileName(), targetFile);
@@ -1504,7 +1517,7 @@ void ContextCpp::OnMoveImpl(wxCommandEvent& e)
     // Remove the current body and replace it with ';'
     rCtrl.SetTargetEnd(blockEndPos);
     rCtrl.SetTargetStart(blockStartPos);
-    rCtrl.ReplaceTarget(wxT(";"));
+    rCtrl.ReplaceTarget(";");
 
     implEditor->CenterLine(implEditor->LineFromPos(implEditor->GetLastPosition()));
 }
@@ -1532,12 +1545,12 @@ bool ContextCpp::DoGetFunctionBody(long curPos, long& blockStartPos, long& block
 
         // valid character
         wxChar ch = rCtrl.GetCharAt(curPos);
-        if(ch == wxT(';')) {
+        if(ch == ';') {
             // no implementation to move
             break;
         }
 
-        if(ch == wxT('{')) {
+        if(ch == '{') {
             blockStartPos = curPos;
             break;
         }
@@ -1546,7 +1559,7 @@ bool ContextCpp::DoGetFunctionBody(long curPos, long& blockStartPos, long& block
     // collect the functions' block
     if(blockStartPos != wxNOT_FOUND) {
         int depth(1);
-        content << wxT("{");
+        content << "{";
         while(depth > 0) {
             curPos = rCtrl.PositionAfter(curPos);
             // eof?
@@ -1562,10 +1575,10 @@ bool ContextCpp::DoGetFunctionBody(long curPos, long& blockStartPos, long& block
             }
 
             switch(ch) {
-            case wxT('{'):
+            case '{':
                 depth++;
                 break;
-            case wxT('}'):
+            case '}':
                 depth--;
                 break;
             }
@@ -1585,7 +1598,7 @@ size_t ContextCpp::DoGetEntriesForHeaderAndImpl(std::vector<TagEntryPtr>& protot
     clEditor& rCtrl = GetCtrl();
     prototypes.clear();
     functions.clear();
-    vector<TagEntryPtr> tmp_tags;
+    std::vector<TagEntryPtr> tmp_tags;
     prototypes = TagsManagerST::Get()->ParseBuffer(rCtrl.GetEditorText());
 
     // filter non prototypes
@@ -1648,8 +1661,8 @@ void ContextCpp::DoAddFunctionImplementation(int line_number)
     int pos = rCtrl.GetCurrentPos();
     wxString context = rCtrl.GetTextRange(0, pos);
     wxString scopeName = TagsManagerST::Get()->GetScopeName(context);
-    if(scopeName.IsEmpty() || scopeName == wxT("<global>")) {
-        wxMessageBox(_("'Add Functions Implementation' can only work inside valid scope, got (") + scopeName + wxT(")"),
+    if(scopeName.IsEmpty() || scopeName == "<global>") {
+        wxMessageBox(_("'Add Functions Implementation' can only work inside valid scope, got (") + scopeName + ")",
                      _("CodeLite"), wxICON_INFORMATION | wxOK);
         return;
     }
@@ -1739,13 +1752,13 @@ void ContextCpp::ApplySettings()
     //-----------------------------------------------
     // Load laguage settings from configuration file
     //-----------------------------------------------
-    SetName(wxT("C++"));
+    SetName("C++");
 
     // Set the key words and the lexer
     LexerConf::Ptr_t lexPtr;
     // Read the configuration file
     if(EditorConfigST::Get()->IsOk()) {
-        lexPtr = EditorConfigST::Get()->GetLexer(wxT("C++"));
+        lexPtr = EditorConfigST::Get()->GetLexer("C++");
     }
 
     // Update the control
@@ -1757,11 +1770,11 @@ void ContextCpp::ApplySettings()
     wxString jsKeywords = lexPtr->GetKeyWords(1);
 
     // C/C++ keywords
-    keyWords.Replace(wxT("\n"), wxT(" "));
-    keyWords.Replace(wxT("\r"), wxT(" "));
+    keyWords.Replace("\n", " ");
+    keyWords.Replace("\r", " ");
 
-    jsKeywords.Replace(wxT("\n"), wxT(" "));
-    jsKeywords.Replace(wxT("\r"), wxT(" "));
+    jsKeywords.Replace("\n", " ");
+    jsKeywords.Replace("\r", " ");
 
     // A javascript file?
     if(!IsJavaScript()) {
@@ -1771,8 +1784,8 @@ void ContextCpp::ApplySettings()
     }
 
     // Doxygen keywords
-    doxyKeyWords.Replace(wxT("\n"), wxT(" "));
-    doxyKeyWords.Replace(wxT("\r"), wxT(" "));
+    doxyKeyWords.Replace("\n", " ");
+    doxyKeyWords.Replace("\r", " ");
     rCtrl.SetKeyWords(2, doxyKeyWords);
 
     DoApplySettings(lexPtr);
@@ -1781,9 +1794,9 @@ void ContextCpp::ApplySettings()
     if(!m_cppFileBmp.IsOk()) {
         // Initialise the file bitmaps
         BitmapLoader* bmpLoader = PluginManager::Get()->GetStdIcons();
-        m_cppFileBmp = bmpLoader->LoadBitmap(wxT("mime-cpp"));
-        m_hFileBmp = bmpLoader->LoadBitmap(wxT("mime-h"));
-        m_otherFileBmp = bmpLoader->LoadBitmap(wxT("mime-txt"));
+        m_cppFileBmp = bmpLoader->LoadBitmap("mime-cpp");
+        m_hFileBmp = bmpLoader->LoadBitmap("mime-h");
+        m_otherFileBmp = bmpLoader->LoadBitmap("mime-txt");
     }
 
     // delete uneeded commands
@@ -1791,7 +1804,7 @@ void ContextCpp::ApplySettings()
     rCtrl.CmdKeyClear('/', wxSTC_KEYMOD_CTRL | wxSTC_KEYMOD_SHIFT);
 
     // update word characters to allow '~' as valid word character
-    rCtrl.SetWordChars(wxT("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"));
+    rCtrl.SetWordChars("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
 }
 
 void ContextCpp::Initialize()
@@ -1811,7 +1824,7 @@ void ContextCpp::AutoAddComment()
     clEditor& rCtrl = GetCtrl();
 
     CommentConfigData data;
-    EditorConfigST::Get()->ReadObject(wxT("CommentConfigData"), &data);
+    EditorConfigST::Get()->ReadObject("CommentConfigData", &data);
 
     int curpos = rCtrl.GetCurrentPos();
     int line = rCtrl.LineFromPosition(curpos);
@@ -1822,7 +1835,7 @@ void ContextCpp::AutoAddComment()
     switch(cur_style) {
     case wxSTC_C_COMMENTLINE:
     case wxSTC_C_COMMENTLINEDOC:
-        dontadd = !text.StartsWith(wxT("//")) || !data.GetContinueCppComment();
+        dontadd = !text.StartsWith("//") || !data.GetContinueCppComment();
         break;
     case wxSTC_C_COMMENT:
     case wxSTC_C_COMMENTDOC:
@@ -1833,7 +1846,7 @@ void ContextCpp::AutoAddComment()
         break;
     }
     if(dontadd) {
-        ContextBase::AutoIndent(wxT('\n'));
+        ContextBase::AutoIndent('\n');
         return;
     }
 
@@ -1841,13 +1854,14 @@ void ContextCpp::AutoAddComment()
     switch(cur_style) {
     case wxSTC_C_COMMENTLINE:
     case wxSTC_C_COMMENTLINEDOC: {
-        if(text.StartsWith(wxT("//"))) {
+        if(text.StartsWith("//")) {
             // try to parse the comment text and indentation
-            unsigned i = (text.Length() > 2 && text[2] == wxT('!')) ? 3 : 2; // support "//!" for doxygen
-            i = text.find_first_not_of(wxT('/'), i);
-            i = text.find_first_not_of(wxT(" \t"), i);
-            if(i == wxString::npos)
+            unsigned i = (text.Length() > 2 && text[2] == '!') ? 3 : 2; // support "//!" for doxygen
+            i = text.find_first_not_of('/', i);
+            i = text.find_first_not_of(" \t", i);
+            if(i == wxString::npos) {
                 i = text.Length() - 1;
+            }
             // we want to avoid duplicating line-long comments such as those
             // that sometime start a comment block; if there's something more on
             // the line, after our match, then we can assume that we do not have
@@ -1860,10 +1874,11 @@ void ContextCpp::AutoAddComment()
             if(i < text.Length() - 1 || i < 40) {
                 toInsert = text.substr(0, i);
             } else {
-                if(cur_style == wxSTC_C_COMMENTLINEDOC && i >= 3)
-                    toInsert = text.substr(0, 3) + wxT(" ");
-                else
-                    toInsert = wxT("// ");
+                if(cur_style == wxSTC_C_COMMENTLINEDOC && i >= 3) {
+                    toInsert = text.substr(0, 3) + " ";
+                } else {
+                    toInsert = "// ";
+                }
             }
         }
     } break;
@@ -1871,7 +1886,7 @@ void ContextCpp::AutoAddComment()
     case wxSTC_C_COMMENTDOC: {
 
         CommentConfigData data;
-        EditorConfigST::Get()->ReadObject(wxT("CommentConfigData"), &data);
+        EditorConfigST::Get()->ReadObject("CommentConfigData", &data);
 
         // Check the text typed before this char
         int startPos = rCtrl.PositionBefore(curpos);
@@ -1893,8 +1908,9 @@ void ContextCpp::AutoAddComment()
                     // get doxygen comment based on file and line
                     DoxygenComment dc = TagsManagerST::Get()->DoCreateDoxygenComment(t, keyPrefix);
                     // do we have a comment?
-                    if(dc.comment.IsEmpty())
+                    if(dc.comment.IsEmpty()) {
                         return;
+                    }
 
                     DoMakeDoxyCommentString(dc, textTyped, keyPrefix);
                     // To make the doxy block fit in, we need to prepend each line
@@ -1929,7 +1945,7 @@ void ContextCpp::AutoAddComment()
         }
 
         if(rCtrl.GetStyleAt(rCtrl.PositionBefore(rCtrl.PositionBefore(curpos))) == cur_style) {
-            toInsert = rCtrl.GetCharAt(rCtrl.GetLineIndentPosition(line - 1)) == wxT('*') ? wxT("* ") : wxT(" * ");
+            toInsert = rCtrl.GetCharAt(rCtrl.GetLineIndentPosition(line - 1)) == '*' ? "* " : " * ";
         }
         break;
     }
@@ -2043,8 +2059,9 @@ void ContextCpp::OnRetagFile(wxCommandEvent& e)
 void ContextCpp::RetagFile()
 {
     CHECK_JS_RETURN_VOID();
-    if(ManagerST::Get()->GetRetagInProgress())
+    if(ManagerST::Get()->GetRetagInProgress()) {
         return;
+    }
 
     clEditor& editor = GetCtrl();
     ManagerST::Get()->RetagFile(editor.GetFileName().GetFullPath());
@@ -2064,8 +2081,9 @@ void ContextCpp::OnUserTypedXChars(const wxString& word)
 void ContextCpp::MakeCppKeywordsTags(const wxString& word, std::vector<TagEntryPtr>& tags)
 {
     // C++ keywords are handled differently
-    if(!IsJavaScript())
+    if(!IsJavaScript()) {
         return;
+    }
 
     LexerConf::Ptr_t lexPtr;
     // Read the configuration file
@@ -2089,19 +2107,20 @@ void ContextCpp::MakeCppKeywordsTags(const wxString& word, std::vector<TagEntryP
 
     wxString s1(word);
     std::set<wxString> uniqueWords;
-    wxArrayString wordsArr = wxStringTokenize(cppWords, wxT(" \r\t\n"));
+    wxArrayString wordsArr = wxStringTokenize(cppWords, " \r\t\n");
     for(size_t i = 0; i < wordsArr.GetCount(); i++) {
 
         // Dont add duplicate words
-        if(uniqueWords.find(wordsArr.Item(i)) != uniqueWords.end())
+        if(uniqueWords.find(wordsArr.Item(i)) != uniqueWords.end()) {
             continue;
+        }
 
         uniqueWords.insert(wordsArr.Item(i));
         wxString s2(wordsArr.Item(i));
         if(s2.StartsWith(s1) || s2.Lower().StartsWith(s1.Lower())) {
             TagEntryPtr tag(new TagEntry());
             tag->SetName(wordsArr.Item(i));
-            tag->SetKind(wxT("cpp_keyword"));
+            tag->SetKind("cpp_keyword");
             tags.push_back(tag);
         }
     }
@@ -2110,9 +2129,9 @@ void ContextCpp::MakeCppKeywordsTags(const wxString& word, std::vector<TagEntryP
 wxString ContextCpp::CallTipContent()
 {
     // if we have an active call tip, return its content
-    if(GetCtrl().GetFunctionTip()->IsActive())
+    if(GetCtrl().GetFunctionTip()->IsActive()) {
         return GetCtrl().GetFunctionTip()->GetText();
-
+    }
     return wxEmptyString;
 }
 
@@ -2123,9 +2142,10 @@ void ContextCpp::DoOpenWorkspaceFile()
     wxFileName fileName(m_selectedWord);
     wxString tmpName(m_selectedWord);
 
-    tmpName.Replace(wxT("\\"), wxT("/"));
-    if(tmpName.Contains(wxT("..")))
+    tmpName.Replace("\\", "/");
+    if(tmpName.Contains("..")) {
         tmpName = fileName.GetFullName();
+    }
 
 #ifdef __WXMSW__
     // On windows, files are case in-sensitive
@@ -2151,7 +2171,7 @@ void ContextCpp::DoOpenWorkspaceFile()
         curFileName.MakeLower();
 #endif
 
-        curFileName.Replace(wxT("\\"), wxT("/"));
+        curFileName.Replace("\\", "/");
         if(curFileName.EndsWith(tmpName)) {
             files2.push_back(files.at(i));
         }
@@ -2198,7 +2218,7 @@ void ContextCpp::DoCreateFile(const wxFileName& fn)
         ProjectPtr p = ManagerST::Get()->GetProject(GetCtrl().GetProject());
         if(p) {
             wxString vd = p->GetVDByFileName(GetCtrl().GetFileName().GetFullPath());
-            vd.Prepend(p->GetName() + wxT(":"));
+            vd.Prepend(p->GetName() + ":");
 
             if(vd.IsEmpty() == false) {
                 clMainFrame::Get()->GetWorkspaceTab()->GetFileView()->CreateAndAddFile(new_file, vd);
@@ -2207,8 +2227,9 @@ void ContextCpp::DoCreateFile(const wxFileName& fn)
     } else {
         // just a plain file
         wxFile file;
-        if(!file.Create(new_file.GetData(), true))
+        if(!file.Create(new_file.GetData(), true)) {
             return;
+        }
 
         if(file.IsOpened()) {
             file.Close();
@@ -2236,27 +2257,28 @@ void ContextCpp::SemicolonShift()
     int foundPos(wxNOT_FOUND);
     int semiColonPos(wxNOT_FOUND);
     clEditor& ctrl = GetCtrl();
-    if(ctrl.NextChar(ctrl.GetCurrentPos(), semiColonPos) == wxT(')')) {
+    if(ctrl.NextChar(ctrl.GetCurrentPos(), semiColonPos) == ')') {
 
         // test to see if we are inside a 'for' statement
         long openBracePos(wxNOT_FOUND);
         int posWordBeforeOpenBrace(wxNOT_FOUND);
 
-        if(ctrl.MatchBraceBack(wxT(')'), semiColonPos, openBracePos)) {
+        if(ctrl.MatchBraceBack(')', semiColonPos, openBracePos)) {
             ctrl.PreviousChar(openBracePos, posWordBeforeOpenBrace);
             if(posWordBeforeOpenBrace != wxNOT_FOUND) {
                 wxString word = ctrl.PreviousWord(posWordBeforeOpenBrace, foundPos);
 
                 // c++ expression with single line and should be treated separatly
-                if(word == wxT("for"))
+                if(word == "for") {
                     return;
+                }
 
                 // At the current pos, we got a ';'
                 // at semiColonPos we got ;
                 // switch
                 ctrl.DeleteBack();
                 ctrl.SetCurrentPos(semiColonPos);
-                ctrl.InsertText(semiColonPos, wxT(";"));
+                ctrl.InsertText(semiColonPos, ";");
                 ctrl.SetCaretAt(semiColonPos + 1);
                 ctrl.GetFunctionTip()->Deactivate();
             }
@@ -2329,12 +2351,12 @@ wxString ContextCpp::GetExpression(long pos, bool onlyWord, clEditor* editor, bo
         }
 
         switch(ch) {
-        case wxT(';'):
+        case ';':
             // dont include this token
             at = ctrl->PositionAfter(at);
             cont = false;
             break;
-        case wxT('-'):
+        case '-':
             if(prevGt) {
                 prevGt = false;
                 // if previous char was '>', we found an arrow so reduce the depth
@@ -2348,29 +2370,29 @@ wxString ContextCpp::GetExpression(long pos, bool onlyWord, clEditor* editor, bo
                 }
             }
             break;
-        case wxT(' '):
-        case wxT('\n'):
-        case wxT('\v'):
-        case wxT('\t'):
-        case wxT('\r'):
+        case ' ':
+        case '\n':
+        case '\v':
+        case '\t':
+        case '\r':
             prevGt = false;
             if(depth <= 0) {
                 cont = false;
                 break;
             }
             break;
-        case wxT('{'):
+        case '{':
             prevGt = false;
             cont = false;
             break;
-        case wxT('='):
+        case '=':
             prevGt = false;
             cont = false;
             // dont include this token
             at = ctrl->PositionAfter(at);
             break;
-        case wxT('('):
-        case wxT('['):
+        case '(':
+        case '[':
             depth--;
             prevGt = false;
             if(depth < 0) {
@@ -2397,11 +2419,11 @@ wxString ContextCpp::GetExpression(long pos, bool onlyWord, clEditor* editor, bo
                 cont = false;
             }
             break;
-        case wxT('>'):
+        case '>':
             prevGt = true;
             depth++;
             break;
-        case wxT('<'):
+        case '<':
             prevGt = false;
             depth--;
             if(depth < 0) {
@@ -2411,8 +2433,8 @@ wxString ContextCpp::GetExpression(long pos, bool onlyWord, clEditor* editor, bo
                 cont = false;
             }
             break;
-        case wxT(')'):
-        case wxT(']'):
+        case ')':
+        case ']':
             prevGt = false;
             depth++;
             break;
@@ -2422,8 +2444,9 @@ wxString ContextCpp::GetExpression(long pos, bool onlyWord, clEditor* editor, bo
         }
     }
 
-    if(at < 0)
+    if(at < 0) {
         at = 0;
+    }
     wxString expr = ctrl->GetTextRange(at, pos);
     if(!forCC) {
         // If we do not require the expression for CodeCompletion
@@ -2438,7 +2461,7 @@ wxString ContextCpp::GetExpression(long pos, bool onlyWord, clEditor* editor, bo
     while((sc.yylex()) != 0) {
         wxString token = _U(sc.YYText());
         expression += token;
-        expression += wxT(" ");
+        expression += " ";
     }
     return expression;
 }
@@ -2462,7 +2485,7 @@ bool ContextCpp::DoGetSingatureRange(int line, int& start, int& end, clEditor* c
             continue;
         }
 
-        if(ch == wxT('(')) {
+        if(ch == '(') {
             start = nCur;
             nCur++;
             break;
@@ -2470,8 +2493,9 @@ bool ContextCpp::DoGetSingatureRange(int line, int& start, int& end, clEditor* c
         nCur++;
     }
 
-    if(start == wxNOT_FOUND)
+    if(start == wxNOT_FOUND) {
         return false;
+    }
 
     // search for the function end position
     int nDepth = 1;
@@ -2484,10 +2508,10 @@ bool ContextCpp::DoGetSingatureRange(int line, int& start, int& end, clEditor* c
         }
 
         switch(ch) {
-        case wxT('('):
+        case '(':
             nDepth++;
             break;
-        case wxT(')'):
+        case ')':
             nDepth--;
             if(nDepth == 0) {
                 nCur++;
@@ -2500,9 +2524,9 @@ bool ContextCpp::DoGetSingatureRange(int line, int& start, int& end, clEditor* c
         nCur++;
     }
 
-    if(end == wxNOT_FOUND)
+    if(end == wxNOT_FOUND) {
         return false;
-
+    }
     return true;
 }
 
@@ -2545,13 +2569,13 @@ wxMenu* ContextCpp::GetMenu()
     wxMenu* menu = NULL;
     if(!IsJavaScript()) {
         // load the context menu from the resource manager
-        menu = wxXmlResource::Get()->LoadMenu(wxT("editor_right_click"));
+        menu = wxXmlResource::Get()->LoadMenu("editor_right_click");
         wxMenuItem* item = menu->FindItem(XRCID("grep_current_workspace"));
         if(item) {
             item->SetBitmap(wxXmlResource::Get()->LoadBitmap("m_bmpFindInFiles"));
         }
     } else {
-        menu = wxXmlResource::Get()->LoadMenu(wxT("editor_right_click_default"));
+        menu = wxXmlResource::Get()->LoadMenu("editor_right_click_default");
     }
     return menu;
 }

--- a/LiteEditor/output_pane.h
+++ b/LiteEditor/output_pane.h
@@ -25,11 +25,11 @@
 #ifndef OUTPUT_PANE_H
 #define OUTPUT_PANE_H
 
-#include <wx/panel.h>
-
 #include "Notebook.h"
 #include "cl_command_event.h"
 #include "shelltab.h"
+
+#include <wx/panel.h>
 
 class BuildTab;
 class ClangOutputTab;
@@ -45,7 +45,6 @@ class TaskPanel;
 class OutputPaneBook;
 class FindUsageTab;
 
-using namespace std;
 /**
  * \ingroup LiteEditor
  * This class represents the default bottom pane in the editor
@@ -79,7 +78,7 @@ protected:
 
         Tab() {}
     };
-    unordered_map<wxString, Tab> m_tabs;
+    std::unordered_map<wxString, Tab> m_tabs;
 
 private:
     wxString m_caption;

--- a/Outline/outline_tab.cpp
+++ b/Outline/outline_tab.cpp
@@ -14,11 +14,11 @@
 
 namespace
 {
-const wxString FUNCTION_SYMBOL = wxT("\u2A10");
-const wxString CLASS_SYMBOL = wxT("\u2394");
-const wxString VARIABLE_SYMBOL = wxT("\u2027");
-const wxString MODULE_SYMBOL = wxT("{}");
-const wxString ENUMERATOR_SYMBOL = wxT("#");
+const wxString FUNCTION_SYMBOL = "\u2A10";
+const wxString CLASS_SYMBOL = "\u2394";
+const wxString VARIABLE_SYMBOL = "\u2027";
+const wxString MODULE_SYMBOL = "{}";
+const wxString ENUMERATOR_SYMBOL = "#";
 } // namespace
 
 using namespace LSP;
@@ -47,7 +47,7 @@ void OutlineTab::OnOutlineSymbols(LSPEvent& event)
     RenderSymbols(event.GetSymbolsInformation(), event.GetFileName());
 }
 
-void OutlineTab::RenderSymbols(const vector<LSP::SymbolInformation>& symbols, const wxString& filename)
+void OutlineTab::RenderSymbols(const std::vector<LSP::SymbolInformation>& symbols, const wxString& filename)
 {
     ClearView();
 
@@ -87,7 +87,7 @@ void OutlineTab::RenderSymbols(const vector<LSP::SymbolInformation>& symbols, co
     wxColour module_colour = lexer->GetProperty(wxSTC_P_STRING).GetFgColour();
     wxColour function_colour = lexer->GetProperty(wxSTC_P_DEFNAME).GetFgColour();
     wxColour operator_colour = lexer->GetProperty(wxSTC_P_OPERATOR).GetFgColour();
-    vector<pair<wxString, int>> containers;
+    std::vector<std::pair<wxString, int>> containers;
 
     constexpr int INITIAL_DEPTH = 0;
     constexpr int DEPTH_WIDTH = 2;

--- a/Outline/outline_tab.h
+++ b/Outline/outline_tab.h
@@ -7,17 +7,16 @@
 
 #include <vector>
 
-using namespace std;
 class OutlineTab : public OutlineTabBaseClass
 {
     wxString m_currentSymbolsFileName;
-    vector<LSP::SymbolInformation> m_symbols;
+    std::vector<LSP::SymbolInformation> m_symbols;
 
 private:
     void OnOutlineSymbols(LSPEvent& event);
     void OnActiveEditorChanged(wxCommandEvent& event);
     void OnAllEditorsClosed(wxCommandEvent& event);
-    void RenderSymbols(const vector<LSP::SymbolInformation>& symbols, const wxString& filename);
+    void RenderSymbols(const std::vector<LSP::SymbolInformation>& symbols, const wxString& filename);
     void ClearView();
 
 public:

--- a/Plugin/GTKNotebook.hpp
+++ b/Plugin/GTKNotebook.hpp
@@ -14,7 +14,6 @@
 #include <wx/menu.h>
 #include <wx/notebook.h>
 
-using namespace std;
 class clGTKNotebook : public wxNotebook
 {
 protected:

--- a/Plugin/LSPNetworkSTDIO.cpp
+++ b/Plugin/LSPNetworkSTDIO.cpp
@@ -12,7 +12,6 @@
 
 #include <sstream>
 
-using namespace std;
 static const char separator_str[] = "\n************\n";
 static size_t separator_str_len = sizeof(separator_str) - 1;
 
@@ -98,7 +97,7 @@ void LSPNetworkSTDIO::DoStartLocalProcess()
     if(m_startupInfo.GetFlags() & LSPStartupInfo::kRemoteLSP) {
 #if USE_SFTP
         // wrap the command in ssh
-        vector<wxString> command = { "ssh", "-o", "ServerAliveInterval=10", "-o", "StrictHostKeyChecking=no" };
+        std::vector<wxString> command = { "ssh", "-o", "ServerAliveInterval=10", "-o", "StrictHostKeyChecking=no" };
         // add user@host
         SFTPSettings s;
         SSHAccountInfo accountInfo;

--- a/Plugin/LanguageServerProtocol.cpp
+++ b/Plugin/LanguageServerProtocol.cpp
@@ -44,7 +44,6 @@
 #include <wx/filesys.h>
 #include <wx/stc/stc.h>
 
-using namespace std;
 thread_local wxString emptyString;
 FileExtManager::FileType LanguageServerProtocol::workspace_file_type = FileExtManager::TypeOther;
 

--- a/Plugin/ThemeImporterManager.cpp
+++ b/Plugin/ThemeImporterManager.cpp
@@ -75,7 +75,7 @@ wxString ThemeImporterManager::Import(const wxString& theme_file)
 {
     // we add all or nothing
     wxString name;
-    vector<LexerConf::Ptr_t> lexers;
+    std::vector<LexerConf::Ptr_t> lexers;
     lexers.reserve(m_importers.size());
     for(auto importer : m_importers) {
         auto lexer = importer->Import(theme_file);

--- a/Plugin/ThemeImporterMarkdown.cpp
+++ b/Plugin/ThemeImporterMarkdown.cpp
@@ -47,8 +47,8 @@ LexerConf::Ptr_t ThemeImporterMarkdown::Import(const wxFileName& theme_file)
     AddProperty(lexer, wxSTC_MARKDOWN_CODEBK, "Code Block", m_editor);
 
     // bold font
-    const vector<int> emphasis = { wxSTC_MARKDOWN_STRONG1, wxSTC_MARKDOWN_STRONG2, wxSTC_MARKDOWN_EM1,
-                                   wxSTC_MARKDOWN_EM2 };
+    const std::vector<int> emphasis = { wxSTC_MARKDOWN_STRONG1, wxSTC_MARKDOWN_STRONG2, wxSTC_MARKDOWN_EM1,
+                                        wxSTC_MARKDOWN_EM2 };
     for(auto state : emphasis) {
         auto& prop = lexer->GetProperty(state);
         prop.SetBold(true);
@@ -59,8 +59,8 @@ LexerConf::Ptr_t ThemeImporterMarkdown::Import(const wxFileName& theme_file)
     prop_link.SetItalic(true);
 
     // headings
-    const vector<int> headings = { wxSTC_MARKDOWN_HEADER1, wxSTC_MARKDOWN_HEADER2, wxSTC_MARKDOWN_HEADER3,
-                                   wxSTC_MARKDOWN_HEADER4, wxSTC_MARKDOWN_HEADER5, wxSTC_MARKDOWN_HEADER6 };
+    const std::vector<int> headings = { wxSTC_MARKDOWN_HEADER1, wxSTC_MARKDOWN_HEADER2, wxSTC_MARKDOWN_HEADER3,
+                                        wxSTC_MARKDOWN_HEADER4, wxSTC_MARKDOWN_HEADER5, wxSTC_MARKDOWN_HEADER6 };
 
     for(auto state : headings) {
         auto& prop_heading = lexer->GetProperty(state);
@@ -69,7 +69,7 @@ LexerConf::Ptr_t ThemeImporterMarkdown::Import(const wxFileName& theme_file)
     }
 
     // code style
-    const vector<int> codes = { wxSTC_MARKDOWN_CODE2, wxSTC_MARKDOWN_CODE, wxSTC_MARKDOWN_CODEBK };
+    const std::vector<int> codes = { wxSTC_MARKDOWN_CODE2, wxSTC_MARKDOWN_CODE, wxSTC_MARKDOWN_CODEBK };
     bool is_dark = lexer->IsDark();
     for(auto state : codes) {
         auto& prop_code = lexer->GetProperty(state);

--- a/Plugin/bitmap_loader.h
+++ b/Plugin/bitmap_loader.h
@@ -36,8 +36,6 @@
 #include <wx/filename.h>
 #include <wx/imaglist.h>
 
-using namespace std;
-
 #ifndef __WXMSW__
 namespace std
 {
@@ -50,8 +48,8 @@ template <> struct hash<FileExtManager::FileType> {
 class WXDLLIMPEXP_SDK clMimeBitmaps
 {
     /// Maps between image-id : index in the list
-    unordered_map<int, int> m_fileIndexMap;
-    vector<wxBitmap> m_bitmaps;
+    std::unordered_map<int, int> m_fileIndexMap;
+    std::vector<wxBitmap> m_bitmaps;
 
 public:
     clMimeBitmaps();
@@ -69,8 +67,8 @@ public:
     void AddBitmap(const wxBitmap& bitmap, int type);
     void Clear();
     bool IsEmpty() const { return m_bitmaps.empty(); }
-    vector<wxBitmap>& GetBitmaps() { return m_bitmaps; }
-    const vector<wxBitmap>& GetBitmaps() const { return m_bitmaps; }
+    std::vector<wxBitmap>& GetBitmaps() { return m_bitmaps; }
+    const std::vector<wxBitmap>& GetBitmaps() const { return m_bitmaps; }
 };
 
 class WXDLLIMPEXP_SDK clBitmaps;
@@ -85,8 +83,8 @@ class WXDLLIMPEXP_SDK clBitmapList : public wxEvtHandler
         wxString name;
         int ref_count = 1;
     };
-    unordered_map<size_t, BmpInfo> m_bitmaps;
-    unordered_map<wxString, size_t> m_nameToIndex;
+    std::unordered_map<size_t, BmpInfo> m_bitmaps;
+    std::unordered_map<wxString, size_t> m_nameToIndex;
 
 protected:
     void OnBitmapsUpdated(clCommandEvent& event);
@@ -116,8 +114,8 @@ class WXDLLIMPEXP_SDK BitmapLoader : public wxEvtHandler
     friend class clBitmaps;
 
 public:
-    typedef unordered_map<FileExtManager::FileType, wxBitmap> BitmapMap_t;
-    typedef vector<wxBitmap> Vec_t;
+    typedef std::unordered_map<FileExtManager::FileType, wxBitmap> BitmapMap_t;
+    typedef std::vector<wxBitmap> Vec_t;
 
     enum eBitmapId {
         kClass = 1000,
@@ -149,9 +147,9 @@ public:
 
 protected:
     wxFileName m_zipPath;
-    unordered_map<wxString, wxBitmap> m_toolbarsBitmaps;
-    unordered_map<wxString, wxString> m_manifest;
-    unordered_map<FileExtManager::FileType, int> m_fileIndexMap;
+    std::unordered_map<wxString, wxBitmap> m_toolbarsBitmaps;
+    std::unordered_map<wxString, wxString> m_manifest;
+    std::unordered_map<FileExtManager::FileType, int> m_fileIndexMap;
     bool m_bMapPopulated;
     size_t m_toolbarIconSize;
     clMimeBitmaps m_mimeBitmaps;

--- a/Plugin/clCodeLiteRemoteProcess.cpp
+++ b/Plugin/clCodeLiteRemoteProcess.cpp
@@ -178,8 +178,8 @@ void clCodeLiteRemoteProcess::StartIfNotRunning()
         return;
     }
 
-    vector<wxString> command = { ssh_exe.GetFullPath(), "-o", "ServerAliveInterval=10", "-o",
-                                 "StrictHostKeyChecking=no" };
+    std::vector<wxString> command = { ssh_exe.GetFullPath(), "-o", "ServerAliveInterval=10", "-o",
+                                      "StrictHostKeyChecking=no" };
     command.push_back(m_account.GetUsername() + "@" + m_account.GetHost());
     command.push_back("-p");
     command.push_back(wxString() << m_account.GetPort());

--- a/Plugin/clComboBox.cpp
+++ b/Plugin/clComboBox.cpp
@@ -98,7 +98,7 @@ void clComboBox::DoCreate(const wxString& value)
     m_textCtrl = new clThemedTextCtrl(this, wxID_ANY, value);
     GetSizer()->Add(m_textCtrl, 1, wxEXPAND | wxALL, 1);
 
-    const wxString arrowSymbol = wxT(" \u25BC ");
+    const wxString arrowSymbol = " \u25BC ";
     m_button = new wxButton(this, wxID_ANY, arrowSymbol, wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
 
     wxColour text_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT);
@@ -245,7 +245,7 @@ void clComboBox::SetStringSelection(const wxString& text)
 
 void clComboBox::SetFocus() { m_textCtrl->SetFocus(); }
 
-void clComboBox::Append(const vector<wxString>& strings)
+void clComboBox::Append(const std::vector<wxString>& strings)
 {
     if(strings.empty()) {
         return;

--- a/Plugin/clComboBox.hpp
+++ b/Plugin/clComboBox.hpp
@@ -14,7 +14,6 @@
 #define INVALID_SIZE_T static_cast<size_t>(wxNOT_FOUND)
 
 class clThemedTextCtrl;
-using namespace std;
 
 class WXDLLIMPEXP_SDK clComboBox : public wxControl
 {
@@ -120,7 +119,7 @@ public:
      */
     void SetStringSelection(const wxString& text);
 
-    void Append(const vector<wxString>& strings);
+    void Append(const std::vector<wxString>& strings);
     void Append(const wxArrayString& strings);
     size_t Append(const wxString& text);
     /**

--- a/Plugin/clControlWithItems.cpp
+++ b/Plugin/clControlWithItems.cpp
@@ -252,7 +252,7 @@ void clControlWithItems::RenderItems(wxDC& dc, const clRowEntry::Vec_t& items)
 
     // Did the user pass wxTR_COLUMN_WIDTH_NEVER_SHRINKS or wxDV_DYNAMIC_COLUMN_WIDTH ?
     if(m_recalcColumnWidthOnPaint) {
-        vector<size_t> max_widths;
+        std::vector<size_t> max_widths;
 
         // calculate the width of the cells
         for(size_t i = 0; i < items.size(); ++i) {

--- a/Plugin/clEnhancedToolBar.hpp
+++ b/Plugin/clEnhancedToolBar.hpp
@@ -3,11 +3,10 @@
 
 #include "clToolBar.h"
 #include "clToolBarButtonBase.h"
+#include "codelite_exports.h"
 
-#include <codelite_exports.h>
 #include <unordered_map>
 
-using namespace std;
 class WXDLLIMPEXP_SDK clEnhancedToolBar : public clToolBar
 {
 public:
@@ -37,7 +36,7 @@ protected:
     };
 
 protected:
-    unordered_map<wxWindowID, ButtonState> m_buttons;
+    std::unordered_map<wxWindowID, ButtonState> m_buttons;
     void OnButtonClicked(wxCommandEvent& event);
 
 public:

--- a/Plugin/clHeaderBar.cpp
+++ b/Plugin/clHeaderBar.cpp
@@ -2,8 +2,8 @@
 
 #include "clControlWithItems.h"
 #include "clScrolledPanel.h"
+#include "file_logger.h"
 
-#include <file_logger.h>
 #include <wx/cursor.h>
 #include <wx/dcbuffer.h>
 #include <wx/dcclient.h>
@@ -251,7 +251,7 @@ void clHeaderBar::DoCancelDrag()
     }
 }
 
-void clHeaderBar::SetColumnsWidth(const vector<size_t>& v_width)
+void clHeaderBar::SetColumnsWidth(const std::vector<size_t>& v_width)
 {
     if(v_width.size() != m_columns.size()) {
         return;

--- a/Plugin/clHeaderBar.h
+++ b/Plugin/clHeaderBar.h
@@ -7,8 +7,6 @@
 #include <vector>
 #include <wx/panel.h>
 
-using namespace std;
-
 class clControlWithItems;
 class WXDLLIMPEXP_SDK clHeaderBar : public wxPanel
 {
@@ -64,7 +62,7 @@ public:
     size_t size() const { return m_columns.size(); }
     size_t GetCount() const { return size(); }
 
-    void SetColumnsWidth(const vector<size_t>& v_width);
+    void SetColumnsWidth(const std::vector<size_t>& v_width);
 
     /**
      * @brief Return the header bar height, taking into consideration all columns

--- a/Plugin/clRemoteDirCtrl.hpp
+++ b/Plugin/clRemoteDirCtrl.hpp
@@ -10,7 +10,6 @@
 
 #include <wx/panel.h>
 
-using namespace std;
 class clRemoteDirCtrlItemData;
 class WXDLLIMPEXP_SDK clRemoteDirCtrl : public wxPanel
 {

--- a/Plugin/clRowEntry.cpp
+++ b/Plugin/clRowEntry.cpp
@@ -376,9 +376,9 @@ void clRowEntry::ClearRects()
     m_rowRect = wxRect();
 }
 
-vector<size_t> clRowEntry::GetColumnWidths(wxWindow* win, wxDC& dc)
+std::vector<size_t> clRowEntry::GetColumnWidths(wxWindow* win, wxDC& dc)
 {
-    vector<size_t> v;
+    std::vector<size_t> v;
     wxRect rowRect = GetItemRect();
     int itemIndent = IsListItem() ? clHeaderItem::X_SPACER : (GetIndentsCount() * m_tree->GetIndent());
     wxFont f = m_tree->GetDefaultFont();

--- a/Plugin/clRowEntry.h
+++ b/Plugin/clRowEntry.h
@@ -18,8 +18,6 @@ class clSearchText;
 class clTreeCtrlModel;
 class clTreeCtrl;
 
-using namespace std;
-
 enum clTreeCtrlNodeFlags {
     kNF_FontBold = (1 << 0),
     kNF_FontItalic = (1 << 1),
@@ -151,7 +149,7 @@ public:
      */
     void DeleteAllChildren();
     void Render(wxWindow* win, wxDC& dc, const clColours& colours, int row_index, clSearchText* searcher);
-    vector<size_t> GetColumnWidths(wxWindow* win, wxDC& dc);
+    std::vector<size_t> GetColumnWidths(wxWindow* win, wxDC& dc);
     void SetHovered(bool b) { SetFlag(kNF_Hovered, b); }
     bool IsHovered() const { return m_flags & kNF_Hovered; }
 

--- a/Plugin/clSFTPManager.cpp
+++ b/Plugin/clSFTPManager.cpp
@@ -13,8 +13,6 @@
 #include "ieditor.h"
 #include "imanager.h"
 #include "macros.h"
-#include "wx/debug.h"
-#include "wx/thread.h"
 
 #include <condition_variable>
 #include <functional>
@@ -22,9 +20,11 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+#include <wx/debug.h>
 #include <wx/event.h>
 #include <wx/msgdlg.h>
 #include <wx/stc/stc.h>
+#include <wx/thread.h>
 #include <wx/utils.h>
 
 wxDEFINE_EVENT(wxEVT_SFTP_ASYNC_SAVE_COMPLETED, clCommandEvent);
@@ -724,7 +724,7 @@ void clSFTPManager::StartWorkerThread()
     }
 
     m_worker_thread = new std::thread(
-        [](SyncQueue<std::function<void()>>& Q, atomic_bool& shutdown) {
+        [](SyncQueue<std::function<void()>>& Q, std::atomic_bool& shutdown) {
             while(!shutdown.load()) {
                 auto work_func = Q.pop_front();
                 if(work_func == nullptr) {

--- a/Plugin/clSFTPManager.hpp
+++ b/Plugin/clSFTPManager.hpp
@@ -36,7 +36,7 @@ protected:
     bool m_eventsConnected = true;
     std::thread* m_worker_thread = nullptr;
     SyncQueue<std::function<void()>> m_q;
-    atomic_bool m_shutdown;
+    std::atomic_bool m_shutdown;
     wxString m_lastError;
     std::unordered_map<wxString, saved_file> m_downloadedFileToAccount;
 

--- a/Plugin/globals.cpp
+++ b/Plugin/globals.cpp
@@ -2229,7 +2229,8 @@ static void DoSetDialogSize(wxDialog* win, double factor)
 #endif
 }
 
-pair<wxString, wxString> clRemoteFolderSelector(const wxString& title, const wxString& accountName, wxWindow* parent)
+std::pair<wxString, wxString> clRemoteFolderSelector(const wxString& title, const wxString& accountName,
+                                                     wxWindow* parent)
 {
 #if USE_SFTP
     SFTPBrowserDlg dlg(parent, title, wxEmptyString, clSFTP::SFTP_BROWSE_FOLDERS, accountName);
@@ -2242,8 +2243,8 @@ pair<wxString, wxString> clRemoteFolderSelector(const wxString& title, const wxS
 #endif
 }
 
-pair<wxString, wxString> clRemoteFileSelector(const wxString& title, const wxString& accountName,
-                                              const wxString& filter, wxWindow* parent)
+std::pair<wxString, wxString> clRemoteFileSelector(const wxString& title, const wxString& accountName,
+                                                   const wxString& filter, wxWindow* parent)
 {
 #if USE_SFTP
     SFTPBrowserDlg dlg(parent, title, filter, clSFTP::SFTP_BROWSE_FOLDERS | clSFTP::SFTP_BROWSE_FILES, accountName);

--- a/Plugin/globals.h
+++ b/Plugin/globals.h
@@ -293,7 +293,7 @@ WXDLLIMPEXP_SDK void GetProjectTemplateList(std::list<ProjectPtr>& list);
  * @brief set the native Windows theme for the application
  * @param win [input]
  */
-WXDLLIMPEXP_SDK void MSWSetNativeTheme(wxWindow* win, const wxString& theme = wxT("Explorer"));
+WXDLLIMPEXP_SDK void MSWSetNativeTheme(wxWindow* win, const wxString& theme = "Explorer");
 
 /**
  * @brief under Windows 10 and later, enable dark mode controls (where it is implemented)
@@ -313,7 +313,7 @@ WXDLLIMPEXP_SDK bool MakeRelativeIfSensible(wxFileName& fn, const wxString& refe
  * @brief joins array element into a string using 'glue' as the array elements
  * separator
  */
-WXDLLIMPEXP_SDK wxString wxImplode(const wxArrayString& arr, const wxString& glue = wxT("\n"));
+WXDLLIMPEXP_SDK wxString wxImplode(const wxArrayString& arr, const wxString& glue = "\n");
 
 /**
  * @brief executes a command under the proper shell and return string as the output
@@ -525,16 +525,16 @@ WXDLLIMPEXP_SDK wxString clGetTextFromUser(const wxString& title, const wxString
 /**
  * @brief similar to wxDirSelector, but on a remote machine
  */
-WXDLLIMPEXP_SDK pair<wxString, wxString>
+WXDLLIMPEXP_SDK std::pair<wxString, wxString>
 clRemoteFolderSelector(const wxString& title, const wxString& accountName = wxEmptyString, wxWindow* parent = NULL);
 
 /**
  * @brief similar to wxFileSelector, but on a remote machine
  */
-WXDLLIMPEXP_SDK pair<wxString, wxString> clRemoteFileSelector(const wxString& title,
-                                                              const wxString& accountName = wxEmptyString,
-                                                              const wxString& filter = wxEmptyString,
-                                                              wxWindow* parent = NULL);
+WXDLLIMPEXP_SDK std::pair<wxString, wxString> clRemoteFileSelector(const wxString& title,
+                                                                   const wxString& accountName = wxEmptyString,
+                                                                   const wxString& filter = wxEmptyString,
+                                                                   wxWindow* parent = NULL);
 /**
  * @brief return the instance to the plugin manager. A convinience method
  */

--- a/Plugin/md5.cpp
+++ b/Plugin/md5.cpp
@@ -86,7 +86,7 @@ void MD5::update(uint1* input, uint4 input_length)
     uint4 buffer_space; // how much space is left in buffer
 
     if(finalized) { // so we can't update!
-        cerr << "MD5::update:  Can't update a finalized digest!" << endl;
+        std::cerr << "MD5::update:  Can't update a finalized digest!" << std::endl;
         return;
     }
 
@@ -94,8 +94,9 @@ void MD5::update(uint1* input, uint4 input_length)
     buffer_index = (unsigned int)((count[0] >> 3) & 0x3F);
 
     // Update number of bits
-    if((count[0] += ((uint4)input_length << 3)) < ((uint4)input_length << 3))
+    if((count[0] += ((uint4)input_length << 3)) < ((uint4)input_length << 3)) {
         count[1]++;
+    }
 
     count[1] += ((uint4)input_length >> 29);
 
@@ -108,8 +109,9 @@ void MD5::update(uint1* input, uint4 input_length)
         transform(buffer);
 
         // now, transform each 64-byte piece of the input, bypassing the buffer
-        for(input_index = buffer_space; input_index + 63 < input_length; input_index += 64)
+        for(input_index = buffer_space; input_index + 63 < input_length; input_index += 64) {
             transform(input + input_index);
+        }
 
         buffer_index = 0; // so we can buffer remaining
     } else
@@ -128,8 +130,9 @@ void MD5::update(FILE* file)
     unsigned char buffer[BUF_SIZE];
     int len;
 
-    while((len = fread(buffer, 1, BUF_SIZE, file)))
+    while((len = fread(buffer, 1, BUF_SIZE, file))) {
         update(buffer, len);
+    }
 
     fclose(file);
 }
@@ -137,7 +140,7 @@ void MD5::update(FILE* file)
 // MD5 update for istreams.
 // Like update for files; see above.
 
-void MD5::update(istream& stream)
+void MD5::update(std::istream& stream)
 {
 
     char buffer[BUF_SIZE];
@@ -153,7 +156,7 @@ void MD5::update(istream& stream)
 // MD5 update for ifstreams.
 // Like update for files; see above.
 
-void MD5::update(ifstream& stream)
+void MD5::update(std::ifstream& stream)
 {
     char buffer[BUF_SIZE];
     int len;
@@ -178,7 +181,7 @@ void MD5::finalize()
                                  0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
     if(finalized) {
-        cerr << "MD5::finalize:  Already finalized this digest!" << endl;
+        std::cerr << "MD5::finalize:  Already finalized this digest!" << std::endl;
         return;
     }
 
@@ -210,7 +213,7 @@ MD5::MD5(FILE* file)
     finalize();
 }
 
-MD5::MD5(istream& stream)
+MD5::MD5(std::istream& stream)
 {
 
     init(); // must called by all constructors
@@ -218,7 +221,7 @@ MD5::MD5(istream& stream)
     finalize();
 }
 
-MD5::MD5(ifstream& stream)
+MD5::MD5(std::ifstream& stream)
 {
 
     init(); // must called by all constructors
@@ -251,20 +254,21 @@ const char* MD5::hex_digest()
     ::memset(hex_digest_buff, 0, sizeof(hex_digest_buff));
 
     if(!finalized) {
-        cerr << "MD5::hex_digest:  Can't get digest if you haven't "
-             << "finalized the digest!" << endl;
+        std::cerr << "MD5::hex_digest:  Can't get digest if you haven't "
+                  << "finalized the digest!" << std::endl;
         return hex_digest_buff;
     }
 
-    for(int i = 0; i < 16; i++)
+    for(int i = 0; i < 16; i++) {
         sprintf(hex_digest_buff + (i * 2), "%02x", digest[i]);
+    }
 
     hex_digest_buff[32] = '\0';
 
     return hex_digest_buff;
 }
 
-ostream& operator<<(ostream& stream, MD5 context)
+std::ostream& operator<<(std::ostream& stream, MD5 context)
 {
 
     stream << context.hex_digest();
@@ -422,9 +426,10 @@ void MD5::decode(uint4* output, uint1* input, uint4 len)
 
     unsigned int i, j;
 
-    for(i = 0, j = 0; j < len; i++, j += 4)
+    for(i = 0, j = 0; j < len; i++, j += 4) {
         output[i] = ((uint4)input[j]) | (((uint4)input[j + 1]) << 8) | (((uint4)input[j + 2]) << 16) |
                     (((uint4)input[j + 3]) << 24);
+    }
 }
 
 // Note: Replace "for loop" with standard memcpy if possible.
@@ -433,8 +438,9 @@ void MD5::memcpy(uint1* output, uint1* input, uint4 len)
 
     unsigned int i;
 
-    for(i = 0; i < len; i++)
+    for(i = 0; i < len; i++) {
         output[i] = input[i];
+    }
 }
 
 // Note: Replace "for loop" with standard memset if possible.
@@ -443,8 +449,9 @@ void MD5::memset(uint1* output, uint1 value, uint4 len)
 
     unsigned int i;
 
-    for(i = 0; i < len; i++)
+    for(i = 0; i < len; i++) {
         output[i] = value;
+    }
 }
 
 // ROTATE_LEFT rotates x left n bits.

--- a/Plugin/md5_header.h
+++ b/Plugin/md5_header.h
@@ -68,7 +68,7 @@ documentation and/or software.
 #include <fstream>
 #include <iostream>
 #include <stdio.h>
-using namespace std;
+
 class MD5
 {
 
@@ -76,22 +76,22 @@ public:
     // methods for controlled operation:
     MD5(); // simple initializer
     void update(unsigned char* input, unsigned int input_length);
-    void update(istream& stream);
+    void update(std::istream& stream);
     void update(FILE* file);
-    void update(ifstream& stream);
+    void update(std::ifstream& stream);
     void finalize();
 
     // constructors for special circumstances.  All these constructors finalize
     // the MD5 context.
     MD5(unsigned char* string); // digest string, finalize
-    MD5(istream& stream);       // digest stream, finalize
+    MD5(std::istream& stream);  // digest stream, finalize
     MD5(FILE* file);            // digest file, close, finalize
-    MD5(ifstream& stream);      // digest stream, close, finalize
+    MD5(std::ifstream& stream); // digest stream, close, finalize
 
     // methods to acquire finalized result
     // unsigned char    *raw_digest ();  // digest as a 16-byte binary array
     const char* hex_digest(); // digest as a 33-byte ascii-hex string
-    friend ostream& operator<<(ostream&, MD5 context);
+    friend std::ostream& operator<<(std::ostream&, MD5 context);
 
 private:
     // first, some types:

--- a/Plugin/open_resource_dialog.cpp
+++ b/Plugin/open_resource_dialog.cpp
@@ -235,11 +235,12 @@ void OpenResourceDialog::DoPopulateList()
 
 void OpenResourceDialog::OnWorkspaceSymbols(LSPEvent& event) { DoPopulateTags(event.GetSymbolsInformation()); }
 
-void OpenResourceDialog::DoPopulateTags(const vector<LSP::SymbolInformation>& symbols)
+void OpenResourceDialog::DoPopulateTags(const std::vector<LSP::SymbolInformation>& symbols)
 {
     // Next, add the tags
-    if(m_userFilters.IsEmpty() || symbols.empty())
+    if(m_userFilters.IsEmpty() || symbols.empty()) {
         return;
+    }
 
     for(const LSP::SymbolInformation& symbol : symbols) {
         if(!MatchesFilter(symbol.GetName())) {
@@ -268,8 +269,9 @@ void OpenResourceDialog::DoPopulateTags(const vector<LSP::SymbolInformation>& sy
 void OpenResourceDialog::DoPopulateWorkspaceFile()
 {
     // do we need to include files?
-    if(!m_filters.IsEmpty() && m_filters.Index(KIND_FILE) == wxNOT_FOUND)
+    if(!m_filters.IsEmpty() && m_filters.Index(KIND_FILE) == wxNOT_FOUND) {
         return;
+    }
 
     if(!m_userFilters.IsEmpty()) {
 
@@ -278,13 +280,14 @@ void OpenResourceDialog::DoPopulateWorkspaceFile()
         int counter = 0;
         for(; (iter != m_files.end()) && (counter < maxFileSize); iter++) {
             const wxString& fullpath = iter->second;
-            if(!MatchesFilter(fullpath))
+            if(!MatchesFilter(fullpath)) {
                 continue;
+            }
 
             wxFileName fn(iter->second);
             int imgId = clGetManager()->GetStdIcons()->GetMimeImageId(fn.GetFullName());
             DoAppendLine(fn.GetFullName(), iter->second, false,
-                         new OpenResourceDialogItemData(iter->second, -1, wxT(""), fn.GetFullName(), wxT("")), imgId);
+                         new OpenResourceDialogItemData(iter->second, -1, "", fn.GetFullName(), ""), imgId);
             ++counter;
         }
     }
@@ -309,8 +312,9 @@ void OpenResourceDialog::OpenSelection(const OpenResourceDialogItemData& selecti
     wxString file_path = selection.m_file;
     clCommandEvent activateEvent(wxEVT_TREE_ITEM_FILE_ACTIVATED);
     activateEvent.SetFileName(file_path);
-    if(EventNotifier::Get()->ProcessEvent(activateEvent))
+    if(EventNotifier::Get()->ProcessEvent(activateEvent)) {
         return;
+    }
 
     clDEBUG() << "Opening editor:" << selection.m_file << ":" << selection.m_line << ":" << selection.m_column << endl;
 
@@ -370,7 +374,7 @@ void OpenResourceDialog::DoAppendLine(const wxString& name, const wxString& full
     clientData->m_impl = boldFont;
     wxVector<wxVariant> cols;
     cols.push_back(::MakeBitmapIndexText(prefix + name, imgid));
-    cols.push_back(clientData->m_impl ? wxString(wxT("\u274C")) : wxString());
+    cols.push_back(clientData->m_impl ? wxString("\u274C") : wxString());
     cols.push_back(fullname);
     m_dataview->AppendItem(cols, (wxUIntPtr)clientData);
 }

--- a/Plugin/open_resource_dialog.h
+++ b/Plugin/open_resource_dialog.h
@@ -57,11 +57,11 @@ public:
 
 public:
     OpenResourceDialogItemData()
-        : m_file(wxT(""))
+        : m_file("")
         , m_line(wxNOT_FOUND)
-        , m_pattern(wxT(""))
-        , m_name(wxT(""))
-        , m_scope(wxT(""))
+        , m_pattern("")
+        , m_name("")
+        , m_scope("")
         , m_impl(false)
     {
     }
@@ -112,7 +112,7 @@ protected:
     void DoPopulateList();
     void DoPopulateWorkspaceFile();
     bool MatchesFilter(const wxString& name);
-    void DoPopulateTags(const vector<LSP::SymbolInformation>& symbols);
+    void DoPopulateTags(const std::vector<LSP::SymbolInformation>& symbols);
     void DoSelectItem(const wxDataViewItem& item);
     void Clear();
     void DoAppendLine(const wxString& name, const wxString& fullname, bool boldFont,

--- a/Plugin/sftp_item_comparator.hpp
+++ b/Plugin/sftp_item_comparator.hpp
@@ -31,7 +31,6 @@
 #include <vector>
 #include <wx/treectrl.h>
 
-using namespace std;
 class WXDLLIMPEXP_SDK clRemoteDirCtrlItemData : public wxTreeItemData
 {
 public:
@@ -48,7 +47,7 @@ protected:
     size_t m_flags = kFile;
 
 public:
-    typedef vector<clRemoteDirCtrlItemData*> Vec_t;
+    typedef std::vector<clRemoteDirCtrlItemData*> Vec_t;
 
 public:
     clRemoteDirCtrlItemData(const wxString& path)

--- a/Remoty/RemotyConfig.cpp
+++ b/Remoty/RemotyConfig.cpp
@@ -1,5 +1,7 @@
 #include "RemotyConfig.hpp"
+
 #include "cl_config.h"
+
 #include <algorithm>
 
 namespace
@@ -13,9 +15,9 @@ RemotyConfig::RemotyConfig() {}
 
 RemotyConfig::~RemotyConfig() {}
 
-vector<RemoteWorkspaceInfo> RemotyConfig::GetRecentWorkspaces() const
+std::vector<RemoteWorkspaceInfo> RemotyConfig::GetRecentWorkspaces() const
 {
-    vector<RemoteWorkspaceInfo> res;
+    std::vector<RemoteWorkspaceInfo> res;
     clConfig::Get().Read(REMOTY_RECENT_WORKSPACES, [&res](const JSONItem& item) {
         size_t count = item.arraySize();
         if(count) {
@@ -26,7 +28,7 @@ vector<RemoteWorkspaceInfo> RemotyConfig::GetRecentWorkspaces() const
             RemoteWorkspaceInfo d;
             d.account = n["account"].toString();
             d.path = n["path"].toString();
-            res.emplace_back(move(d));
+            res.emplace_back(std::move(d));
         }
     });
     return res;
@@ -46,7 +48,7 @@ void RemotyConfig::UpdateRecentWorkspaces(const RemoteWorkspaceInfo& workspaceIn
         curitems.erase(where);
     }
 
-    curitems.insert(curitems.begin(), move(workspaceInfo));
+    curitems.insert(curitems.begin(), std::move(workspaceInfo));
     if(curitems.size() > MAX_ITEMS) {
         // shrink the list
         curitems.resize(MAX_ITEMS);

--- a/Remoty/RemotyConfig.hpp
+++ b/Remoty/RemotyConfig.hpp
@@ -5,7 +5,6 @@
 #include <wx/arrstr.h>
 #include <wx/string.h>
 
-using namespace std;
 struct RemoteWorkspaceInfo {
     wxString account;
     wxString path;
@@ -21,7 +20,7 @@ public:
      * @brief read the recent workspaces from the file system
      * @return
      */
-    vector<RemoteWorkspaceInfo> GetRecentWorkspaces() const;
+    std::vector<RemoteWorkspaceInfo> GetRecentWorkspaces() const;
 
     /**
      * @brief update recent workspaces with workspace

--- a/Remoty/RemotySwitchToWorkspaceDlg.cpp
+++ b/Remoty/RemotySwitchToWorkspaceDlg.cpp
@@ -1,12 +1,14 @@
 #include "RemotySwitchToWorkspaceDlg.h"
+
 #include "RemotyConfig.hpp"
 #include "SFTPBrowserDlg.h"
 #include "cl_config.h"
 #include "file_logger.h"
 #include "fileutils.h"
 #include "globals.h"
-#include "wx/dirdlg.h"
-#include "wx/filedlg.h"
+
+#include <wx/dirdlg.h>
+#include <wx/filedlg.h>
 #include <wx/tokenzr.h>
 
 namespace
@@ -60,7 +62,7 @@ void RemotySwitchToWorkspaceDlg::OnBrowse(wxCommandEvent& event)
         UpdateSelection(m_comboBoxPath, path);
     } else {
         wxString path = ::wxFileSelector(_("Choose a file"), wxEmptyString, wxEmptyString, wxEmptyString,
-                                         wxT("CodeLite Workspace files (*.workspace)|*.workspace"));
+                                         "CodeLite Workspace files (*.workspace)|*.workspace");
         if(path.empty()) {
             return;
         }
@@ -109,7 +111,7 @@ void RemotySwitchToWorkspaceDlg::InitialiseDialog()
         }
     } else {
         // remote workspaces
-        set<wxString> S;
+        std::set<wxString> S;
         if(m_remoteWorkspaces.empty()) {
             return;
         }

--- a/Remoty/RemotySwitchToWorkspaceDlg.h
+++ b/Remoty/RemotySwitchToWorkspaceDlg.h
@@ -6,10 +6,9 @@
 #include <unordered_map>
 #include <vector>
 
-using namespace std;
 class RemotySwitchToWorkspaceDlg : public RemotySwitchToWorkspaceDlgBase
 {
-    vector<RemoteWorkspaceInfo> m_remoteWorkspaces;
+    std::vector<RemoteWorkspaceInfo> m_remoteWorkspaces;
 
 public:
     RemotySwitchToWorkspaceDlg(wxWindow* parent);

--- a/Remoty/RemotyWorkspace.cpp
+++ b/Remoty/RemotyWorkspace.cpp
@@ -389,7 +389,7 @@ void RemotyWorkspace::OnCustomTargetMenu(clContextMenuEvent& event)
     wxArrayString arrTargets;
     const auto& targets = m_settings.GetSelectedConfig()->GetBuildTargets();
 
-    unordered_map<int, wxString> M;
+    std::unordered_map<int, wxString> M;
     for(const auto& vt : targets) {
         const wxString& name = vt.first;
         int menuId = wxXmlResource::GetXRCID(vt.first);
@@ -753,7 +753,7 @@ void RemotyWorkspace::DoConfigureLSP(const LSPParams& lsp)
 IProcess* RemotyWorkspace::DoRunSSHProcess(const wxString& scriptContent, bool sync)
 {
     wxString path = UploadScript(scriptContent);
-    vector<wxString> args = { "/bin/bash", path };
+    std::vector<wxString> args = { "/bin/bash", path };
     size_t flags = IProcessCreateDefault | IProcessCreateSSH;
     if(sync) {
         flags |= IProcessCreateSync;

--- a/Remoty/clRemoteTerminal.cpp
+++ b/Remoty/clRemoteTerminal.cpp
@@ -29,7 +29,7 @@ bool clRemoteTerminal::Start()
         return false;
     }
 
-    vector<wxString> command = { "ssh", "-o", "ServerAliveInterval=10", "-o", "StrictHostKeyChecking=no" };
+    std::vector<wxString> command = { "ssh", "-o", "ServerAliveInterval=10", "-o", "StrictHostKeyChecking=no" };
     command.push_back(m_account.GetUsername() + "@" + m_account.GetHost());
     command.push_back("-t");
     command.push_back("-p");
@@ -60,7 +60,7 @@ const wxString& clRemoteTerminal::ReadTty()
         return empty_string;
     }
 
-    vector<wxString> command = { "cat", m_tty_file };
+    std::vector<wxString> command = { "cat", m_tty_file };
     IProcess::Ptr_t proc(::CreateAsyncProcess(this, command, IProcessCreateSSH | IProcessCreateSync, wxEmptyString,
                                               nullptr, m_account.GetAccountName()));
 

--- a/Remoty/clRemoteTerminal.hpp
+++ b/Remoty/clRemoteTerminal.hpp
@@ -3,10 +3,10 @@
 
 #include "cl_command_event.h"
 #include "ssh_account_info.h"
+
 #include <memory>
 #include <wx/event.h>
 
-using namespace std;
 class clRemoteTerminal : public wxEvtHandler
 {
     IProcess* m_proc = nullptr;
@@ -15,7 +15,7 @@ class clRemoteTerminal : public wxEvtHandler
     SSHAccountInfo m_account;
 
 public:
-    typedef unique_ptr<clRemoteTerminal> ptr_t;
+    typedef std::unique_ptr<clRemoteTerminal> ptr_t;
 
 public:
     clRemoteTerminal(const SSHAccountInfo& account);

--- a/codelite-generate-themes/codelite-generate-themes/main.cpp
+++ b/codelite-generate-themes/codelite-generate-themes/main.cpp
@@ -20,8 +20,6 @@
 #include <gtk/gtk.h>
 #endif
 
-using namespace std;
-
 namespace
 {
 void import_files(const wxString& input_dir, const wxString& output_dir)

--- a/ctagsd/lib/Channel.cpp
+++ b/ctagsd/lib/Channel.cpp
@@ -9,8 +9,6 @@
 #include <sstream>
 #include <string>
 
-using namespace std;
-
 ChannelSocket::ChannelSocket(const wxString& ip, int port)
     : m_ip(ip)
     , m_port(port)
@@ -59,7 +57,7 @@ bool ChannelSocket::write_reply(const wxString& message)
     return true;
 }
 
-unique_ptr<JSON> ChannelSocket::read_message()
+std::unique_ptr<JSON> ChannelSocket::read_message()
 {
     while(true) {
         auto msg = LSP::Message::GetJSONPayload(m_buffer);

--- a/ctagsd/lib/Channel.hpp
+++ b/ctagsd/lib/Channel.hpp
@@ -7,8 +7,6 @@
 #include <memory>
 #include <wx/string.h>
 
-using namespace std;
-
 enum class eReadSome {
     kTimeout,
     kError,
@@ -21,9 +19,9 @@ public:
     virtual bool write_reply(const wxString& message) = 0;
     virtual bool write_reply(const JSONItem& response) = 0;
     virtual bool write_reply(const JSON& response) = 0;
-    virtual unique_ptr<JSON> read_message() = 0;
+    virtual std::unique_ptr<JSON> read_message() = 0;
     virtual void open() = 0;
-    typedef shared_ptr<Channel> ptr_t;
+    typedef std::shared_ptr<Channel> ptr_t;
 };
 
 // socket based channel
@@ -45,6 +43,6 @@ public:
     bool write_reply(const wxString& message) override;
     bool write_reply(const JSONItem& response) override;
     bool write_reply(const JSON& response) override;
-    unique_ptr<JSON> read_message() override;
+    std::unique_ptr<JSON> read_message() override;
 };
 #endif // Channel_HPP

--- a/ctagsd/lib/LSPUtils.cpp
+++ b/ctagsd/lib/LSPUtils.cpp
@@ -10,7 +10,7 @@ LSPUtils::LSPUtils() {}
 
 LSPUtils::~LSPUtils() {}
 
-void LSPUtils::encode_semantic_tokens(const vector<TokenWrapper>& tokens_vec, vector<int>* encoded_arr)
+void LSPUtils::encode_semantic_tokens(const std::vector<TokenWrapper>& tokens_vec, std::vector<int>* encoded_arr)
 {
     TokenWrapper dummy;
     dummy.token = SimpleTokenizer::Token(0, 0, 0, 0);
@@ -19,7 +19,7 @@ void LSPUtils::encode_semantic_tokens(const vector<TokenWrapper>& tokens_vec, ve
     const auto* prev_token_ptr = &dummy.token;
     for(size_t i = 0; i < tokens_vec.size(); ++i) {
         auto* current_token_ptr = &tokens_vec[i].token;
-        array<int, 5> info;
+        std::array<int, 5> info;
 
         bool changed_line = prev_token_ptr->line() != current_token_ptr->line();
         if(changed_line) {
@@ -112,10 +112,10 @@ LSP::CompletionItem::eCompletionItemKind LSPUtils::get_completion_kind(const Tag
     return kind;
 }
 
-vector<LSP::SymbolInformation> LSPUtils::to_symbol_information_array(const vector<TagEntryPtr>& tags,
-                                                                     bool for_tree_view)
+std::vector<LSP::SymbolInformation> LSPUtils::to_symbol_information_array(const std::vector<TagEntryPtr>& tags,
+                                                                          bool for_tree_view)
 {
-    vector<LSP::SymbolInformation> result;
+    std::vector<LSP::SymbolInformation> result;
     result.reserve(tags.size());
 
     wxStringSet_t parent_seen;
@@ -127,9 +127,10 @@ vector<LSP::SymbolInformation> LSPUtils::to_symbol_information_array(const vecto
     return result;
 }
 
-vector<LSP::SymbolInformation> LSPUtils::to_symbol_information_array(const vector<TagEntry>& tags, bool for_tree_view)
+std::vector<LSP::SymbolInformation> LSPUtils::to_symbol_information_array(const std::vector<TagEntry>& tags,
+                                                                          bool for_tree_view)
 {
-    vector<LSP::SymbolInformation> result;
+    std::vector<LSP::SymbolInformation> result;
     result.reserve(tags.size());
 
     wxStringSet_t parent_seen;
@@ -142,7 +143,7 @@ vector<LSP::SymbolInformation> LSPUtils::to_symbol_information_array(const vecto
 }
 
 void LSPUtils::to_symbol_information(const TagEntry* tag, LSP::SymbolInformation& symbol_information,
-                                     unordered_set<wxString>* parents_seen)
+                                     std::unordered_set<wxString>* parents_seen)
 {
     if(parents_seen && tag->IsContainer()) {
         parents_seen->insert(tag->GetName());

--- a/ctagsd/lib/LSPUtils.hpp
+++ b/ctagsd/lib/LSPUtils.hpp
@@ -5,10 +5,9 @@
 #include "LSP/basic_types.h"
 #include "SimpleTokenizer.hpp"
 #include "entry.h"
+
 #include <unordered_set>
 #include <vector>
-
-using namespace std;
 
 enum eTokenType {
     TYPE_VARIABLE,
@@ -25,18 +24,19 @@ class LSPUtils
 {
 private:
     static void to_symbol_information(const TagEntry* tag, LSP::SymbolInformation& symbol_information,
-                                      unordered_set<wxString>* parents_seen = nullptr);
+                                      std::unordered_set<wxString>* parents_seen = nullptr);
 
 public:
     LSPUtils();
     ~LSPUtils();
 
-    static void encode_semantic_tokens(const vector<TokenWrapper>& tokens_vec, vector<int>* encoded_arr);
+    static void encode_semantic_tokens(const std::vector<TokenWrapper>& tokens_vec, std::vector<int>* encoded_arr);
     static LSP::eSymbolKind get_symbol_kind(const TagEntry* tag);
     static LSP::CompletionItem::eCompletionItemKind get_completion_kind(const TagEntry* tag);
-    static vector<LSP::SymbolInformation> to_symbol_information_array(const vector<TagEntryPtr>& tags,
-                                                                      bool for_tree_view);
-    static vector<LSP::SymbolInformation> to_symbol_information_array(const vector<TagEntry>& tags, bool for_tree_view);
+    static std::vector<LSP::SymbolInformation> to_symbol_information_array(const std::vector<TagEntryPtr>& tags,
+                                                                           bool for_tree_view);
+    static std::vector<LSP::SymbolInformation> to_symbol_information_array(const std::vector<TagEntry>& tags,
+                                                                           bool for_tree_view);
 };
 
 #endif // LSPUTILS_HPP

--- a/ctagsd/lib/ParseThread.hpp
+++ b/ctagsd/lib/ParseThread.hpp
@@ -13,21 +13,20 @@
 #include <wx/string.h>
 #include <wx/thread.h>
 
-using namespace std;
 enum class eParseThreadCallbackRC {
     RC_SUCCESS,
     RC_EXIT,
 };
 
-typedef function<eParseThreadCallbackRC()> ParseThreadTaskFunc;
+typedef std::function<eParseThreadCallbackRC()> ParseThreadTaskFunc;
 
 class ParseThread
 {
-    thread* m_change_thread = nullptr;
-    mutex m_mutex;
-    condition_variable m_cv;
-    atomic_bool m_shutdown;
-    vector<ParseThreadTaskFunc> m_queue;
+    std::thread* m_change_thread = nullptr;
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+    std::atomic_bool m_shutdown;
+    std::vector<ParseThreadTaskFunc> m_queue;
     wxString m_settings_folder;
     wxString m_indexer_path;
 

--- a/ctagsd/lib/ProtocolHandler.cpp
+++ b/ctagsd/lib/ProtocolHandler.cpp
@@ -43,7 +43,7 @@ FileLogger& operator<<(FileLogger& logger, const TagEntry& tag)
     return logger;
 }
 
-FileLogger& operator<<(FileLogger& logger, const vector<TagEntryPtr>& tags)
+FileLogger& operator<<(FileLogger& logger, const std::vector<TagEntryPtr>& tags)
 {
     for(const auto& tag : tags) {
         logger << (*tag) << endl;
@@ -190,7 +190,7 @@ void ProtocolHandler::parse_buffer(const wxFileName& filename, const wxString& b
     db->OpenDatabase(dbfile);
     clDEBUG() << "Generating ctags file..." << endl;
 
-    vector<TagEntryPtr> tags;
+    std::vector<TagEntryPtr> tags;
     if(CTags::ParseBuffer(filename, buffer, settings.GetCodeliteIndexer(), settings.GetMacroTable(), tags) == 0) {
         clDEBUG() << "Failed to generate ctags file for buffer. file:" << endl;
         return;
@@ -217,10 +217,10 @@ void ProtocolHandler::parse_file(const wxFileName& filename, const CTagsdSetting
     parse_files({ filename.GetFullPath() }, settings);
 }
 
-void ProtocolHandler::do_parse_chunk(ITagsStoragePtr db, const vector<wxString>& file_list, size_t chunk_id,
+void ProtocolHandler::do_parse_chunk(ITagsStoragePtr db, const std::vector<wxString>& file_list, size_t chunk_id,
                                      const CTagsdSettings& settings)
 {
-    vector<TagEntryPtr> tags;
+    std::vector<TagEntryPtr> tags;
     clDEBUG() << "Parsing chunk (" << chunk_id << ") of" << file_list.size() << "files" << endl;
     if(CTags::ParseFiles(file_list, settings.GetCodeliteIndexer(), settings.GetMacroTable(), tags) == 0) {
         clDEBUG() << "0 tags generated. processed:" << file_list.size()
@@ -249,7 +249,7 @@ void ProtocolHandler::do_parse_chunk(ITagsStoragePtr db, const vector<wxString>&
     db->Commit();
 }
 
-void ProtocolHandler::parse_files(const vector<wxString>& file_list, const CTagsdSettings& settings)
+void ProtocolHandler::parse_files(const std::vector<wxString>& file_list, const CTagsdSettings& settings)
 {
     clDEBUG() << "Parsing" << file_list.size() << "files" << endl;
     clDEBUG() << "Removing un-modified and unwanted files..." << endl;
@@ -268,7 +268,7 @@ void ProtocolHandler::parse_files(const vector<wxString>& file_list, const CTags
     }
 
     TagsManagerST::Get()->FilterNonNeededFilesForRetaging(files_to_parse, db);
-    vector<wxString> filtered_file_list = { files_to_parse.begin(), files_to_parse.end() };
+    std::vector<wxString> filtered_file_list = { files_to_parse.begin(), files_to_parse.end() };
     clDEBUG() << "There are total of" << filtered_file_list.size() << "files that require parsing" << endl;
     clDEBUG() << "Generating ctags file..." << endl;
 
@@ -295,22 +295,22 @@ void ProtocolHandler::parse_files(const vector<wxString>& file_list, const CTags
         if((start_offset + chunk_size) > filtered_file_list.size()) {
             iter_end = filtered_file_list.end();
         }
-        vector<wxString> chunk_vec{ iter_start, iter_end };
+        std::vector<wxString> chunk_vec{ iter_start, iter_end };
         do_parse_chunk(db, chunk_vec, i, settings);
     }
     clDEBUG() << "Success" << endl;
 }
 
-vector<wxString> ProtocolHandler::update_additional_scopes_for_file(const wxString& filepath)
+std::vector<wxString> ProtocolHandler::update_additional_scopes_for_file(const wxString& filepath)
 {
     // we need to visit each node in the file graph and create a set of all the namespaces
-    vector<wxString> additional_scopes;
+    std::vector<wxString> additional_scopes;
     if(m_additional_scopes.count(filepath)) {
         additional_scopes = m_additional_scopes[filepath];
     } else {
         wxStringSet_t visited;
         wxStringSet_t ns;
-        vector<wxString> Q;
+        std::vector<wxString> Q;
         Q.push_back(filepath);
         while(!Q.empty()) {
             // pop the front of queue
@@ -423,7 +423,7 @@ bool ProtocolHandler::do_comments_exist_for_file(const wxString& filepath) const
 //---------------------------------------------------------------------------------
 
 // Request <-->
-void ProtocolHandler::on_initialize(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_initialize(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     // start the parser thread
     clDEBUG() << "Received `initialize` request" << endl;
@@ -502,7 +502,7 @@ void ProtocolHandler::on_initialize(unique_ptr<JSON>&& msg, Channel::ptr_t chann
     remove_db_if_needed(fn_db_path.GetFullPath());
 
     wxString indexer_path = m_settings.GetCodeliteIndexer();
-    vector<wxString> files_to_parse = { files.begin(), files.end() };
+    std::vector<wxString> files_to_parse = { files.begin(), files.end() };
     clDEBUG() << "on_initialize(): parsing files..." << endl;
     ProtocolHandler::parse_files(files_to_parse, m_settings);
     clDEBUG() << "on_initialize(): parsing files... Success" << endl;
@@ -523,7 +523,7 @@ void ProtocolHandler::on_initialize(unique_ptr<JSON>&& msg, Channel::ptr_t chann
 }
 
 // Request <-->
-void ProtocolHandler::on_unsupported_message(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_unsupported_message(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     wxString message;
     message << _("unsupported message: `") << msg->toElement()["method"].toString() << "`";
@@ -531,7 +531,7 @@ void ProtocolHandler::on_unsupported_message(unique_ptr<JSON>&& msg, Channel::pt
 }
 
 // Notification -->
-void ProtocolHandler::on_initialized(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_initialized(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     // a notification
     wxUnusedVar(msg);
@@ -540,7 +540,7 @@ void ProtocolHandler::on_initialized(unique_ptr<JSON>&& msg, Channel::ptr_t chan
 }
 
 // Notification -->
-void ProtocolHandler::on_did_open(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_did_open(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     wxUnusedVar(channel);
     // keep the file content in the internal map
@@ -566,7 +566,7 @@ void ProtocolHandler::on_did_open(unique_ptr<JSON>&& msg, Channel::ptr_t channel
 }
 
 // Notification -->
-void ProtocolHandler::on_did_close(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_did_close(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     wxUnusedVar(channel);
     auto json = msg->toElement();
@@ -582,7 +582,7 @@ void ProtocolHandler::on_did_close(unique_ptr<JSON>&& msg, Channel::ptr_t channe
 }
 
 // Notification -->
-void ProtocolHandler::on_did_change(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_did_change(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     static wxStringSet_t empty_set;
 
@@ -645,7 +645,7 @@ void ProtocolHandler::on_did_change(unique_ptr<JSON>&& msg, Channel::ptr_t chann
 
         // parse the files included by this file
         if(!new_includes.empty()) {
-            vector<wxString> includes_to_parse{ new_includes.begin(), new_includes.end() };
+            std::vector<wxString> includes_to_parse{ new_includes.begin(), new_includes.end() };
             ParseThreadTaskFunc headers_parse_task = [=]() {
                 clDEBUG() << "on_did_change(): parsing header files" << includes_to_parse << endl;
                 ProtocolHandler::parse_files(includes_to_parse, m_settings);
@@ -694,7 +694,7 @@ wxString ProtocolHandler::minimize_buffer(const wxString& filepath, int line, in
 }
 
 // Request <-->
-void ProtocolHandler::on_completion(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_completion(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     auto json = msg->toElement();
     size_t id = json["id"].toSize_t();
@@ -716,7 +716,7 @@ void ProtocolHandler::on_completion(unique_ptr<JSON>&& msg, Channel::ptr_t chann
     const wxString& full_buffer = m_filesOpened[filepath];
     bool is_include_completion = false;
     wxString file_name;
-    vector<TagEntryPtr> candidates;
+    std::vector<TagEntryPtr> candidates;
 
     wxArrayString lines = ::wxStringTokenize(full_buffer, "\n", wxTOKEN_RET_EMPTY_ALL);
     if(line < (int)lines.size()) {
@@ -750,7 +750,7 @@ void ProtocolHandler::on_completion(unique_ptr<JSON>&& msg, Channel::ptr_t chann
         bool is_function_calltip = !expression.empty() && expression.Last() == '(';
 
         clDEBUG() << "  --> update_additional_scopes_for_file() " << endl;
-        vector<wxString> visible_scopes = update_additional_scopes_for_file(filepath);
+        std::vector<wxString> visible_scopes = update_additional_scopes_for_file(filepath);
         clDEBUG() << "  -<-- update_additional_scopes_for_file() " << endl;
 
         if(is_trigger_char) {
@@ -844,7 +844,7 @@ void ProtocolHandler::on_completion(unique_ptr<JSON>&& msg, Channel::ptr_t chann
 }
 
 // Notificatin -->
-void ProtocolHandler::on_did_save(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_did_save(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     wxUnusedVar(channel);
     JSONItem json = msg->toElement();
@@ -868,7 +868,7 @@ void ProtocolHandler::on_did_save(unique_ptr<JSON>&& msg, Channel::ptr_t channel
     TagsManagerST::Get()->GetDatabase()->DeleteByFileName({}, filepath, true);
 
     // re-parse the file
-    vector<wxString> files;
+    std::vector<wxString> files;
     files.push_back(filepath);
 
     wxArrayString includes = get_files_to_parse(get_first_level_includes(filepath));
@@ -912,7 +912,7 @@ void add_to_types_set(const wxString& name, wxStringSet_t& types, const wxString
 } // namespace
 
 // Request <-->
-void ProtocolHandler::on_semantic_tokens(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_semantic_tokens(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     JSONItem json = msg->toElement();
     clDEBUG1() << json.format() << endl;
@@ -922,7 +922,7 @@ void ProtocolHandler::on_semantic_tokens(unique_ptr<JSON>&& msg, Channel::ptr_t 
 
     // use CTags to gather local variables
     wxString tmpdir = clStandardPaths::Get().GetTempDir();
-    vector<TagEntryPtr> tags;
+    std::vector<TagEntryPtr> tags;
 
     // get list of local tags
     CTags::ParseLocals(filepath, m_filesOpened[filepath], m_settings.GetCodeliteIndexer(), m_settings.GetMacroTable(),
@@ -979,9 +979,9 @@ void ProtocolHandler::on_semantic_tokens(unique_ptr<JSON>&& msg, Channel::ptr_t 
 
     wxStringSet_t visited;
 
-    unordered_map<wxString, TokenWrapper> variables;
-    unordered_map<wxString, TokenWrapper> classes;
-    unordered_map<wxString, TokenWrapper> functions;
+    std::unordered_map<wxString, TokenWrapper> variables;
+    std::unordered_map<wxString, TokenWrapper> classes;
+    std::unordered_map<wxString, TokenWrapper> functions;
 
     while(tokenizer.next(&token_wrapper.token)) {
         const auto& tok = token_wrapper.token;
@@ -1024,7 +1024,7 @@ void ProtocolHandler::on_semantic_tokens(unique_ptr<JSON>&& msg, Channel::ptr_t 
     }
 
     // remove all duplicate entries
-    vector<TokenWrapper> tokens_vec;
+    std::vector<TokenWrapper> tokens_vec;
     tokens_vec.reserve(functions.size() + variables.size() + classes.size());
 
     for(const auto& vt : classes) {
@@ -1056,7 +1056,7 @@ void ProtocolHandler::on_semantic_tokens(unique_ptr<JSON>&& msg, Channel::ptr_t 
     JSONItem response = root.toElement();
     auto result = build_result(response, id, cJSON_Object);
 
-    vector<int> encoding;
+    std::vector<int> encoding;
     encoding.reserve(5 * tokens_vec.size());
 
     clDEBUG() << "Found" << tokens_vec.size() << "semantic tokens" << endl;
@@ -1067,7 +1067,7 @@ void ProtocolHandler::on_semantic_tokens(unique_ptr<JSON>&& msg, Channel::ptr_t 
 }
 
 // Request <-->
-void ProtocolHandler::on_workspace_symbol(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_workspace_symbol(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     auto json = msg->toElement();
     size_t id = json["id"].toSize_t();
@@ -1075,7 +1075,7 @@ void ProtocolHandler::on_workspace_symbol(unique_ptr<JSON>&& msg, Channel::ptr_t
     wxString query = json["params"]["query"].toString();
     wxArrayString parts = ::wxStringTokenize(query, " \t", wxTOKEN_STRTOK);
 
-    vector<TagEntryPtr> tags;
+    std::vector<TagEntryPtr> tags;
     TagsManagerST::Get()->GetTagsByPartialNames(parts, tags);
 
     // build the reply
@@ -1091,7 +1091,7 @@ void ProtocolHandler::on_workspace_symbol(unique_ptr<JSON>&& msg, Channel::ptr_t
 }
 
 // Request <-->
-void ProtocolHandler::on_document_symbol(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_document_symbol(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     wxUnusedVar(msg);
     wxUnusedVar(channel);
@@ -1108,7 +1108,7 @@ void ProtocolHandler::on_document_symbol(unique_ptr<JSON>&& msg, Channel::ptr_t 
         return;
 
     // parse hte buffer
-    vector<TagEntryPtr> tags;
+    std::vector<TagEntryPtr> tags;
     CTags::ParseBuffer(filepath, m_filesOpened[filepath], m_settings.GetCodeliteIndexer(), m_settings.GetMacroTable(),
                        tags);
     if(tags.empty()) {
@@ -1116,7 +1116,7 @@ void ProtocolHandler::on_document_symbol(unique_ptr<JSON>&& msg, Channel::ptr_t 
     }
 
     // remove parameters from the list
-    vector<TagEntryPtr> tags_no_parameters;
+    std::vector<TagEntryPtr> tags_no_parameters;
     tags_no_parameters.reserve(tags.size());
     for(auto tag : tags) {
         if(tag->IsParameter()) {
@@ -1139,7 +1139,7 @@ void ProtocolHandler::on_document_symbol(unique_ptr<JSON>&& msg, Channel::ptr_t 
 }
 
 // Request <-->
-void ProtocolHandler::on_document_signature_help(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_document_signature_help(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     wxUnusedVar(channel);
 
@@ -1164,16 +1164,16 @@ void ProtocolHandler::on_document_signature_help(unique_ptr<JSON>&& msg, Channel
         minimize_buffer(filepath, line, character, m_filesOpened[filepath], CompletionHelper::TRUNCATE_EXACT_POS);
     wxString expression = helper.get_expression(text, true, &last_word);
 
-    vector<TagEntryPtr> candidates;
-    vector<wxString> visible_scopes = update_additional_scopes_for_file(filepath);
+    std::vector<TagEntryPtr> candidates;
+    std::vector<wxString> visible_scopes = update_additional_scopes_for_file(filepath);
     m_completer->word_complete(filepath, line + 1, expression, text, visible_scopes, true, candidates);
 
     // filter everything and just keep the methods tags
-    vector<TagEntryPtr> matches;
+    std::vector<TagEntryPtr> matches;
     matches.reserve(candidates.size() * 5);
     for(TagEntryPtr match : candidates) {
         if(match->IsClass() || match->IsStruct()) {
-            vector<TagEntryPtr> ctors;
+            std::vector<TagEntryPtr> ctors;
             m_completer->get_class_constructors(match, ctors);
             matches.insert(matches.end(), ctors.begin(), ctors.end());
         } else if(match->IsMethod()) {
@@ -1221,17 +1221,17 @@ void ProtocolHandler::on_document_signature_help(unique_ptr<JSON>&& msg, Channel
     channel->write_reply(response);
 }
 
-void ProtocolHandler::on_hover(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_hover(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     auto json = msg->toElement();
     size_t id = json["id"].toSize_t();
     clDEBUG1() << json.format() << endl;
 
-    vector<TagEntryPtr> tags;
+    std::vector<TagEntryPtr> tags;
     do_find_definition_tags(move(msg), channel, true, tags, nullptr);
 
     // format tip from tag
-    vector<TagEntryPtr> function_tag_arr;
+    std::vector<TagEntryPtr> function_tag_arr;
     wxStringSet_t visited;
     CompletionHelper helper;
 
@@ -1355,8 +1355,8 @@ void ProtocolHandler::on_hover(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
     channel->write_reply(response);
 }
 
-size_t ProtocolHandler::do_find_definition_tags(unique_ptr<JSON>&& msg, Channel::ptr_t channel,
-                                                bool try_definition_first, vector<TagEntryPtr>& tags,
+size_t ProtocolHandler::do_find_definition_tags(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel,
+                                                bool try_definition_first, std::vector<TagEntryPtr>& tags,
                                                 wxString* file_match)
 {
     auto json = msg->toElement();
@@ -1412,7 +1412,7 @@ size_t ProtocolHandler::do_find_definition_tags(unique_ptr<JSON>&& msg, Channel:
             }
         }
     } else {
-        vector<wxString> visible_scopes = update_additional_scopes_for_file(filepath);
+        std::vector<wxString> visible_scopes = update_additional_scopes_for_file(filepath);
         m_completer->find_definition(filepath, line + 1, expression, text, visible_scopes, tags);
         clDEBUG() << " --> Match found:" << tags.size() << "matches" << endl;
         clDEBUG() << tags << endl;
@@ -1420,9 +1420,9 @@ size_t ProtocolHandler::do_find_definition_tags(unique_ptr<JSON>&& msg, Channel:
     return tags.size();
 }
 
-void ProtocolHandler::do_definition(unique_ptr<JSON>&& msg, Channel::ptr_t channel, bool try_definition_first)
+void ProtocolHandler::do_definition(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel, bool try_definition_first)
 {
-    vector<TagEntryPtr> tags;
+    std::vector<TagEntryPtr> tags;
     wxString file_match;
     size_t id = msg->toElement()["id"].toSize_t();
     do_find_definition_tags(move(msg), channel, try_definition_first, tags, &file_match);
@@ -1467,12 +1467,12 @@ void ProtocolHandler::do_definition(unique_ptr<JSON>&& msg, Channel::ptr_t chann
     channel->write_reply(response);
 }
 
-void ProtocolHandler::on_declaration(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_declaration(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     do_definition(move(msg), channel, false);
 }
 
-void ProtocolHandler::on_definition(unique_ptr<JSON>&& msg, Channel::ptr_t channel)
+void ProtocolHandler::on_definition(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel)
 {
     do_definition(move(msg), channel, true);
 }
@@ -1548,7 +1548,7 @@ void ProtocolHandler::parse_file_for_includes_and_using_namespace(const wxString
 wxArrayString ProtocolHandler::get_files_to_parse(const wxArrayString& files)
 {
     clDEBUG() << "Scanning for files to parse (base list contains:" << files.size() << "files)" << endl;
-    deque<wxString> files_to_parse{ files.begin(), files.end() };
+    std::deque<wxString> files_to_parse{ files.begin(), files.end() };
 
     wxArrayString result;
     result.reserve(10000);
@@ -1588,7 +1588,7 @@ wxArrayString ProtocolHandler::get_first_level_includes(const wxString& filepath
 
 size_t ProtocolHandler::get_includes_recrusively(const wxString& filepath, wxStringSet_t* output)
 {
-    deque<wxString> Q;
+    std::deque<wxString> Q;
     Q.push_back(filepath);
     output->insert(filepath);
 

--- a/ctagsd/lib/ProtocolHandler.hpp
+++ b/ctagsd/lib/ProtocolHandler.hpp
@@ -4,25 +4,23 @@
 #include "Channel.hpp"
 #include "CompletionHelper.hpp"
 #include "CxxCodeCompletion.hpp"
+#include "JSON.h"
 #include "ParseThread.hpp"
 #include "Scanner.hpp"
 #include "Settings.hpp"
 #include "istorage.h"
 #include "macros.h"
 
-#include <JSON.h>
 #include <algorithm>
 #include <memory>
 #include <wx/string.h>
-
-using namespace std;
 
 struct CachedComment {
     wxString str;
     long line;
     long column;
     // line to comment map
-    typedef unordered_map<long, wxString> Map_t;
+    typedef std::unordered_map<long, wxString> Map_t;
 };
 
 struct ParsedFileInfo {
@@ -33,7 +31,7 @@ struct ParsedFileInfo {
 class ProtocolHandler
 {
 public:
-    typedef void (ProtocolHandler::*CallbackFunc)(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    typedef void (ProtocolHandler::*CallbackFunc)(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
 
 private:
     CTagsdSettings m_settings;
@@ -42,9 +40,9 @@ private:
     wxStringMap_t m_filesOpened;
 
     // cached parsed comments file <-> comments
-    unordered_map<wxString, CachedComment::Map_t> m_comments_cache;
-    unordered_map<wxString, ParsedFileInfo> m_parsed_files_info;
-    unordered_map<wxString, vector<wxString>> m_additional_scopes;
+    std::unordered_map<wxString, CachedComment::Map_t> m_comments_cache;
+    std::unordered_map<wxString, ParsedFileInfo> m_parsed_files_info;
+    std::unordered_map<wxString, std::vector<wxString>> m_additional_scopes;
     wxArrayString m_search_paths;
     Scanner m_file_scanner;
     CxxCodeCompletion::ptr_t m_completer;
@@ -64,10 +62,10 @@ private:
     /**
      * @brief parse list of files
      */
-    static void parse_files(const vector<wxString>& files, const CTagsdSettings& settings);
+    static void parse_files(const std::vector<wxString>& files, const CTagsdSettings& settings);
 
     // helper method for parsing a chunk of files
-    static void do_parse_chunk(ITagsStoragePtr db, const vector<wxString>& files, size_t chunk_id,
+    static void do_parse_chunk(ITagsStoragePtr db, const std::vector<wxString>& files, size_t chunk_id,
                                const CTagsdSettings& settings);
 
     bool ensure_file_content_exists(const wxString& filepath, Channel::ptr_t channel, size_t req_id);
@@ -75,12 +73,12 @@ private:
     void update_comments_for_file(const wxString& filepath);
     const wxString& get_comment(const wxString& filepath, long line, const wxString& default_value) const;
     bool do_comments_exist_for_file(const wxString& filepath) const;
-    vector<wxString> update_additional_scopes_for_file(const wxString& filepath);
+    std::vector<wxString> update_additional_scopes_for_file(const wxString& filepath);
 
     wxArrayString FilterNonWantedNamespaces(const wxArrayString& namespace_arr) const;
-    void do_definition(unique_ptr<JSON>&& msg, Channel::ptr_t channel, bool try_definition_first);
-    size_t do_find_definition_tags(unique_ptr<JSON>&& msg, Channel::ptr_t channel, bool try_definition_first,
-                                   vector<TagEntryPtr>& tags, wxString* file_match);
+    void do_definition(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel, bool try_definition_first);
+    size_t do_find_definition_tags(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel, bool try_definition_first,
+                                   std::vector<TagEntryPtr>& tags, wxString* file_match);
 
     void build_search_path();
     void parse_file_for_includes_and_using_namespace(const wxString& filepath);
@@ -109,21 +107,21 @@ public:
     ProtocolHandler();
     ~ProtocolHandler();
 
-    void on_initialize(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_initialized(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_unsupported_message(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_did_open(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_did_change(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_completion(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_did_close(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_did_save(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_semantic_tokens(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_document_symbol(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_document_signature_help(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_definition(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_declaration(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_hover(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
-    void on_workspace_symbol(unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_initialize(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_initialized(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_unsupported_message(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_did_open(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_did_change(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_completion(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_did_close(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_did_save(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_semantic_tokens(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_document_symbol(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_document_signature_help(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_definition(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_declaration(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_hover(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
+    void on_workspace_symbol(std::unique_ptr<JSON>&& msg, Channel::ptr_t channel);
 
     /**
      * @brief send a "window/logMessage" message to the client

--- a/ctagsd/lib/Scanner.hpp
+++ b/ctagsd/lib/Scanner.hpp
@@ -9,7 +9,6 @@
 #include <wx/filename.h>
 #include <wx/string.h>
 
-using namespace std;
 class Scanner
 {
     wxStringSet_t m_missing_includes;

--- a/ctagsd/lib/Settings.cpp
+++ b/ctagsd/lib/Settings.cpp
@@ -17,7 +17,7 @@
 
 namespace
 {
-FileLogger& operator<<(FileLogger& logger, const vector<pair<wxString, wxString>>& vec)
+FileLogger& operator<<(FileLogger& logger, const std::vector<std::pair<wxString, wxString>>& vec)
 {
     wxString buffer;
     buffer << "[";
@@ -29,7 +29,7 @@ FileLogger& operator<<(FileLogger& logger, const vector<pair<wxString, wxString>
     return logger;
 }
 
-vector<wxString> DEFAULT_TYPES = {
+std::vector<wxString> DEFAULT_TYPES = {
     "std::unique_ptr::pointer=_Tp", // needed for unique_ptr
                                     // {unordered}_map / map / {unordered}_multimap
     "std::*map::*iterator=std::pair<_Key, _Tp>",
@@ -55,7 +55,7 @@ vector<wxString> DEFAULT_TYPES = {
     "std::list::*reference=_Tp",
 };
 
-vector<wxString> DEFAULT_TOKENS = {
+std::vector<wxString> DEFAULT_TOKENS = {
     "ATTRIBUTE_PRINTF_1",
     "ATTRIBUTE_PRINTF_2",
     "BEGIN_DECLARE_EVENT_TYPES()=enum {",
@@ -373,19 +373,19 @@ vector<wxString> DEFAULT_TOKENS = {
 #endif
 };
 
-vector<pair<wxString, wxString>> to_vector_of_pairs(const vector<wxString>& arr)
+std::vector<std::pair<wxString, wxString>> to_vector_of_pairs(const std::vector<wxString>& arr)
 {
-    vector<pair<wxString, wxString>> result;
+    std::vector<std::pair<wxString, wxString>> result;
     result.reserve(arr.size());
     for(const wxString& line : arr) {
         wxString k = line.BeforeFirst('=');
         wxString v = line.AfterFirst('=');
-        result.emplace_back(make_pair(k, v));
+        result.emplace_back(std::make_pair(k, v));
     }
     return result;
 }
 
-void write_to_json(JSONItem& json_arr, const vector<pair<wxString, wxString>>& arr)
+void write_to_json(JSONItem& json_arr, const std::vector<std::pair<wxString, wxString>>& arr)
 {
     for(const auto& entry : arr) {
         auto type = json_arr.AddObject(wxEmptyString);
@@ -395,7 +395,6 @@ void write_to_json(JSONItem& json_arr, const vector<pair<wxString, wxString>>& a
 }
 } // namespace
 
-using namespace std;
 CTagsdSettings::CTagsdSettings()
 {
     // set some defaults
@@ -481,7 +480,7 @@ void CTagsdSettings::build_search_path(const wxFileName& filepath)
     wxFileName compile_flags_txt(path, "compile_flags.txt");
     wxFileName compile_commands_json(path, "compile_commands.json");
 
-    set<wxString> S{ m_search_path.begin(), m_search_path.end() };
+    std::set<wxString> S{ m_search_path.begin(), m_search_path.end() };
     if(compile_flags_txt.FileExists()) {
         // we are using the compile_flags.txt file method
         CompileFlagsTxt cft(compile_flags_txt);
@@ -512,7 +511,7 @@ void CTagsdSettings::build_search_path(const wxFileName& filepath)
 
     wxString content;
     FileUtils::ReadFileContent(tmpfile.GetFullPath(), content);
-    wxArrayString outputArr = wxStringTokenize(content, wxT("\n\r"), wxTOKEN_STRTOK);
+    wxArrayString outputArr = wxStringTokenize(content, "\n\r", wxTOKEN_STRTOK);
 
     // Analyze the output
     bool collect(false);
@@ -521,12 +520,12 @@ void CTagsdSettings::build_search_path(const wxFileName& filepath)
         line.Trim().Trim(false);
 
         // search the scan starting point
-        if(line.Contains(wxT("#include <...> search starts here:"))) {
+        if(line.Contains("#include <...> search starts here:")) {
             collect = true;
             continue;
         }
 
-        if(line.Contains(wxT("End of search list."))) {
+        if(line.Contains("End of search list.")) {
             break;
         }
 

--- a/ctagsd/lib/Settings.hpp
+++ b/ctagsd/lib/Settings.hpp
@@ -7,13 +7,12 @@
 #include <wx/arrstr.h>
 #include <wx/filename.h>
 
-using namespace std;
 class CTagsdSettings
 {
     wxString m_file_mask = "*.cpp;*.h;*.hpp;*.cxx;*.cc;*.hxx";
     wxArrayString m_search_path;
-    vector<pair<wxString, wxString>> m_tokens;
-    vector<pair<wxString, wxString>> m_types;
+    std::vector<std::pair<wxString, wxString>> m_tokens;
+    std::vector<std::pair<wxString, wxString>> m_types;
     wxString m_codelite_indexer;
     wxString m_ignore_spec = "/.git/;/.svn/;/build/;/build-;/CPack_Packages/;/CMakeFiles/";
     size_t m_limit_results = 150;
@@ -36,14 +35,14 @@ public:
     void SetFileMask(const wxString& file_mask) { this->m_file_mask = file_mask; }
     void SetIgnoreSpec(const wxString& ignore_spec) { this->m_ignore_spec = ignore_spec; }
     void SetSearchPath(const wxArrayString& search_path) { this->m_search_path = search_path; }
-    void SetTokens(const vector<pair<wxString, wxString>>& tokens) { this->m_tokens = tokens; }
+    void SetTokens(const std::vector<std::pair<wxString, wxString>>& tokens) { this->m_tokens = tokens; }
     const wxString& GetCodeliteIndexer() const { return m_codelite_indexer; }
     const wxString& GetFileMask() const { return m_file_mask; }
     const wxString& GetIgnoreSpec() const { return m_ignore_spec; }
     const wxArrayString& GetSearchPath() const { return m_search_path; }
-    const vector<pair<wxString, wxString>>& GetTokens() const { return m_tokens; }
-    void SetTypes(const vector<pair<wxString, wxString>>& types) { this->m_types = types; }
-    const vector<pair<wxString, wxString>>& GetTypes() const { return m_types; }
+    const std::vector<std::pair<wxString, wxString>>& GetTokens() const { return m_tokens; }
+    void SetTypes(const std::vector<std::pair<wxString, wxString>>& types) { this->m_types = types; }
+    const std::vector<std::pair<wxString, wxString>>& GetTypes() const { return m_types; }
     const wxString& GetSettingsDir() const { return m_settings_dir; }
     wxStringMap_t GetMacroTable() const;
 };

--- a/ctagsd/main.cpp
+++ b/ctagsd/main.cpp
@@ -15,7 +15,7 @@
 
 namespace
 {
-unordered_map<wxString, ProtocolHandler::CallbackFunc> function_table = {
+std::unordered_map<wxString, ProtocolHandler::CallbackFunc> function_table = {
     { "initialize", &ProtocolHandler::on_initialize },
     { "initialized", &ProtocolHandler::on_initialized },
     { "textDocument/didOpen", &ProtocolHandler::on_did_open },


### PR DESCRIPTION
This causes a symbol collision (`std::byte` vs. `::byte`) in Windows' `rpcndr.h` header when built with C++17 mode (which is the default C++ mode from GCC 11 and onwards).
To resolve this and further possible issues, reduce the use of `using namespace std;`.

I've recently upgraded my MSYS2 MinGW to 11.3.0 and CodeLite no longer compiles out of the box.