### PR TITLE
Revert all changes to unicode string literals

### DIFF
--- a/Outline/outline_tab.cpp
+++ b/Outline/outline_tab.cpp
@@ -14,11 +14,11 @@
 
 namespace
 {
-const wxString FUNCTION_SYMBOL = "\u2A10";
-const wxString CLASS_SYMBOL = "\u2394";
-const wxString VARIABLE_SYMBOL = "\u2027";
-const wxString MODULE_SYMBOL = "{}";
-const wxString ENUMERATOR_SYMBOL = "#";
+const wxString FUNCTION_SYMBOL = wxT("\u2A10");
+const wxString CLASS_SYMBOL = wxT("\u2394");
+const wxString VARIABLE_SYMBOL = wxT("\u2027");
+const wxString MODULE_SYMBOL = wxT("{}");
+const wxString ENUMERATOR_SYMBOL = wxT("#");
 } // namespace
 
 using namespace LSP;

--- a/Plugin/open_resource_dialog.cpp
+++ b/Plugin/open_resource_dialog.cpp
@@ -374,7 +374,7 @@ void OpenResourceDialog::DoAppendLine(const wxString& name, const wxString& full
     clientData->m_impl = boldFont;
     wxVector<wxVariant> cols;
     cols.push_back(::MakeBitmapIndexText(prefix + name, imgid));
-    cols.push_back(clientData->m_impl ? wxString("\u274C") : wxString());
+    cols.push_back(clientData->m_impl ? wxString(wxT("\u274C")) : wxString());
     cols.push_back(fullname);
     m_dataview->AppendItem(cols, (wxUIntPtr)clientData);
 }


### PR DESCRIPTION
This is another fix for the commit 5a99fa1 (which was introduced in my earlier commit 26312f0).