### PR TITLE
Change 'size_t' to Windows version 'SIZE_T'

### DIFF
--- a/CodeLite/AsyncProcess/winprocess_impl.cpp
+++ b/CodeLite/AsyncProcess/winprocess_impl.cpp
@@ -253,7 +253,7 @@ HRESULT PrepareStartupInformation(HPCON hpc, STARTUPINFOEX* psi)
     si.StartupInfo.cb = sizeof(STARTUPINFOEX);
 
     // Discover the size required for the list
-    size_t bytesRequired;
+    SIZE_T bytesRequired;
     InitializeProcThreadAttributeList(NULL, 1, 0, &bytesRequired);
 
     // Allocate memory to represent the list


### PR DESCRIPTION
Change 'size_t' to Windows version 'SIZE_T' to best fit Windows API's requirement and avoid possible errors on 32b systems.