### PR TITLE
Fix warning about `printf`:

### DIFF
--- a/CxxParser/main.cpp
+++ b/CxxParser/main.cpp
@@ -68,7 +68,7 @@ void testFuncParser(char *buf)
     }
 
 //	printf("total time: %d\n", end-start);
-    printf("matches found: %d\n", li.size());
+    printf("matches found: %d\n", (int)li.size());
 }
 
 void testExprParser(char *buf)
@@ -116,7 +116,7 @@ void testVarParser(char *buf)
     }
 
 //	printf("total time: %d\n", end-start);
-    printf("matches found: %d\n", li.size());
+    printf("matches found: %d\n", (int)li.size());
 }
 
 void testTypedefParser(char *buf)
@@ -131,7 +131,7 @@ void testTypedefParser(char *buf)
         clTypedef var = *iter;
         var.print();
     }
-    printf("matches found: %d\n", li.size());
+    printf("matches found: %d\n", (int)li.size());
 }
 
 //-------------------------------------------------------


### PR DESCRIPTION
- warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type `std::size_t`.