### PR TITLE
DebugAdapterClient compile fix: std=c++17

### DIFF
--- a/DebugAdapterClient/CMakeLists.txt
+++ b/DebugAdapterClient/CMakeLists.txt
@@ -1,5 +1,5 @@
 # lldb requires C++11
-add_definitions(-std=c++11)
+add_definitions(-std=c++17)
 set(PLUGIN_NAME "DebugAdapterClient")
 project(DebugAdapterClient)
 


### PR DESCRIPTION
Neither master or release 17.2.0 builds on Linux (Arch Linux)

This patch fixes the following compile error:
```
FAILED: DebugAdapterClient/CMakeFiles/DebugAdapterClient.dir/BreakpointsHelper.cpp.o

In file included from /tmp/codelite-devel.git/DebugAdapterClient/clDapSettingsStore.hpp:4,
                 from /tmp/codelite-devel.git/DebugAdapterClient/DebugSession.hpp:4,
                 from /tmp/codelite-devel.git/DebugAdapterClient/BreakpointsHelper.hpp:4,
                 from /tmp/codelite-devel.git/DebugAdapterClient/BreakpointsHelper.cpp:1:
/tmp/codelite-devel.git/CodeLite/JSON.h:101:29: error: ‘string_view’ is not a member of ‘std’
  101 |     std::unordered_map<std::string_view, JSONItem> GetAsMap() const;
      |                             ^~~~~~~~~~~
/tmp/codelite-devel.git/CodeLite/JSON.h:101:29: note: ‘std::string_view’ is only available from C++17 onwards
/tmp/codelite-devel.git/CodeLite/JSON.h:101:29: error: ‘string_view’ is not a member of ‘std’
/tmp/codelite-devel.git/CodeLite/JSON.h:101:29: note: ‘std::string_view’ is only available from C++17 onwards
/tmp/codelite-devel.git/CodeLite/JSON.h:101:50: error: template argument 1 is invalid
  101 |     std::unordered_map<std::string_view, JSONItem> GetAsMap() const;
      |                                                  ^
/tmp/codelite-devel.git/CodeLite/JSON.h:101:50: error: template argument 3 is invalid
/tmp/codelite-devel.git/CodeLite/JSON.h:101:50: error: template argument 4 is invalid
/tmp/codelite-devel.git/CodeLite/JSON.h:101:50: error: template argument 5 is invalid
```