### PR TITLE
After FSW refresh expand Workspace panel/tree to match the current active tab

### DIFF
--- a/Plugin/clTreeCtrlPanel.cpp
+++ b/Plugin/clTreeCtrlPanel.cpp
@@ -1012,6 +1012,10 @@ void clTreeCtrlPanel::OnRefresh(wxCommandEvent& event)
 {
     wxUnusedVar(event);
     RefreshSelections();
+
+    if(clGetManager()->GetActiveEditor() && (m_options & kLinkToEditor)) {
+        CallAfter(&clTreeCtrlPanel::ExpandToFileVoid, clGetManager()->GetActiveEditor()->GetFileName());
+    }
 }
 
 void clTreeCtrlPanel::SetNewFileTemplate(const wxString& newfile, size_t charsToHighlight)
@@ -1177,6 +1181,11 @@ void clTreeCtrlPanel::RefreshTree()
 
     GetTreeCtrl()->SortChildren(GetTreeCtrl()->GetRootItem());
     ToggleView();
+
+    if(clGetManager()->GetActiveEditor() && (m_options & kLinkToEditor)) {
+        CallAfter(&clTreeCtrlPanel::ExpandToFileVoid, clGetManager()->GetActiveEditor()->GetFileName());
+    }
+
 }
 
 void clTreeCtrlPanel::OnFilesCreated(clFileSystemEvent& event)


### PR DESCRIPTION
Subject: After FSW refresh expand FSW panel/tree to match the current active editor tab

This is my solution proposal to fix a problem that has annoyed me for some time now.

You can refresh the FSW tree in 2 ways:
1) by pressing the `Refresh` button above the (FS)Workspace panel
2) by right click on a node in the FSW tree - then select `Refresh` in the context menu.

In both cases the FSW tree is refreshed - but it leaves the (FS)Workspace tree collapsed - even if the `link-with-editor` option is enabled.

It may not be the right way to do this - but it seems to work -  feel free to change to something more correct if you like :-)
