### PR TITLE
[cleanup] Fix typos:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,7 +592,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DebugFull)
     set(CL_PCH_FILE "${CL_SRC_ROOT}/PCH/precompiled_header_dbg.h")
     set(CL_PCH_TARGET "precompiled_header_dbg.h.gch")
 
-    # Set the libraries outout directory
+    # Set the libraries output directory
     set(CL_BIN_DIR bin)
     set(CL_LIB_DIR lib)
     if(APPLE)
@@ -662,7 +662,7 @@ else()
         add_custom_target(distclean COMMAND cd ${CL_SRC_ROOT}/PCH && $(MAKE) type=release clean)
     endif(APPLE)
 
-    # Set the libraries outout directory
+    # Set the libraries output directory
     set(CL_BIN_DIR bin)
     set(CL_LIB_DIR lib)
 

--- a/CodeLite/AsyncProcess/asyncprocess.h
+++ b/CodeLite/AsyncProcess/asyncprocess.h
@@ -213,7 +213,7 @@ WXDLLIMPEXP_CL IProcess* CreateAsyncProcess(wxEvtHandler* parent, const std::vec
                                             const wxString& sshAccountName = wxEmptyString);
 
 /**
- * @brief create synchronus process
+ * @brief create synchronous process
  * @param cmd command to execute
  * @param flags process creation flags
  * @param workingDir working directory for the new process

--- a/CodeLite/archive.h
+++ b/CodeLite/archive.h
@@ -49,7 +49,7 @@ WX_DECLARE_STRING_HASH_MAP(wxString, StringMap);
 
 /**
  * \class Archive
- * \brief an auxulariy class which serializes variables into XML format
+ * \brief an auxiliary class which serializes variables into XML format
  * \author Eran
  * \date 07/20/07
  */

--- a/Debugger/debuggergdb.h
+++ b/Debugger/debuggergdb.h
@@ -36,7 +36,7 @@
 #include <wx/hashmap.h>
 #include <wx/string.h>
 
-#ifdef MSVC_VER
+#ifdef _MSC_VER
 // declare the debugger function creation
 extern "C++" IDebugger* CreateDebuggerGDB();
 // declare the function that will be called by host application

--- a/Interfaces/ieditor.h
+++ b/Interfaces/ieditor.h
@@ -398,7 +398,7 @@ public:
      * inside the pattern and will select it
      * @param pattern pattern to search in the editor
      * @param what    sub string of pattern to select
-     * @param navmgr  Navigation manager to place browsing recrods
+     * @param navmgr  Navigation manager to place browsing records
      * @return return true if a match was found, false otherwise
      */
     virtual bool FindAndSelect(const wxString& pattern, const wxString& what, int from_pos, NavMgr* navmgr) = 0;
@@ -429,14 +429,14 @@ public:
     virtual void SetLexerName(const wxString& lexerName) = 0;
 
     /**
-     * @brief return the line numebr containing 'pos'
+     * @brief return the line number containing 'pos'
      * @param pos the position
      */
     virtual int LineFromPos(int pos) = 0;
     /**
-     * @brief return the start pos of line nummber
+     * @brief return the start pos of line number
      * @param line the line number
-     * @return line nummber or 0 if the document is empty
+     * @return line number or 0 if the document is empty
      */
     virtual int PosFromLine(int line) = 0;
 

--- a/Interfaces/imanager.h
+++ b/Interfaces/imanager.h
@@ -355,7 +355,7 @@ public:
      * @brief add files to a virtual folder in the project
      * @param item a tree item which represents the tree item of the virtual folder
      * @param paths an array of files to add
-     * @return true on sucesss, false otherwise
+     * @return true on success, false otherwise
      */
     virtual bool AddFilesToVirtualFolder(wxTreeItemId& item, wxArrayString& paths) = 0;
 
@@ -363,7 +363,7 @@ public:
      * @brief add files to a virtual folder in the project
      * @param vdFullPath virtual directory full path in the form of <project>:vd1:vd2:...:vdN
      * @param paths an array of files to add
-     * @return true on sucesss, false otherwise
+     * @return true on success, false otherwise
      */
     virtual bool AddFilesToVirtualFolder(const wxString& vdFullPath, wxArrayString& paths) = 0;
 
@@ -371,7 +371,7 @@ public:
      * @brief Add a pair of cpp/h files to the :src/include folders, if these exist
      * @param vdFullPath virtual directory full path in the form of <project>:vd1:vd2:...:vdN
      * @param paths an array of files to add
-     * @return true on sucesss, false otherwise
+     * @return true on success, false otherwise
      */
     virtual bool AddFilesToVirtualFolderIntelligently(const wxString& vdFullPath, wxArrayString& paths) = 0;
 
@@ -418,7 +418,7 @@ public:
     /**
      * @brief return the project execution command as set in the project's settings
      * @param projectName the project
-     * @param wd starting dirctory
+     * @param wd starting directory
      * @return the execution command or wxEmptyString if the project does not exist
      */
     virtual wxString GetProjectExecutionCommand(const wxString& projectName, wxString& wd) = 0;

--- a/LiteEditor/cl_editor.h
+++ b/LiteEditor/cl_editor.h
@@ -823,7 +823,7 @@ public:
      * @param pattern pattern to search in the editor
      * @param what    sub string of pattern to select
      * @param pos     start the search from 'pos'
-     * @param navmgr  Navigation manager to place browsing recrods
+     * @param navmgr  Navigation manager to place browsing records
      * @return return true if a match was found, false otherwise
      */
     bool FindAndSelect(const wxString& pattern, const wxString& what, int pos, NavMgr* navmgr) override;
@@ -1010,15 +1010,15 @@ public:
     wxString FormatTextKeepIndent(const wxString& text, int pos, size_t flags = 0) override;
 
     /**
-     * @brief return the line numebr containing 'pos'
+     * @brief return the line number containing 'pos'
      * @param pos the position
      */
     int LineFromPos(int pos) override;
 
     /**
-     * @brief return the start pos of line nummber
+     * @brief return the start pos of line number
      * @param line the line number
-     * @return line nummber or 0 if the document is empty
+     * @return line number or 0 if the document is empty
      */
     int PosFromLine(int line) override;
 

--- a/abbreviation/abbreviation.cpp
+++ b/abbreviation/abbreviation.cpp
@@ -257,7 +257,7 @@ bool AbbreviationPlugin::InsertExpansion(const wxString& abbreviation)
 
         text = editor->FormatTextKeepIndent(text, selStart, Format_Text_Save_Empty_Lines);
 
-        // remove the first line indenation that might have been placed by CL
+        // remove the first line indentation that might have been placed by CL
         text.Trim(false).Trim();
         text = textLeadingSpaces + text;
 

--- a/sdk/websocketpp/websocketpp/processors/processor.hpp
+++ b/sdk/websocketpp/websocketpp/processors/processor.hpp
@@ -305,7 +305,7 @@ public:
 
     /// process new websocket connection bytes
     /**
-     * WebSocket connections are a continous stream of bytes that must be
+     * WebSocket connections are a continuous stream of bytes that must be
      * interpreted by a protocol processor into discrete frames.
      *
      * @param buf Buffer from which bytes should be read.


### PR DESCRIPTION
- MSVC_VER -> _MSC_VER (Only one CODE related)
- auxulariy -> auxiliary
- continous -> continuous
- dirctory -> directory
- indenation -> indentation
- numebr nummber -> number
- outout -> output
- recrods -> records
- sucesss -> success
- synchronus -> synchronous