### PR TITLE
Fix compilation on windows with wxWidget version < v3.3.0 (unreleased).

### DIFF
--- a/LiteEditor/app.cpp
+++ b/LiteEditor/app.cpp
@@ -361,7 +361,7 @@ bool CodeLiteApp::OnInit()
 
     ::wxInitAllImageHandlers();
 
-#if defined(__WXMSW__) && !defined(_MSC_VER)
+#if defined(__WXMSW__) && wxCHECK_VERSION(3, 3, 0)
     if (clConfig::Get().Read("CodeLiteAppearance", 0) == 1) {
         // force dark
         MSWEnableDarkMode(wxApp::DarkMode_Always);

--- a/Plugin/drawingutils.cpp
+++ b/Plugin/drawingutils.cpp
@@ -406,7 +406,11 @@ wxBrush DrawingUtils::GetStippleBrush()
     wxColour bgColour = clSystemSettings::GetColour(wxSYS_COLOUR_3DFACE);
     wxBitmap bmpStipple(3, 3);
     wxColour lightPen = bgColour.ChangeLightness(105);
+#if wxCHECK_VERSION(3, 3, 0)
     wxColour darkPen = clSystemSettings::Get().SelectLightDark(bgColour.ChangeLightness(95), *wxBLACK);
+#else
+    wxColour darkPen = clSystemSettings::Get().IsDark() ? bgColour.ChangeLightness(95) : *wxBLACK;
+#endif
 #else
     wxColour bgColour = clSystemSettings::GetDefaultPanelColour();
     wxBitmap bmpStipple(3, 3);


### PR DESCRIPTION
- `SelectLightDark()` and `MSWEnableDarkMode` will be added in v3.3.0.

Note: I tried to test v3.2.4 in CI, but install requires explicitly v3.3.0 dll files ([action](https://github.com/Jarod42/codelite/actions/runs/8950123275/job/24585147575) with
```
CMake Error at cmake_install.cmake:264 (file):
  file INSTALL cannot find
  "D:/a/_temp/msys64/home/runneradmin/root/lib/clang_x64_dll/wxmsw330u_clang_custom.dll"
```
)
