### PR TITLE
PHPParser: Handle PHP Attributes

### DIFF
--- a/CodeLite/PhpLexer.l
+++ b/CodeLite/PhpLexer.l
@@ -40,6 +40,8 @@ extern "C" int yywrap(void*) { return 1; }
     return x;\
 }
 
+int bracket_count = 0;
+
 %}
 
 /* regex and modes */
@@ -55,6 +57,7 @@ extern "C" int yywrap(void*) { return 1; }
 %x HEREDOC
 %x DSTRING
 %x SINGLE_STRING
+%x ATTRIBUTE
 
 identifier [a-zA-Z_][0-9a-zA-Z_]*
 
@@ -195,6 +198,24 @@ horizontal_white [ ]|{h_tab}
     if(userData->IsCollectingComments()) {
         userData->AppendToComment(yytext[0]);
     }
+}
+<PHP>"#[" {
+    BEGIN(ATTRIBUTE);
+    bracket_count = 1;
+}
+<ATTRIBUTE>"[" {
+    bracket_count++;
+}
+<ATTRIBUTE>"]" {
+    bracket_count--;
+    if (bracket_count == 0) {
+        BEGIN(PHP);
+        return ATTRIBUTE;
+    }
+}
+<ATTRIBUTE>"\n" {
+}
+<ATTRIBUTE>. {
 }
 
 <PHP>"//"|"#" { 


### PR DESCRIPTION
Fixes #3388

This adds very basic parsing of PHP Attributes. Nothing about the content of the attribute is understood or retained, this is just enough to not encounter a parser errors for files that contain non-backwards compatible attributes.

In the long run we will probably need something like PHPDocComment.cpp for parsing the content. Though I'm not sure if that is the right way to go since the format is a lot more formal then PHPDoc.