### PR TITLE
closes #3105.

### DIFF
--- a/CodeLite/cl_process.h
+++ b/CodeLite/cl_process.h
@@ -45,7 +45,6 @@ class WXDLLIMPEXP_CL clProcess : public wxProcess
 {
     long m_pid;
     int m_uid;
-    int m_type;
     wxString m_cmd;
     bool m_redirect;
 
@@ -81,9 +80,7 @@ public:
      */
     long Start(bool hide = true);
 
-    int GetUid() { return m_uid; }
-    void SetType(int type) { m_type = type; }
-    int GetType() const { return m_type; }
+    int GetUid() const { return m_uid; }
     void SetCommand(const wxString& cmd) { m_cmd = cmd; }
     bool HasInput(wxString& input, wxString& errors);
 


### PR DESCRIPTION
closes #3105.
`m_type` not initialized, but in fact not used at all, so removed.