### PR TITLE
fixed: correct locale name to find

### DIFF
--- a/LiteEditor/app.cpp
+++ b/LiteEditor/app.cpp
@@ -620,7 +620,11 @@ bool CodeLiteApp::OnInit()
         // versions
         wxString preferredLocalename = EditorConfigST::Get()->GetOptions()->GetPreferredLocale();
         if(!preferredLocalename.IsEmpty()) {
-            const wxLanguageInfo* info = wxLocale::FindLanguageInfo(preferredLocalename);
+            wxString localeToFind = preferredLocalename.BeforeFirst(':');
+            if(localeToFind.IsEmpty()) {
+                localeToFind << preferredLocalename;
+            }
+            const wxLanguageInfo* info = wxLocale::FindLanguageInfo(localeToFind);
             if(info) {
                 preferredLocale = info->Language;
                 if(preferredLocale == wxLANGUAGE_UNKNOWN) {


### PR DESCRIPTION
Fixes #3067.

In `config/codelite.xml`, the option shown in the preferences dialog in the form of `"<lang>: <desc>"` is directly written such as `m_preferredLocale="ja_JP: Japanese (Japan)"`.

When loading a locale, the existing implementation invokes `wxLocale::FindLanguageInfo("<lang>: <desc>")` directly, instead of `wxLocale::FindLanguageInfo("<lang>")` which is the correct way. In the wrong case `wxLocale::FindLanguageInfo` returns `nullptr`, and that's why this bug happens.

This fix works when `m_preferredLocale` is both `"<lang>: <desc>"` and `"<lang>"`.