### PR TITLE
PHPParser: Add support for Null Safe Operator

### DIFF
--- a/CodeLite/PhpLexer.l
+++ b/CodeLite/PhpLexer.l
@@ -265,6 +265,7 @@ horizontal_white [ ]|{h_tab}
 <PHP>"trait"                {LEX_RETURN(kPHP_T_TRAIT);}
 <PHP>"extends"              {LEX_RETURN(kPHP_T_EXTENDS);}
 <PHP>"implements"           {LEX_RETURN(kPHP_T_IMPLEMENTS);}
+<PHP>"?->"                  {LEX_RETURN(kPHP_T_OBJECT_OPERATOR);}
 <PHP>"->"                   {LEX_RETURN(kPHP_T_OBJECT_OPERATOR);}
 <PHP>"::"                   {LEX_RETURN(kPHP_T_PAAMAYIM_NEKUDOTAYIM);}
 <PHP>\\                     {LEX_RETURN(kPHP_T_NS_SEPARATOR);}


### PR DESCRIPTION
Adding this will allow the IDE to properly trigger auto complete suggestion when the null safe operator is used.

From CodeLites perspective there shouldn't be a reason to treat it any different from the regular Object Operator. At least for now.