### PR TITLE
Search pattern without '/' but including ':line[:column]' would not f…

### DIFF
--- a/Plugin/open_resource_dialog.cpp
+++ b/Plugin/open_resource_dialog.cpp
@@ -475,7 +475,7 @@ void OpenResourceDialog::GetLineAndColumnFromFilter(const wxString& filter, wxSt
     tmpstr.Replace("\\", "/");
 
     const size_t sep_last = tmpstr.Find('/', true);
-    const size_t col_first = tmpstr.find(':', sep_last);
+    const size_t col_first = tmpstr.find(':', (sep_last == wxNOT_FOUND ? 0 : sep_last));
     if (col_first == wxNOT_FOUND) {
         return;
     }


### PR DESCRIPTION
Search pattern without '/' but including ':line[:column]' would not find any matches
