### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,8 +21,9 @@ jobs:
       uses: actions/checkout@v4
       with:
           repository: wxWidgets/wxWidgets
-          path: wxWidgets
+          ref: v3.2.5
           submodules: recursive
+          path: wxWidgets
     
     - name: Build and install wxWidgets
       run: |

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -33,9 +33,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: wxWidgets/wxWidgets
-        path: wxWidgets
-        # ref: 3.2.4 # use master
+        ref: v3.2.5
         submodules: recursive
+        path: wxWidgets
 
     - name: build and install wxWidgets
       shell: msys2 {0}

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: wxWidgets/wxWidgets
-        ref: v3.2.5
+        ref: 3737245c5195d84f0c788e650c6ad7992eec03d7 # requires a v3.3.0
         submodules: recursive
         path: wxWidgets
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,9 +18,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: wxWidgets/wxWidgets
-        path: wxWidgets
-        ref: 3.2
+        ref: v3.2.5
         submodules: recursive
+        path: wxWidgets
 
     - name: build and install wxWidgets
       run: |


### PR DESCRIPTION
Fix CI
- Use WxWidgets v3.2.5 (latest release) for unix/MacOS
- Use the last working commit from (unreleased) V3.3.0 for msys2 (CMake install uses wxmsw330u_clang_custom.dll)