### PR TITLE
Fix issue with "Open Resource..." searches containing :line[:column]

### DIFF
--- a/Plugin/open_resource_dialog.cpp
+++ b/Plugin/open_resource_dialog.cpp
@@ -474,16 +474,16 @@ void OpenResourceDialog::GetLineAndColumnFromFilter(const wxString& filter, wxSt
     wxString tmpstr = filter;
     tmpstr.Replace("\\", "/");
 
-    wxString remainder = filter.AfterLast('/');
-    if(remainder.find(':') == wxString::npos) {
+    const size_t sep_last = tmpstr.Find('/', true);
+    const size_t col_first = tmpstr.find(':', sep_last);
+    if (col_first == wxNOT_FOUND) {
         return;
     }
 
-    auto parts = ::wxStringTokenize(remainder, ":", wxTOKEN_STRTOK);
-    // the first part is the name
-    modFilter = parts.Item(0);
-    parts.RemoveAt(0);
+    modFilter = tmpstr.substr(0, col_first);
+    wxString remainder = tmpstr.substr(col_first);
 
+    auto parts = ::wxStringTokenize(remainder, ":", wxTOKEN_STRTOK);
     if(!parts.empty()) {
         // line number
         parts.Item(0).ToCLong(&lineNumber);


### PR DESCRIPTION
Fix issue with "Open Resource..." searches containing :line[:column]

When search pattern includes :line[:column] the current search only uses the filename - paths before the filename are ignored

Example: using the CodeLite project as example:

open "Open Resouce..." dialog

Type the following into search field (without the braces):
git/CMakeLists.txt

The above should give one hit/result

Then try:
git/CMakeLists.txt:33

Now the search ignores the path (git/) and finds all files named CMakeLists.txt

This pull request corrects this behavior 

 


