### PR TITLE
Small spelling mistake in a comment

### DIFF
--- a/codelitegcc/main.cpp
+++ b/codelitegcc/main.cpp
@@ -77,7 +77,7 @@ void WriteContent( const std::string& logfile, const std::string& filename, cons
 extern void WriteContent( const std::string& logfile, const std::string& filename, const std::string& flags );
 
 // A thin wrapper around gcc
-// Its soul purpose is to parse gcc's output and to store the parsed output
+// Its sole purpose is to parse gcc's output and to store the parsed output
 // in a sqlite database
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
"soul" -> "sole" (Corrected spelling for the word "sole" from "soul) in the second single line comment above main function