### PR TITLE
[CI] Fix msys CI and use both wxWidgets 'v3.2.5' and 'master'.

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -9,6 +9,11 @@ jobs:
   msys2:
     runs-on: windows-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        wx-version: ['v3.2.5', 'master']
+
     steps:
     - uses: msys2/setup-msys2@v2
       with:
@@ -33,7 +38,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: wxWidgets/wxWidgets
-        ref: 3737245c5195d84f0c788e650c6ad7992eec03d7 # requires a v3.3.0
+        ref: ${{matrix.wx-version}}
         submodules: recursive
         path: wxWidgets
 
@@ -81,7 +86,7 @@ jobs:
     - name: artifact
       uses: actions/upload-artifact@v4
       with:
-        name: codelite-installer
+        name: codelite-installer-wx-${{matrix.wx-version}}
         path: |
           build-release/installer/**.*
 


### PR DESCRIPTION
wxWidgets sha1 3737245c5195d84f0c788e650c6ad7992eec03d7 no longer works with Codelite Fix