### PR TITLE
Fix missing declarations

### DIFF
--- a/CodeLite/LSP/RenameRequest.cpp
+++ b/CodeLite/LSP/RenameRequest.cpp
@@ -3,6 +3,7 @@
 #include "LSP/LSPEvent.h"
 #include "LSP/ResponseError.h"
 #include "event_notifier.h"
+#include <wx/msgdlg.h>
 
 LSP::RenameRequest::RenameRequest(const wxString& new_name, const wxString& filename, size_t line, size_t column)
 {

--- a/CodeLite/MSYS2.cpp
+++ b/CodeLite/MSYS2.cpp
@@ -4,8 +4,10 @@
 
 #include <functional>
 #include <wx/arrstr.h>
+#include <wx/filename.h>
 #include <wx/stdpaths.h>
 #include <wx/tokenzr.h>
+#include <wx/utils.h>
 
 #ifdef __WXMSW__
 #include <wx/msw/registry.h>

--- a/CodeLite/PlatformCommon.hpp
+++ b/CodeLite/PlatformCommon.hpp
@@ -4,6 +4,7 @@
 #include "codelite_exports.h"
 
 #include <vector>
+#include <wx/arrstr.h>
 #include <wx/string.h>
 
 class WXDLLIMPEXP_CL PlatformCommon

--- a/CodeLite/StdToWX.h
+++ b/CodeLite/StdToWX.h
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <vector>
+#include <wx/arrstr.h>
 #include <wx/string.h>
 
 class WXDLLIMPEXP_CL StdToWX

--- a/CodeLite/istorage.h
+++ b/CodeLite/istorage.h
@@ -31,6 +31,7 @@
 #include "fileentry.h"
 #include "pptable.h"
 #include "tag_tree.h"
+#include <wx/filename.h>
 
 #define MAX_SEARCH_LIMIT 250
 

--- a/LanguageServer/LanguageServerCluster.cpp
+++ b/LanguageServer/LanguageServerCluster.cpp
@@ -39,6 +39,7 @@
 #include <wx/choicdlg.h>
 #include <wx/richmsgdlg.h>
 #include <wx/stc/stc.h>
+#include <wx/wupdlock.h>
 
 namespace
 {

--- a/LiteEditor/ContextRust.cpp
+++ b/LiteEditor/ContextRust.cpp
@@ -32,6 +32,7 @@
 #include "cl_editor_tip_window.h"
 #include "editor_config.h"
 
+#include <wx/xrc/xmlres.h>
 #include <unordered_set>
 
 ContextRust::ContextRust(clEditor* editor)

--- a/LiteEditor/SecondarySideBar.cpp
+++ b/LiteEditor/SecondarySideBar.cpp
@@ -7,6 +7,8 @@
 #include "globals.h"
 #include "imanager.h"
 
+#include <wx/xrc/xmlres.h>
+
 #define VIEW_NAME "Secondary Sidebar"
 
 SecondarySideBar::SecondarySideBar(wxWindow* parent, long style)

--- a/LiteEditor/clConfigurationSelectionCtrl.h
+++ b/LiteEditor/clConfigurationSelectionCtrl.h
@@ -5,6 +5,7 @@
 #include "cl_command_event.h"
 
 #include <wx/arrstr.h>
+#include <wx/choice.h>
 #include <wx/panel.h>
 
 #define OPEN_CONFIG_MGR_STR _("Open Workspace Configuration Manager...")

--- a/LiteEditor/clPrintout.h
+++ b/LiteEditor/clPrintout.h
@@ -26,6 +26,7 @@
 #ifndef CLPRINTOUT_H
 #define CLPRINTOUT_H
 
+#include <wx/choice.h>
 #include <wx/string.h>
 #include <wx/gdicmn.h>
 #include <wx/prntbase.h>

--- a/LiteEditor/tabgroupmanager.h
+++ b/LiteEditor/tabgroupmanager.h
@@ -33,7 +33,7 @@
 #include <wx/arrstr.h>
 #include <wx/event.h>
 #include <wx/string.h>
-
+#include <wx/xml/xml.h>
 /**
  * Each pair consists of the tabgroup name, and an array of the names of the constituent tabs
  */

--- a/Plugin/clEditorEditEventsHandler.cpp
+++ b/Plugin/clEditorEditEventsHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "event_notifier.h"
 
+#include <wx/app.h>
 #include <wx/combobox.h>
 #include <wx/stc/stc.h>
 #include <wx/textctrl.h>

--- a/Plugin/clPluginsFindBar.h
+++ b/Plugin/clPluginsFindBar.h
@@ -33,6 +33,7 @@
 #include <codelite_exports.h>
 #include <wx/combobox.h>
 #include <wx/panel.h>
+#include <wx/stattext.h>
 
 class wxStyledTextCtrl;
 

--- a/Plugin/clSideBarCtrl.hpp
+++ b/Plugin/clSideBarCtrl.hpp
@@ -5,7 +5,10 @@
 
 #include <wx/bitmap.h>
 #include <wx/control.h>
+#include <wx/panel.h>
+#include <wx/settings.h>
 #include <wx/simplebook.h>
+#include <wx/sizer.h>
 
 class SideBarButton;
 class WXDLLIMPEXP_SDK clSideBarButtonCtrl : public wxControl

--- a/Plugin/wxTerminalCtrl/wxTerminalEvent.hpp
+++ b/Plugin/wxTerminalCtrl/wxTerminalEvent.hpp
@@ -4,6 +4,7 @@
 #include "codelite_exports.h"
 
 #include <wx/arrstr.h>
+#include <wx/event.h>
 #include <wx/ffile.h>
 #include <wx/utils.h>
 

--- a/Plugin/wxTerminalCtrl/wxTerminalInputCtrl.cpp
+++ b/Plugin/wxTerminalCtrl/wxTerminalInputCtrl.cpp
@@ -12,6 +12,7 @@
 #include <wx/dcclient.h>
 #include <wx/dcgraph.h>
 #include <wx/dcmemory.h>
+#include <wx/menu.h>
 #include <wx/tokenzr.h>
 #include <wx/uiaction.h>
 

--- a/Remoty/sample_codelite_remote_json.cpp
+++ b/Remoty/sample_codelite_remote_json.cpp
@@ -1,6 +1,8 @@
 #ifndef SAMPLE_CODELITE_REMOTE_JSON_HPP
 #define SAMPLE_CODELITE_REMOTE_JSON_HPP
 
+#include <wx/string.h>
+
 const wxString DEFAULT_CODELITE_REMOTE_JSON = R"EOF(
 {
   "Language Server Plugin": {


### PR DESCRIPTION
Fix missing declarations, these cause build problem when not using PCH.
Fixes most of the problems mentioned in #3308 .