### PR TITLE
Undo Home, End list navigation in Open Resource Dialog

### DIFF
--- a/Plugin/open_resource_dialog.cpp
+++ b/Plugin/open_resource_dialog.cpp
@@ -335,8 +335,7 @@ void OpenResourceDialog::OnKeyDown(wxKeyEvent& event)
 
     if (event.GetKeyCode() == WXK_DOWN || event.GetKeyCode() == WXK_UP ||
         event.GetKeyCode() == WXK_NUMPAD_UP || event.GetKeyCode() == WXK_NUMPAD_DOWN ||
-        event.GetKeyCode() == WXK_PAGEUP || event.GetKeyCode() == WXK_PAGEDOWN ||
-        event.GetKeyCode() == WXK_HOME || event.GetKeyCode() == WXK_END)
+        event.GetKeyCode() == WXK_PAGEUP || event.GetKeyCode() == WXK_PAGEDOWN)
     {
         event.Skip(false);
 


### PR DESCRIPTION
After having evaluated my previous pull request... I realize that it feels wierd not beeing able to use Home and End keys to jump back and forth in the text field