### PR TITLE
Fix build error in wxCrafter due to wxWidgets change

### DIFF
--- a/wxcrafter/myxh_propgrid.cpp
+++ b/wxcrafter/myxh_propgrid.cpp
@@ -48,7 +48,7 @@ wxObject* MyWxPropGridXmlHandler::DoCreateResource()
 
         // add the splitter property after the children were added
         int splitterLeft = GetBool("splitterleft");
-        if(splitterLeft) { m_pgmgr->GetPage(0)->SetSplitterLeft(); }
+        if(splitterLeft) { m_pgmgr->SetSplitterLeft(); }
 
         int splitterPos = GetLong("splitterpos", wxNOT_FOUND);
         if(splitterPos != wxNOT_FOUND) { m_pgmgr->GetPage(0)->SetSplitterPosition(splitterPos); }


### PR DESCRIPTION
Fix build problem with wxCrafter in the latest wxWidgets master on GitHub.

wxCrafter was previously using a non-documented internal function (SetSplitterLeft) on a property grid page. These functions are now protected, but the same effect can be achieved by calling SetSplitterLeft() on the property grid manager instead, as per this pull request.