### PR TITLE
Fix GUI hang on build in case too big output

### DIFF
--- a/LiteEditor/BuildTab.hpp
+++ b/LiteEditor/BuildTab.hpp
@@ -20,6 +20,8 @@ class BuildTab : public wxPanel
     // cleanable properties (between builds)
     bool m_buildInProgress = false;
     wxString m_buffer;
+    wxStopWatch m_buffer_sw;
+    long m_buffer_time = 0;
     CompilerPtr m_activeCompiler;
     size_t m_error_count = 0;
     size_t m_warn_count = 0;

--- a/Plugin/clRowEntry.cpp
+++ b/Plugin/clRowEntry.cpp
@@ -227,20 +227,21 @@ void clRowEntry::ConnectNodes(clRowEntry* first, clRowEntry* second)
 
 void clRowEntry::InsertChild(clRowEntry* child, clRowEntry* prev)
 {
+    clRowEntry::Vec_t::iterator iterCur;
     child->SetParent(this);
     child->SetIndentsCount(GetIndentsCount() + 1);
 
     // We need the last item of this subtree (prev 'this' is the root)
     if(prev == nullptr || prev == this) {
         // make it the first item
-        m_children.insert(m_children.begin(), child);
+        iterCur = m_children.insert(m_children.begin(), child);
     } else {
 
         // optimization:
         // we often get here by calling AddChild(), so don't loop over the list, check if `prev`
         // is the last item
         if(!m_children.empty() && m_children.back() == prev) {
-            m_children.insert(m_children.end(), child);
+            iterCur = m_children.insert(m_children.end(), child);
         } else {
             // Insert the item in the parent children list
             clRowEntry::Vec_t::iterator iter = m_children.end();
@@ -249,14 +250,11 @@ void clRowEntry::InsertChild(clRowEntry* child, clRowEntry* prev)
                 ++iter;
             }
             // if iter is end(), than the is actually appending the item
-            m_children.insert(iter, child);
+            iterCur = m_children.insert(iter, child);
         }
     }
 
     // Connect the linked list for sequential iteration
-    clRowEntry::Vec_t::iterator iterCur =
-        std::find_if(m_children.begin(), m_children.end(), [&](clRowEntry* c) { return c == child; });
-
     clRowEntry* nodeBefore = nullptr;
     // Find the item before and after
     if(iterCur == m_children.begin()) {
@@ -288,12 +286,8 @@ void clRowEntry::SetParent(clRowEntry* parent)
 void clRowEntry::DeleteChild(clRowEntry* child)
 {
     // first remove all of its children
-    // do this in a while loop since 'child->RemoveChild(c);' will alter
-    // the array and will invalidate all iterators
-    while(!child->m_children.empty()) {
-        clRowEntry* c = child->m_children[0];
-        child->DeleteChild(c);
-    }
+    child->DeleteAllChildren();
+
     // Connect the list
     clRowEntry* prev = child->m_prev;
     clRowEntry* next = child->m_next;
@@ -304,10 +298,14 @@ void clRowEntry::DeleteChild(clRowEntry* child)
         next->m_prev = prev;
     }
     // Now disconnect this child from this node
-    clRowEntry::Vec_t::iterator iter =
-        std::find_if(m_children.begin(), m_children.end(), [&](clRowEntry* c) { return c == child; });
-    if(iter != m_children.end()) {
-        m_children.erase(iter);
+    if (child == m_children.back()) { // Fast track for DeleteAllChildren().
+        m_children.pop_back();
+    } else {
+        clRowEntry::Vec_t::iterator iter =
+            std::find_if(m_children.begin(), m_children.end(), [&](clRowEntry* c) { return c == child; });
+        if(iter != m_children.end()) {
+            m_children.erase(iter);
+        }
     }
     wxDELETE(child);
 }
@@ -865,7 +863,7 @@ bool clRowEntry::IsVisible() const
 void clRowEntry::DeleteAllChildren()
 {
     while(!m_children.empty()) {
-        clRowEntry* c = m_children[0];
+        clRowEntry* c = m_children.back();
         // DeleteChild will remove it from the array
         DeleteChild(c);
     }


### PR DESCRIPTION
Fix for https://github.com/eranif/codelite/issues/3298

Added process rate limit because ```m_view->Commit();``` and ```m_view->ScrollToBottom();``` heavy. (100 ms)
Added output lines count process limit to reduce ```m_activeCompiler->Matches()``` calls (8192 lines)

Improve ```clRowEntry::DeleteAllChildren()``` and ```clRowEntry::InsertChild()``` speed.