### PR TITLE
Fix SIOF (Static initializer order Fiasco) 

### DIFF
--- a/CodeLite/LSP/basic_types.cpp
+++ b/CodeLite/LSP/basic_types.cpp
@@ -13,7 +13,10 @@ INITIALISE_MODULE_LOG(LSP_LOG_HANDLER, "LSP", "lsp.log");
 namespace LSP
 {
 
-clModuleLogger& GetLogHandle() { return LSP_LOG_HANDLER; }
+clModuleLogger& GetLogHandle()
+{
+    return LSP_LOG_HANDLER();
+}
 
 wxString FileNameToURI(const wxString& filename)
 {

--- a/CodeLite/ssh/clSSHChannel.cpp
+++ b/CodeLite/ssh/clSSHChannel.cpp
@@ -125,7 +125,7 @@ void clSSHChannel::Close()
 
     if(m_hadErrors) {
         // log this
-        LOG_DEBUG(LOG) << "ssh session had errors. discarding it" << endl;
+        LOG_DEBUG(LOG()) << "ssh session had errors. discarding it" << endl;
 
     } else {
         // put back the ssh session
@@ -140,7 +140,7 @@ IProcess::Ptr_t clSSHChannel::CreateAndExecuteScript(clSSH::Ptr_t ssh, clSSHDele
                                                      bool wantStderr)
 {
     if(!ssh::write_remote_file_content(ssh, script_path, content)) {
-        LOG_ERROR(LOG) << "failed to write remote file:" << script_path << endl;
+        LOG_ERROR(LOG()) << "failed to write remote file:" << script_path << endl;
         return nullptr;
     }
     return Execute(ssh, std::move(deleter_cb), owner, script_path, wantStderr);
@@ -154,7 +154,7 @@ IProcess::Ptr_t clSSHChannel::Execute(clSSH::Ptr_t ssh, clSSHDeleterFunc deleter
         channel = new clSSHChannel(ssh, std::move(deleter_cb), owner, wantStderr);
         channel->Open();
     } catch(clException& e) {
-        LOG_ERROR(LOG) << "failed to open channel." << e.What() << endl;
+        LOG_ERROR(LOG()) << "failed to open channel." << e.What() << endl;
         wxDELETE(channel);
         return nullptr;
     }

--- a/CodeLite/ssh/clSSHChannelCommon.cpp
+++ b/CodeLite/ssh/clSSHChannelCommon.cpp
@@ -37,14 +37,14 @@ void channel_read_internal(SSHChannel_t channel, ReadResult* result, bool isStde
     int bytes = ssh_channel_read_timeout(channel, buffer, sizeof(buffer) - 1, isStderr ? 1 : 0, 1);
     if(bytes == SSH_ERROR) {
         // an error
-        LOG_DEBUG(LOG) << "channel read error" << endl;
+        LOG_DEBUG(LOG()) << "channel read error" << endl;
         int exit_code = ssh_channel_get_exit_status(channel);
         result->exit_code = exit_code;
         result->rc = ssh::read_result::SSH_IO_ERROR;
 
     } else if(bytes == SSH_EOF) {
         // channel closed
-        LOG_DEBUG(LOG) << "channel read eof" << endl;
+        LOG_DEBUG(LOG()) << "channel read eof" << endl;
         int exit_code = ssh_channel_get_exit_status(channel);
         result->exit_code = exit_code;
         result->rc = ssh::read_result::SSH_CONN_CLOSED;
@@ -52,7 +52,7 @@ void channel_read_internal(SSHChannel_t channel, ReadResult* result, bool isStde
     } else if(bytes == 0) {
         // timeout
         if(ssh_channel_is_eof(channel)) {
-            LOG_DEBUG(LOG) << "channel eof detected" << endl;
+            LOG_DEBUG(LOG()) << "channel eof detected" << endl;
             int exit_code = ssh_channel_get_exit_status(channel);
             result->exit_code = exit_code;
             result->rc = ssh::read_result::SSH_CONN_CLOSED;
@@ -63,7 +63,7 @@ void channel_read_internal(SSHChannel_t channel, ReadResult* result, bool isStde
             result->rc = ssh::read_result::SSH_TIMEOUT;
         }
     } else {
-        LOG_DEBUG(LOG) << "read" << bytes << "bytes" << endl;
+        LOG_DEBUG(LOG()) << "read" << bytes << "bytes" << endl;
         buffer[bytes] = 0;
         result->exit_code = 0;
         result->rc = ssh::read_result::SSH_SUCCESS;

--- a/Plugin/LSP/LSPNetworkRemoteSTDIO.cpp
+++ b/Plugin/LSP/LSPNetworkRemoteSTDIO.cpp
@@ -30,11 +30,11 @@ void LSPNetworkRemoteSTDIO::DoClose()
 
 void LSPNetworkRemoteSTDIO::DoStartRemoteProcess()
 {
-    LOG_DEBUG(LOG) << "Starting remote process:" << endl;
-    LOG_DEBUG(LOG) << m_startupInfo.GetLspServerCommand() << endl;
-    LOG_DEBUG(LOG) << m_startupInfo.GetWorkingDirectory() << endl;
+    LOG_DEBUG(LOG()) << "Starting remote process:" << endl;
+    LOG_DEBUG(LOG()) << m_startupInfo.GetLspServerCommand() << endl;
+    LOG_DEBUG(LOG()) << m_startupInfo.GetWorkingDirectory() << endl;
     for(const auto& p : m_startupInfo.GetEnv()) {
-        LOG_DEBUG(LOG) << p.first << "=" << p.second << endl;
+        LOG_DEBUG(LOG()) << p.first << "=" << p.second << endl;
     }
 
     m_process = clRemoteHost::Instance()->run_interactive_process(
@@ -48,9 +48,9 @@ void LSPNetworkRemoteSTDIO::DoStartRemoteProcess()
 
 void LSPNetworkRemoteSTDIO::Send(const std::string& data)
 {
-    LOG_IF_DEBUG { LOG_DEBUG(LOG) << ">" << data << endl; }
+    LOG_IF_DEBUG { LOG_DEBUG(LOG()) << ">" << data << endl; }
     if(!m_process) {
-        LOG_WARNING(LOG) << "remote server is not running" << endl;
+        LOG_WARNING(LOG()) << "remote server is not running" << endl;
         return;
     }
     m_process->WriteRaw(data);
@@ -88,7 +88,7 @@ void LSPNetworkRemoteSTDIO::OnProcessStderr(clProcessEvent& event)
 void LSPNetworkRemoteSTDIO::BindEvents()
 {
     if(!m_process) {
-        LOG_WARNING(LOG) << "failed to bind events. process is not running" << endl;
+        LOG_WARNING(LOG()) << "failed to bind events. process is not running" << endl;
         return;
     }
     if(!m_eventsBound) {

--- a/Plugin/clRemoteHost.cpp
+++ b/Plugin/clRemoteHost.cpp
@@ -95,7 +95,7 @@ clSSH::Ptr_t clRemoteHost::CreateSession(const wxString& account_name)
     // create new session
     auto account = SSHAccountInfo::LoadAccount(account_name);
     if(account.GetHost().empty()) {
-        LOG_WARNING(LOG) << "could not find account:" << account_name << endl;
+        LOG_WARNING(LOG()) << "could not find account:" << account_name << endl;
         return nullptr;
     }
 
@@ -111,11 +111,11 @@ clSSH::Ptr_t clRemoteHost::CreateSession(const wxString& account_name)
         }
         ssh_session->Login();
     } catch(clException& e) {
-        LOG_ERROR(LOG) << "Failed to open ssh channel to account:" << account.GetAccountName() << "." << e.What()
+        LOG_ERROR(LOG()) << "Failed to open ssh channel to account:" << account.GetAccountName() << "." << e.What()
                        << endl;
         return nullptr;
     }
-    LOG_DEBUG(LOG) << "Initializing for account:" << account_name << "completed successfully" << endl;
+    LOG_DEBUG(LOG()) << "Initializing for account:" << account_name << "completed successfully" << endl;
     return ssh_session;
 }
 
@@ -140,10 +140,10 @@ void clRemoteHost::OnCommandStderr(clProcessEvent& event)
 {
     const std::string& output = event.GetStringRaw();
     if(m_callbacks.empty()) {
-        LOG_WARNING(LOG) << "no callback found for command output" << endl;
+        LOG_WARNING(LOG()) << "no callback found for command output" << endl;
         return;
     }
-    LOG_DEBUG(LOG) << "stderr:" << event.GetStringRaw().size() << "bytes" << endl;
+    LOG_DEBUG(LOG()) << "stderr:" << event.GetStringRaw().size() << "bytes" << endl;
     // call the callback
     m_callbacks.front().first(output, clRemoteCommandStatus::STDERR);
 }
@@ -152,10 +152,10 @@ void clRemoteHost::OnCommandStdout(clProcessEvent& event)
 {
     const std::string& output = event.GetStringRaw();
     if(m_callbacks.empty()) {
-        LOG_WARNING(LOG) << "no callback found for command output" << endl;
+        LOG_WARNING(LOG()) << "no callback found for command output" << endl;
         return;
     }
-    LOG_DEBUG(LOG) << "stdout:" << event.GetStringRaw().size() << "bytes" << endl;
+    LOG_DEBUG(LOG()) << "stdout:" << event.GetStringRaw().size() << "bytes" << endl;
     // call the callback
     m_callbacks.front().first(output, clRemoteCommandStatus::STDOUT);
 }
@@ -163,12 +163,12 @@ void clRemoteHost::OnCommandStdout(clProcessEvent& event)
 void clRemoteHost::OnCommandCompleted(clProcessEvent& event)
 {
     if(m_callbacks.empty()) {
-        LOG_WARNING(LOG) << "no callback found for command output" << endl;
+        LOG_WARNING(LOG()) << "no callback found for command output" << endl;
         return;
     }
 
     // call the callback and consume it from the queue
-    LOG_DEBUG(LOG) << "command completed. exit status:" << event.GetInt() << endl;
+    LOG_DEBUG(LOG()) << "command completed. exit status:" << event.GetInt() << endl;
     m_callbacks.front().first("", event.GetInt() == 0 ? clRemoteCommandStatus::DONE
                                                       : clRemoteCommandStatus::DONE_WITH_ERROR);
     m_callbacks.erase(m_callbacks.begin());
@@ -180,11 +180,11 @@ IProcess::Ptr_t clRemoteHost::run_interactive_process(wxEvtHandler* parent, cons
     // create new ssh session
     auto ssh_session = CreateSession(m_activeAccount);
     if(!ssh_session) {
-        LOG_ERROR(LOG) << "no ssh session available" << endl;
+        LOG_ERROR(LOG()) << "no ssh session available" << endl;
         return IProcess::Ptr_t{};
     }
 
-    LOG_DEBUG(LOG) << "Launching remote process:" << command << endl;
+    LOG_DEBUG(LOG()) << "Launching remote process:" << command << endl;
     std::vector<wxString> argv{ command.begin(), command.end() };
 
     IProcess::Ptr_t proc(

--- a/Plugin/cl_remote_executor.cpp
+++ b/Plugin/cl_remote_executor.cpp
@@ -34,7 +34,7 @@ IProcess::Ptr_t clRemoteExecutor::try_execute(const clRemoteExecutor::Cmd& cmd)
 {
     auto ssh_session = clRemoteHost::Instance()->TakeSession();
     if(!ssh_session) {
-        LOG_WARNING(LOG) << "SSH session is not opened" << endl;
+        LOG_WARNING(LOG()) << "SSH session is not opened" << endl;
         return nullptr;
     }
 
@@ -44,7 +44,7 @@ IProcess::Ptr_t clRemoteExecutor::try_execute(const clRemoteExecutor::Cmd& cmd)
         ssh_session, [](clSSH::Ptr_t ssh) { clRemoteHost::Instance()->AddSshSession(ssh); }, this, command, true);
 
     if(!proc) {
-        LOG_ERROR(LOG) << "failed to start remote command:" << command << endl;
+        LOG_ERROR(LOG()) << "failed to start remote command:" << command << endl;
         return nullptr;
     }
     return proc;
@@ -54,7 +54,7 @@ void clRemoteExecutor::OnChannelStdout(clCommandEvent& event)
 {
     clProcessEvent output_event{ wxEVT_ASYNC_PROCESS_OUTPUT };
     output_event.SetStringRaw(event.GetStringRaw());
-    LOG_DEBUG(LOG) << "stdout read:" << event.GetStringRaw().size() << "bytes" << endl;
+    LOG_DEBUG(LOG()) << "stdout read:" << event.GetStringRaw().size() << "bytes" << endl;
     ProcessEvent(output_event);
 }
 
@@ -62,13 +62,13 @@ void clRemoteExecutor::OnChannelStderr(clCommandEvent& event)
 {
     clProcessEvent output_event{ wxEVT_ASYNC_PROCESS_STDERR };
     output_event.SetStringRaw(event.GetStringRaw());
-    LOG_DEBUG(LOG) << "stderr read:" << event.GetStringRaw().size() << "bytes" << endl;
+    LOG_DEBUG(LOG()) << "stderr read:" << event.GetStringRaw().size() << "bytes" << endl;
     ProcessEvent(output_event);
 }
 
 void clRemoteExecutor::OnChannelClosed(clCommandEvent& event)
 {
-    LOG_DEBUG(LOG) << "remote channel closed" << endl;
+    LOG_DEBUG(LOG()) << "remote channel closed" << endl;
 
     clProcessEvent output_event{ wxEVT_ASYNC_PROCESS_TERMINATED };
     output_event.SetInt(event.GetInt());

--- a/Plugin/wxTerminalCtrl/wxTerminalAnsiEscapeHandler.cpp
+++ b/Plugin/wxTerminalCtrl/wxTerminalAnsiEscapeHandler.cpp
@@ -990,7 +990,7 @@ wxHandlResultStringView before_first(wxStringView sv, wxChar ch)
 
 void wxTerminalAnsiEscapeHandler::handle_sgr(wxStringView sv, wxTerminalAnsiRendererInterface* renderer)
 {
-    LOG_IF_DEBUG { LOG_DEBUG(LOG) << "SGR:" << wxString(sv.data(), sv.length()) << endl; }
+    LOG_IF_DEBUG { LOG_DEBUG(LOG()) << "SGR:" << wxString(sv.data(), sv.length()) << endl; }
 
     if(sv.empty()) {
         // handle like reset

--- a/Plugin/wxTerminalCtrl/wxTerminalAnsiRendererInterface.cpp
+++ b/Plugin/wxTerminalCtrl/wxTerminalAnsiRendererInterface.cpp
@@ -9,63 +9,63 @@ wxTerminalAnsiRendererInterface::wxTerminalAnsiRendererInterface() {}
 
 wxTerminalAnsiRendererInterface::~wxTerminalAnsiRendererInterface() {}
 
-void wxTerminalAnsiRendererInterface::Bell() { LOG_DEBUG(LOG) << "Bell!" << endl; }
-void wxTerminalAnsiRendererInterface::Backspace() { LOG_DEBUG(LOG) << "Backspace!" << endl; }
-void wxTerminalAnsiRendererInterface::Tab() { LOG_DEBUG(LOG) << "Tab!" << endl; }
-void wxTerminalAnsiRendererInterface::LineFeed() { LOG_DEBUG(LOG) << "Line Feed!" << endl; }
-void wxTerminalAnsiRendererInterface::FormFeed() { LOG_DEBUG(LOG) << "Form Feed!" << endl; }
-void wxTerminalAnsiRendererInterface::CarriageReturn() { LOG_DEBUG(LOG) << "CR!" << endl; }
+void wxTerminalAnsiRendererInterface::Bell() { LOG_DEBUG(LOG()) << "Bell!" << endl; }
+void wxTerminalAnsiRendererInterface::Backspace() { LOG_DEBUG(LOG()) << "Backspace!" << endl; }
+void wxTerminalAnsiRendererInterface::Tab() { LOG_DEBUG(LOG()) << "Tab!" << endl; }
+void wxTerminalAnsiRendererInterface::LineFeed() { LOG_DEBUG(LOG()) << "Line Feed!" << endl; }
+void wxTerminalAnsiRendererInterface::FormFeed() { LOG_DEBUG(LOG()) << "Form Feed!" << endl; }
+void wxTerminalAnsiRendererInterface::CarriageReturn() { LOG_DEBUG(LOG()) << "CR!" << endl; }
 void wxTerminalAnsiRendererInterface::AddString(wxStringView str) {}
 void wxTerminalAnsiRendererInterface::EraseCharacter(int) {}
 
 void wxTerminalAnsiRendererInterface::MoveCaret(long n, wxDirection direction)
 {
-    LOG_IF_DEBUG { LOG_DEBUG(LOG) << "MoveCaret:" << n << ". Direction:" << (int)direction << endl; }
+    LOG_IF_DEBUG { LOG_DEBUG(LOG()) << "MoveCaret:" << n << ". Direction:" << (int)direction << endl; }
 }
 
 void wxTerminalAnsiRendererInterface::SetCaretX(long n)
 {
     m_pos.x = (n - 1); // we are 0 based
     m_pos.x = wxMax(m_pos.x, 0);
-    LOG_IF_DEBUG { LOG_DEBUG(LOG) << "SetCaretX(" << n << ")" << endl; }
+    LOG_IF_DEBUG { LOG_DEBUG(LOG()) << "SetCaretX(" << n << ")" << endl; }
 }
 
 void wxTerminalAnsiRendererInterface::SetCaretY(long n)
 {
     m_pos.y = (n - 1); // we are 0 based
     m_pos.y = wxMax(m_pos.y, 0);
-    LOG_IF_DEBUG { LOG_DEBUG(LOG) << "SetCaretY(" << n << ")" << endl; }
+    LOG_IF_DEBUG { LOG_DEBUG(LOG()) << "SetCaretY(" << n << ")" << endl; }
 }
 
 void wxTerminalAnsiRendererInterface::ClearLine(size_t dir)
 {
-    LOG_IF_DEBUG { LOG_DEBUG(LOG) << "ClearLine" << endl; }
+    LOG_IF_DEBUG { LOG_DEBUG(LOG()) << "ClearLine" << endl; }
 }
 void wxTerminalAnsiRendererInterface::ClearDisplay(size_t dir)
 {
-    LOG_IF_DEBUG { LOG_DEBUG(LOG) << "ClearDisplay" << endl; }
+    LOG_IF_DEBUG { LOG_DEBUG(LOG()) << "ClearDisplay" << endl; }
 }
 void wxTerminalAnsiRendererInterface::SetWindowTitle(wxStringView window_title)
 {
     LOG_IF_DEBUG
     {
-        LOG_DEBUG(LOG) << "SetWindowTitle(" << wxString(window_title.data(), window_title.length()) << ")" << endl;
+        LOG_DEBUG(LOG()) << "SetWindowTitle(" << wxString(window_title.data(), window_title.length()) << ")" << endl;
     }
 }
 
 void wxTerminalAnsiRendererInterface::ResetStyle()
 {
     m_curAttr = m_defaultAttr;
-    LOG_IF_DEBUG { LOG_DEBUG(LOG) << "ResetStyle" << endl; }
+    LOG_IF_DEBUG { LOG_DEBUG(LOG()) << "ResetStyle" << endl; }
 }
 
 void wxTerminalAnsiRendererInterface::SetTextColour(const wxColour& col)
 {
     if(col.IsOk()) {
-        LOG_IF_DEBUG { LOG_DEBUG(LOG) << "SetTextColour(" << col << ")" << endl; }
+        LOG_IF_DEBUG { LOG_DEBUG(LOG()) << "SetTextColour(" << col << ")" << endl; }
         m_curAttr.SetTextColour(col);
     } else {
-        LOG_IF_DEBUG { LOG_DEBUG(LOG) << "SetTextColour(NullColour)" << endl; }
+        LOG_IF_DEBUG { LOG_DEBUG(LOG()) << "SetTextColour(NullColour)" << endl; }
         m_curAttr.SetTextColour(m_defaultAttr.GetTextColour());
     }
 }

--- a/Plugin/wxTerminalCtrl/wxTerminalCtrl.cpp
+++ b/Plugin/wxTerminalCtrl/wxTerminalCtrl.cpp
@@ -99,7 +99,7 @@ void wxTerminalCtrl::StartShell()
     penv = &env;
 #endif
 
-    LOG_DEBUG(TERM_LOG) << "Starting shell process:" << shell_exec << endl;
+    LOG_DEBUG(TERM_LOG()) << "Starting shell process:" << shell_exec << endl;
     if(m_shellCommand == "bash") {
         m_shell = ::CreateAsyncProcess(this, shell_exec + " --login -i", IProcessRawOutput, wxEmptyString, penv);
     } else {
@@ -107,17 +107,17 @@ void wxTerminalCtrl::StartShell()
     }
 
     if(m_shell) {
-        LOG_DEBUG(TERM_LOG) << "Setting working directory to:" << m_startingDirectory << endl;
+        LOG_DEBUG(TERM_LOG()) << "Setting working directory to:" << m_startingDirectory << endl;
         if(!m_startingDirectory.empty()) {
             // now that we have a shell, set the working directory
             SetTerminalWorkingDirectory(m_startingDirectory);
         }
-        LOG_DEBUG(TERM_LOG) << "Successfully started shell terminal" << endl;
+        LOG_DEBUG(TERM_LOG()) << "Successfully started shell terminal" << endl;
         wxTerminalEvent readyEvent(wxEVT_TERMINAL_CTRL_READY);
         readyEvent.SetEventObject(this);
         GetEventHandler()->AddPendingEvent(readyEvent);
     } else {
-        LOG_ERROR(TERM_LOG) << "Failed to launch shell terminal:" << shell_exec << endl;
+        LOG_ERROR(TERM_LOG()) << "Failed to launch shell terminal:" << shell_exec << endl;
     }
     m_inputCtrl->SetFocus();
 }
@@ -127,7 +127,7 @@ void wxTerminalCtrl::Run(const wxString& command)
     if(!m_shell) {
         return;
     }
-    LOG_DEBUG(TERM_LOG) << "-->" << command << endl;
+    LOG_DEBUG(TERM_LOG()) << "-->" << command << endl;
     m_shell->WriteRaw(command + "\n");
 
     wxStringView sv{ command.wc_str(), command.length() };
@@ -328,7 +328,7 @@ void wxTerminalCtrl::ProcessOutputBuffer()
     }
 
     wxStringView sv{ m_processOutput.data(), m_processOutput.length() };
-    LOG_IF_DEBUG { LOG_DEBUG(TERM_LOG) << "<--" << wxString(sv.data(), sv.length()) << endl; }
+    LOG_IF_DEBUG { LOG_DEBUG(TERM_LOG()) << "<--" << wxString(sv.data(), sv.length()) << endl; }
 
     AppendText(sv);
 

--- a/Plugin/wxTerminalCtrl/wxTerminalOutputCtrl.cpp
+++ b/Plugin/wxTerminalCtrl/wxTerminalOutputCtrl.cpp
@@ -16,12 +16,9 @@
 #include "wxTerminalCtrl.h"
 #include "wxTerminalInputCtrl.hpp"
 
-#include <wx/uiaction.h>
-
-INITIALISE_MODULE_LOG(LOG, "AnsiEscapeHandler", "ansi_escape_parser.log");
-
 #include <wx/menu.h>
 #include <wx/sizer.h>
+#include <wx/uiaction.h>
 #include <wx/wupdlock.h>
 
 namespace


### PR DESCRIPTION
with lazy initialization of loggers:

`clStandardPaths::Get().GetUserDataDir()` (called from Logger constructor) requires that Application is set.