### PR TITLE
Check for looping symlinks when building PHP projects

### DIFF
--- a/codelitephp/PHPParser/FilesCollector.cpp
+++ b/codelitephp/PHPParser/FilesCollector.cpp
@@ -52,8 +52,7 @@ void FilesCollector::Collect(const wxString& rootFolder)
             bool isDirectory = wxFileName::DirExists(fullpath);
             if(isDirectory && (m_excludeFolders.count(filename) == 0)) {
                 wxString canonicalPath = wxFileName(fullpath).ResolveLink().GetFullPath();
-                if (visitedFolders.find(canonicalPath) == visitedFolders.end()) {
-                    visitedFolders.insert(canonicalPath);
+                if (visitedFolders.insert(canonicalPath).second) {
                     // A directory
                     Q.push(fullpath);
                     fullpath << wxFileName::GetPathSeparator() << FOLDER_MARKER;

--- a/codelitephp/PHPParser/FilesCollector.cpp
+++ b/codelitephp/PHPParser/FilesCollector.cpp
@@ -31,6 +31,7 @@ void FilesCollector::Collect(const wxString& rootFolder)
         m_filesAndFolders.clear();
         return;
     }
+    std::unordered_set<wxString> visitedFolders;
     std::queue<wxString> Q;
     Q.push(rootFolder);
 
@@ -50,11 +51,14 @@ void FilesCollector::Collect(const wxString& rootFolder)
             fullpath << dir.GetNameWithSep() << filename;
             bool isDirectory = wxFileName::DirExists(fullpath);
             if(isDirectory && (m_excludeFolders.count(filename) == 0)) {
-                // A directory
-                Q.push(fullpath);
-                fullpath << wxFileName::GetPathSeparator() << FOLDER_MARKER;
-                V.push_back(fullpath);
-
+                wxString canonicalPath = wxFileName(fullpath).ResolveLink().GetFullPath();
+                if (visitedFolders.find(canonicalPath) == visitedFolders.end()) {
+                    visitedFolders.insert(canonicalPath);
+                    // A directory
+                    Q.push(fullpath);
+                    fullpath << wxFileName::GetPathSeparator() << FOLDER_MARKER;
+                    V.push_back(fullpath);
+                }
             } else if(!isDirectory && IsFileOK(filename)) {
                 // A file
                 V.push_back(fullpath);


### PR DESCRIPTION
Fixes https://github.com/eranif/codelite/issues/3396

Finally located the issue for the IDE getting stuck on some project, this has brought so much pain over the last few years :sob: 
(I had gotten used to removing the vendor folder before starting CodeLite, or loading a different project and adding search paths)

The solution here is to resolve each folder before scanning it and then keeping track of the resolved paths, if we encounter a real path we have already seen previously we do not visit the symlink.
The alternative could be to simply not follow symlinks, but this feels like a better solution as it supports cases where the symlinks are relevant, but avoids cases where they are self nesting.