### PR TITLE
Handle anonymous classes

### DIFF
--- a/CodeLite/PHPSourceFile.cpp
+++ b/CodeLite/PHPSourceFile.cpp
@@ -767,14 +767,17 @@ void PHPSourceFile::OnClass(const phpLexerToken& tok)
     bool isAbstractClass = LookBackTokensContains(kPHP_T_ABSTRACT);
 
     // Read until we get the class name
+    wxString name;
     phpLexerToken token;
     while(NextToken(token)) {
         if(token.IsAnyComment())
             continue;
         if(token.type != kPHP_T_IDENTIFIER) {
-            // expecting the class name
-            return;
+            // Anonymous classes
+            name = "@anonymous/" + m_filename.GetFullPath() + "/" + wxString::Format(wxT("%i"), token.lineNumber);
+            break;
         }
+        name = PrependCurrentScope(token.Text());
         break;
     }
 
@@ -789,7 +792,7 @@ void PHPSourceFile::OnClass(const phpLexerToken& tok)
     pClass->SetIsInterface(tok.type == kPHP_T_INTERFACE);
     pClass->SetIsAbstractClass(isAbstractClass);
     pClass->SetIsTrait(tok.type == kPHP_T_TRAIT);
-    pClass->SetFullName(PrependCurrentScope(token.Text()));
+    pClass->SetFullName(name);
     pClass->SetLine(token.lineNumber);
 
     while(NextToken(token)) {


### PR DESCRIPTION
Fixes #3398

Generate a name similar to the run time names for anonymous classes, when encountering a classes with no identifier.

Before this PR a class with no identifier would not be set as the current scope so it's content would instead be assigned to which ever previous scope was set (usually a method) which could lead to crashes when trying to cast it to a class.