### PR TITLE
Prevent descriptor leak into child process

### DIFF
--- a/CodeLite/UnixProcess.cpp
+++ b/CodeLite/UnixProcess.cpp
@@ -34,6 +34,12 @@ UnixProcess::UnixProcess(wxEvtHandler* owner, const wxArrayString& args)
         m_childStdout.Close();
         m_childStderr.Close();
 
+        // prevent descriptor leak into child process
+        const int fd_max = (sysconf(_SC_OPEN_MAX) != -1 ? sysconf(_SC_OPEN_MAX) : FD_SETSIZE);
+        for (int fd = 3; fd < fd_max; fd++) {
+            close(fd);
+        }
+
         char** argv = new char*[args.size() + 1];
         for(size_t i = 0; i < args.size(); ++i) {
             wxString wx_arg = args[i];

--- a/codelite-stdio/UnixProcess.cpp
+++ b/codelite-stdio/UnixProcess.cpp
@@ -24,6 +24,12 @@ UnixProcess::UnixProcess(wxEvtHandler* owner, const wxArrayString& args)
         m_childStdout.close();
         m_childStderr.close();
 
+        // prevent descriptor leak into child process
+        const int fd_max = (sysconf(_SC_OPEN_MAX) != -1 ? sysconf(_SC_OPEN_MAX) : FD_SETSIZE);
+        for (int fd = 3; fd < fd_max; fd++) {
+            close(fd);
+        }
+
         char** argv = new char*[args.size() + 1];
         for(size_t i = 0; i < args.size(); ++i) {
             std::string cstr_arg = FileUtils::ToStdString(args[i]);


### PR DESCRIPTION
I accidentally stumbled over a fork/exec file descriptor leak in CL

Below is a `lsof` dump of `clangd` started by CL (through fork/execv)
The first thing that caught my eye was that `clangd` also was listening on 127.0.0.1:13648 on FD 14 - just like CL

```
% lsof -n -P -p 51075
COMMAND     PID USER   FD   TYPE             DEVICE  SIZE/OFF    NODE NAME
clangd.ma 51075   uj  cwd    DIR                8,2      4096 5364899 /tmp
clangd.ma 51075   uj  rtd    DIR                8,1      4096       2 /
clangd.ma 51075   uj  txt    REG                8,1  27618032 1746187 /usr/bin/clangd
clangd.ma 51075   uj  mem    REG               0,31  19259072    3166 /tmp/preamble-5da313.pch
clangd.ma 51075   uj  mem    REG                8,1  32035672 1735740 /usr/lib/libicudata.so.73.2
clangd.ma 51075   uj  mem    REG                8,1   2119656 1740514 /usr/lib/libicuuc.so.73.2
clangd.ma 51075   uj  mem    REG                8,1   2366624 1730677 /usr/lib/libc.so.6
clangd.ma 51075   uj  mem    REG                8,1   1457584 1743013 /usr/lib/libxml2.so.2.11.5
clangd.ma 51075   uj  mem    REG                8,1  21512640 1784635 /usr/lib/libstdc++.so.6.0.32
clangd.ma 51075   uj  mem    REG                8,1    206792 1709565 /usr/lib/liblzma.so.5.4.4
clangd.ma 51075   uj  mem    REG                8,1    862080 1707440 /usr/lib/libzstd.so.1.5.5
clangd.ma 51075   uj  mem    REG                8,1 137678144 1776905 /usr/lib/libLLVM-16.so
clangd.ma 51075   uj  mem    REG                8,1  55085424 1755990 /usr/lib/libclang-cpp.so.16
clangd.ma 51075   uj  mem    REG                8,1    486624 1704262 /usr/lib/libncursesw.so.6.4
clangd.ma 51075   uj  mem    REG                8,1    100296 1713292 /usr/lib/libz.so.1.3
clangd.ma 51075   uj  mem    REG                8,1    231464 1720279 /usr/lib/libedit.so.0.0.72
clangd.ma 51075   uj  mem    REG                8,1     43160 1724278 /usr/lib/libffi.so.8.1.2
clangd.ma 51075   uj  mem    REG                8,1    728120 1764342 /usr/lib/libgcc_s.so.1
clangd.ma 51075   uj  mem    REG                8,1    965016 1737041 /usr/lib/libm.so.6
clangd.ma 51075   uj  mem    REG                8,1    216192 1718097 /usr/lib/ld-linux-x86-64.so.2
clangd.ma 51075   uj    0r  FIFO               0,14       0t0  437538 pipe
clangd.ma 51075   uj    1w  FIFO               0,14       0t0  437540 pipe
clangd.ma 51075   uj    2w  FIFO               0,14       0t0  437539 pipe
clangd.ma 51075   uj    4r   REG                8,1       641 1864751 /usr/include/tbb/tbb.h
clangd.ma 51075   uj    9u  unix 0x000000005814755d       0t0   25145 type=STREAM (CONNECTED)
clangd.ma 51075   uj   10u  unix 0x000000000f43d562       0t0   25146 type=STREAM (CONNECTED)
clangd.ma 51075   uj   14u  IPv4             352121       0t0     TCP 127.0.0.1:13648 (LISTEN)
uj@CPH-EMP-UJ L1  codelite-devel.git (master_uj_fsw_symlink_patch u=) 0 %                                                                      
```

Below is `lsof` dump of `clangd` started by CL after the fork/exec fix has been applied
```
% lsof -n -P -p 54220
COMMAND     PID USER   FD   TYPE DEVICE  SIZE/OFF    NODE NAME
clangd.ma 54220   uj  cwd    DIR    8,3     40960 3794373 /tmp
clangd.ma 54220   uj  rtd    DIR    8,1      4096       2 /
clangd.ma 54220   uj  txt    REG    8,1  27618032 1746187 /usr/bin/clangd
clangd.ma 54220   uj  mem    REG   0,31   4609688    3341 /tmp/preamble-d71863.pch
clangd.ma 54220   uj  mem    REG    8,1  32035672 1735740 /usr/lib/libicudata.so.73.2
clangd.ma 54220   uj  mem    REG    8,1   2119656 1740514 /usr/lib/libicuuc.so.73.2
clangd.ma 54220   uj  mem    REG    8,1   2366624 1730677 /usr/lib/libc.so.6
clangd.ma 54220   uj  mem    REG    8,1   1457584 1743013 /usr/lib/libxml2.so.2.11.5
clangd.ma 54220   uj  mem    REG    8,1  21512640 1784635 /usr/lib/libstdc++.so.6.0.32
clangd.ma 54220   uj  mem    REG    8,1    486624 1704262 /usr/lib/libncursesw.so.6.4
clangd.ma 54220   uj  mem    REG    8,1    862080 1707440 /usr/lib/libzstd.so.1.5.5
clangd.ma 54220   uj  mem    REG    8,1 137678144 1776905 /usr/lib/libLLVM-16.so
clangd.ma 54220   uj  mem    REG    8,1  55085424 1755990 /usr/lib/libclang-cpp.so.16
clangd.ma 54220   uj  mem    REG    8,1    206792 1709565 /usr/lib/liblzma.so.5.4.4
clangd.ma 54220   uj  mem    REG    8,1    100296 1713292 /usr/lib/libz.so.1.3
clangd.ma 54220   uj  mem    REG    8,1    231464 1720279 /usr/lib/libedit.so.0.0.72
clangd.ma 54220   uj  mem    REG    8,1     43160 1724278 /usr/lib/libffi.so.8.1.2
clangd.ma 54220   uj  mem    REG    8,1    728120 1764342 /usr/lib/libgcc_s.so.1
clangd.ma 54220   uj  mem    REG    8,1    965016 1737041 /usr/lib/libm.so.6
clangd.ma 54220   uj  mem    REG    8,1    216192 1718097 /usr/lib/ld-linux-x86-64.so.2
clangd.ma 54220   uj    0r  FIFO   0,14       0t0  467229 pipe
clangd.ma 54220   uj    1w  FIFO   0,14       0t0  467231 pipe
clangd.ma 54220   uj    2w  FIFO   0,14       0t0  467230 pipe
```