### PR TITLE
fix: properly close find bar on diff view

### DIFF
--- a/Plugin/DiffSideBySidePanel.h
+++ b/Plugin/DiffSideBySidePanel.h
@@ -203,5 +203,10 @@ public:
      * @brief set whether to store the diff's filepaths for later reload
      */
     void SetSaveFilepaths(bool save) { m_storeFilepaths = save; }
+
+    /**
+     * @brief returns whether find bar has focus
+     */
+    bool HasFindBarFocus() const { return m_findBar->HasFocus(); }
 };
 #endif // DIFFSIDEBYSIDEPANEL_H

--- a/Plugin/clDiffFrame.cpp
+++ b/Plugin/clDiffFrame.cpp
@@ -119,7 +119,7 @@ void clDiffFrame::OnClose(wxCommandEvent& event)
 void clDiffFrame::OnCharHook(wxKeyEvent& event)
 {
     event.Skip();
-    if(event.GetKeyCode() == WXK_ESCAPE) {
+    if(event.GetKeyCode() == WXK_ESCAPE && !m_diffView->HasFindBarFocus()) {
         Close();
     }
 }

--- a/Plugin/clPluginsFindBar.cpp
+++ b/Plugin/clPluginsFindBar.cpp
@@ -98,7 +98,7 @@ clPluginsFindBar::clPluginsFindBar(wxWindow* parent, wxWindowID id)
     m_toolbar->SetMiniToolBar(true);
 
     clBitmapList* bitmaps = new clBitmapList;
-    m_toolbar->AddTool(wxID_CLOSE, _("Close"), bitmaps->Add("file_close"), _("Close"), wxITEM_NORMAL);
+    m_toolbar->AddTool(ID_TOOL_CLOSE, _("Close"), bitmaps->Add("file_close"), _("Close"), wxITEM_NORMAL);
     m_toolbar->AddSeparator();
     m_matchesFound = new wxStaticText(m_toolbar, wxID_ANY, "", wxDefaultPosition, wxSize(250, -1),
                                       wxST_NO_AUTORESIZE | wxALIGN_LEFT);
@@ -113,7 +113,7 @@ clPluginsFindBar::clPluginsFindBar(wxWindow* parent, wxWindowID id)
     m_toolbar->AssignBitmaps(bitmaps);
 
     m_toolbar->Realize();
-    m_toolbar->Bind(wxEVT_TOOL, &clPluginsFindBar::OnHide, this, wxID_CLOSE);
+    m_toolbar->Bind(wxEVT_TOOL, &clPluginsFindBar::OnHide, this, ID_TOOL_CLOSE);
     m_toolbar->Bind(
         wxEVT_TOOL,
         [&](wxCommandEvent& e) {
@@ -1237,4 +1237,16 @@ void clPluginsFindBar::OnPaint(wxPaintEvent& e)
     dc.SetBrush(clSystemSettings::GetDefaultPanelColour());
     dc.SetPen(clSystemSettings::GetDefaultPanelColour());
     dc.DrawRectangle(GetClientRect());
+}
+
+bool clPluginsFindBar::HasFocus() const
+{
+    wxWindow* win = wxWindow::FindFocus();
+    return win == m_textCtrlFind
+        || win == m_buttonFind
+        || win == m_buttonFindPrev
+        || win == m_buttonFindAll
+        || win == m_textCtrlReplace
+        || win == m_buttonReplace
+        || win == m_buttonReplaceAll;
 }

--- a/Plugin/clPluginsFindBar.h
+++ b/Plugin/clPluginsFindBar.h
@@ -161,6 +161,7 @@ public:
 
     wxString GetFindWhat() const { return m_textCtrlFind->GetValue(); }
     void SetFindWhat(const wxString& findwhat) { m_textCtrlFind->ChangeValue(findwhat); }
+    virtual bool HasFocus() const;
 };
 
 #endif // __quickfindbar__


### PR DESCRIPTION
Fixes #3071.

Clicking close button on find bar closes the find bar.

Also, in terms of user experience, when one of the controls on find bar has focus and ESCAPE is typed, only the find bar is closed.