### PR TITLE
gdbparser: fix compile warnings

### DIFF
--- a/gdbparser/main.cpp
+++ b/gdbparser/main.cpp
@@ -95,6 +95,8 @@ bool testChildrenParser()
 
     info.print();
     free(l);
+
+    return true;
 }
 
 char *loadFile(const char *fileName)
@@ -140,6 +142,8 @@ bool testTokens()
     ReadTokens();
     gdb_result_lex_clean();
     free(l);
+
+    return true;
 }
 
 bool testParseLocals()


### PR DESCRIPTION
gdbparser: fix compile warnings

```
32% 498/1526: 1028/1/498: 421.261 1.2 ?: Building CXX object gdbparser/CMakeFiles/gdbparser.dir/main.cpp.o
/tmp/codelite-devel.git/gdbparser/main.cpp: In function `bool testChildrenParser()':
/tmp/codelite-devel.git/gdbparser/main.cpp:98:1: warning: control reaches end of non-void function
[-Wreturn-type]
   98 | }
      | ^
/tmp/codelite-devel.git/gdbparser/main.cpp: In function `bool testTokens()':
/tmp/codelite-devel.git/gdbparser/main.cpp:142:9: warning: control reaches end of non-void
function [-Wreturn-type]
  142 |     free(l);
      |     ~~~~^~~
``'
