### PR TITLE
Register a URL handler for codelite://

### DIFF
--- a/LiteEditor/CMakeLists.txt
+++ b/LiteEditor/CMakeLists.txt
@@ -185,8 +185,13 @@ if(NOT APPLE)
             FILES ${CL_SRC_ROOT}/Runtime/codelite_xterm
             DESTINATION ${CL_INSTALL_BIN}
             PERMISSIONS ${EXE_PERM})
+        install(
+            FILES ${CL_SRC_ROOT}/Runtime/codelite-url-handler
+            DESTINATION ${CL_INSTALL_BIN}
+            PERMISSIONS ${EXE_PERM})
         # Create application launcher, copy application icon to standard location
         install(FILES ${CL_SRC_ROOT}/Runtime/codelite.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+        install(FILES ${CL_SRC_ROOT}/Runtime/codelite-url-handler.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
         # Install icons
 
         # 32x32

--- a/Runtime/codelite-url-handler
+++ b/Runtime/codelite-url-handler
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# CodeLite URL Handler
+# codelite://open?url=file://@file&line=@line
+# codelite://open?file=@file&line=@line
+# codelite://open?url=file://@file:@line
+# codelite://open?file=@file:line
+#
+# @license GPL
+# @author Stefan Auditor <stefan@auditor.email>
+
+function urldecode() { : "${*//+/ }"; echo -e "${_//%/\\x}"; }
+
+arg=$(urldecode "${1}")
+pattern=".*file(:\/\/|\=)(.*)(:|&line=)(.*)"
+
+# Get the file path.
+file=$(echo "${arg}" | sed -r "s/${pattern}/\2/")
+
+# Get the line number.
+line=$(echo "${arg}" | sed -r "s/${pattern}/\4/")
+
+# Check if codelite command exist.
+if type codelite > /dev/null; then
+    /usr/bin/env codelite --line "${line}" "${file}" &
+fi
+
+if type wmctrl > /dev/null; then
+    filename=$(basename "$file")
+    /usr/bin/env wmctrl -i -a $(wmctrl -l | grep "${filename}" | tail -n 1 | cut -d ' ' -f1)
+fi
+
+exit 0

--- a/Runtime/codelite-url-handler.desktop
+++ b/Runtime/codelite-url-handler.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=CodeLite URL Handler
+Exec=codelite-url-handler %u
+Type=Application
+StartupNotify=false
+MimeType=x-scheme-handler/codelite;


### PR DESCRIPTION
Rational: Lots of web development debugging tools support debugging links that opens a file in the editor at a given line. This is often seen in relation to stack traces or other fault detection tools.

Examples of usage:
- [Laravel debugbar](https://github.com/barryvdh/laravel-debugbar/blob/master/config/debugbar.php#L64)
- [PHPStan Pro](https://github.com/phpstan/phpstan/issues/5739#issue-1015340661)

This is based on https://github.com/sanduhrs/phpstorm-url-handler