### PR TITLE
PHP: Add support for Enums

### DIFF
--- a/CodeFormatter/PHPFormatterBuffer.cpp
+++ b/CodeFormatter/PHPFormatterBuffer.cpp
@@ -95,7 +95,7 @@ PHPFormatterBuffer& PHPFormatterBuffer::ProcessToken(const phpLexerToken& token)
             if(m_options.flags & kPFF_BreakBeforeWhile) {
                 InsertSeparatorLine();
             }
-        } else if(token.type == kPHP_T_CLASS) {
+        } else if(token.type == kPHP_T_CLASS || token.type == kPHP_T_ENUM) {
             if(m_options.flags & kPFF_BreakBeforeClass) {
                 InsertSeparatorLine();
             }

--- a/CodeLite/PHPEntityBase.h
+++ b/CodeLite/PHPEntityBase.h
@@ -84,6 +84,7 @@ enum {
     kClass_Interface = (1 << 1),
     kClass_Trait = (1 << 2),
     kClass_Abstract = (1 << 3),
+    kClass_Enum = (1 << 4),
 };
 
 class WXDLLIMPEXP_CL PHPEntityBase

--- a/CodeLite/PHPEntityClass.h
+++ b/CodeLite/PHPEntityClass.h
@@ -74,7 +74,9 @@ public:
     void SetIsInterface(bool b) { SetFlag(kClass_Interface, b); }
     bool IsInterface() const { return HasFlag(kClass_Interface); }
     void SetIsTrait(bool b) { SetFlag(kClass_Trait, b); }
+    void SetIsEnum(bool b) { SetFlag(kClass_Enum, b); }
     bool IsTrait() const { return HasFlag(kClass_Trait); }
+    bool IsEnum() const { return HasFlag(kClass_Enum); }
     void SetIsAbstractClass(bool b) { SetFlag(kClass_Abstract, b); }
     bool IsAbstractClass() const { return HasFlag(kClass_Abstract); }
 };

--- a/CodeLite/PHPExpression.cpp
+++ b/CodeLite/PHPExpression.cpp
@@ -56,6 +56,7 @@ phpLexerToken::Vet_t PHPExpression::CreateExpression(const wxString& text)
         case kPHP_T_CASE:
         case kPHP_T_RETURN:
         case kPHP_T_THROW:
+        case kPHP_T_ENUM:
         case kPHP_T_CLASS:
         case kPHP_T_TRAIT:
         case kPHP_T_INTERFACE:

--- a/CodeLite/PHPScannerTokens.h
+++ b/CodeLite/PHPScannerTokens.h
@@ -130,6 +130,7 @@ enum {
     kPHP_T_HALT_COMPILER,
     kPHP_T_CLASS,
     kPHP_T_TRAIT,
+    kPHP_T_ENUM,
     kPHP_T_INTERFACE,
     kPHP_T_EXTENDS,
     kPHP_T_IMPLEMENTS,

--- a/CodeLite/PHPSourceFile.h
+++ b/CodeLite/PHPSourceFile.h
@@ -187,6 +187,11 @@ protected:
     void OnConstant(const phpLexerToken& tok);
 
     /**
+     * @brief found enum case
+     */
+    void OnEnumCase(const phpLexerToken& tok);
+
+    /**
      * @brief go over the look back tokens and extract all function flags
      */
     size_t LookBackForFunctionFlags();

--- a/CodeLite/PhpLexer.l
+++ b/CodeLite/PhpLexer.l
@@ -281,6 +281,7 @@ horizontal_white [ ]|{h_tab}
 <PHP>"goto"                 {LEX_RETURN(kPHP_T_GOTO);}
 <PHP>"echo"                 {LEX_RETURN(kPHP_T_ECHO);}
 <PHP>"print"                {LEX_RETURN(kPHP_T_PRINT);}
+<PHP>"enum"                 {LEX_RETURN(kPHP_T_ENUM);}
 <PHP>"class"                {LEX_RETURN(kPHP_T_CLASS);}
 <PHP>"interface"            {LEX_RETURN(kPHP_T_INTERFACE);}
 <PHP>"trait"                {LEX_RETURN(kPHP_T_TRAIT);}

--- a/codelitephp/PHPParser/php_code_completion.cpp
+++ b/codelitephp/PHPParser/php_code_completion.cpp
@@ -762,7 +762,7 @@ int PHPCodeCompletion::GetLocationForSettersGetters(const wxString& filecontent,
     phpLexerToken token;
     bool isOK = false;
     while(::phpLexerNext(scanner, token)) {
-        if(token.type != kPHP_T_CLASS) {
+        if(token.type != kPHP_T_CLASS && token.type != kPHP_T_ENUM) {
             continue;
         }
 


### PR DESCRIPTION
This adds full support for [Enums](https://www.php.net/manual/en/language.enumerations.php) (build in methods depends on an up to date STL, see https://github.com/eranif/codelite/pull/3394).