### PR TITLE
[CI]: build wxWidget in C++17 with no longer hardcoded parallel jobs.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,8 +28,8 @@ jobs:
       run: |
         mkdir wxWidgets/build-release
         cd wxWidgets/build-release
-        ../configure --enable-shared --enable-monolithic --with-osx_cocoa CXX='clang++ -std=c++11 -stdlib=libc++ -I../src/tiff/libtiff' CC=clang --disable-debug --disable-mediactrl --enable-stl
-        make -j10
+        ../configure --enable-shared --enable-monolithic --with-osx_cocoa CXX='clang++ -std=c++17 -stdlib=libc++ -I../src/tiff/libtiff' CC=clang --disable-debug --disable-mediactrl --enable-stl
+        make -j$(sysctl -n hw.physicalcpu)
         sudo make install
 
     # Codelite
@@ -46,5 +46,6 @@ jobs:
         cmake --build . -j $(sysctl -n hw.physicalcpu)
         cmake --build . --target install
 
-    - name: codelite --version
-      run: codelite.app/Contents/MacOS/codelite --version || exit 0 # codelite --version returns -1
+# Not the right command/path for codelite
+#    - name: codelite --version
+#      run: codelite.app/Contents/MacOS/codelite --version || exit 0 # codelite --version returns -1

--- a/docs/docs/build/build_wx_widgets.md
+++ b/docs/docs/build/build_wx_widgets.md
@@ -106,8 +106,8 @@ git submodule init
 git submodule update
 mkdir build-release
 cd build-release
-../configure --enable-shared --enable-monolithic --with-osx_cocoa CXX='clang++ -std=c++11 -stdlib=libc++ -I../src/tiff/libtiff' CC=clang --disable-debug --disable-mediactrl --enable-stl
-make -j10
+../configure --enable-shared --enable-monolithic --with-osx_cocoa CXX='clang++ -std=c++17 -stdlib=libc++ -I../src/tiff/libtiff' CC=clang --disable-debug --disable-mediactrl --enable-stl
+make -j$(sysctl -n hw.physicalcpu)
 sudo make install
 ```
 


### PR DESCRIPTION
Disable `codelite --version` as path is incorrect.

Report changes in doc too. (Not sure if there is something to do so
https://docs.codelite.org/build/build_wx_widgets/#macos
is actually updated)