### PR TITLE
[cleanup]:

### DIFF
--- a/abbreviation/abbreviation.h
+++ b/abbreviation/abbreviation.h
@@ -29,35 +29,31 @@
 #include "cl_command_event.h"
 #include "plugin.h"
 
-class AbbreviationPlugin;
 class AbbreviationPlugin : public IPlugin
 {
-    wxEvtHandler* m_topWindow;
+    wxEvtHandler* m_topWindow = nullptr;
     clConfig m_config;
-    // AbbreviationServiceProvider* m_helper = nullptr;
-
-    friend class AbbreviationServiceProvider;
 
 protected:
     void OnSettings(wxCommandEvent& e);
     void OnShowAbbvreviations(wxCommandEvent& e);
-    void GetAbbreviations(wxCodeCompletionBoxEntry::Vec_t& entries, const wxString& filter);
+    wxCodeCompletionBoxEntry::Vec_t GetAbbreviations(const wxString& filter);
     void OnAbbrevSelected(clCodeCompletionEvent& e);
     void InitDefaults();
     bool InsertExpansion(const wxString& abbreviation);
     void OnCompletionBoxShowing(clCodeCompletionEvent& event);
 
 public:
-    AbbreviationPlugin(IManager* manager);
-    ~AbbreviationPlugin();
+    explicit AbbreviationPlugin(IManager* manager);
+    ~AbbreviationPlugin() override = default;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 };
 
 #endif // abbreviation

--- a/abbreviation/abbreviationentry.cpp
+++ b/abbreviation/abbreviationentry.cpp
@@ -24,13 +24,6 @@
 //////////////////////////////////////////////////////////////////////////////
 
 #include "abbreviationentry.h"
-AbbreviationEntry::AbbreviationEntry()
-    : m_entries()
-    , m_autoInsert(false)
-{
-}
-
-AbbreviationEntry::~AbbreviationEntry() {}
 
 void AbbreviationEntry::DeSerialize(Archive& arch)
 {

--- a/abbreviation/abbreviationentry.h
+++ b/abbreviation/abbreviationentry.h
@@ -26,22 +26,22 @@
 #ifndef __abbreviationentry__
 #define __abbreviationentry__
 
-#include "cl_config.h"
 #include "JSON.h"
+#include "cl_config.h"
 #include "serialized_object.h"
 
 class AbbreviationEntry : public SerializedObject
 {
     wxStringMap_t m_entries;
-    bool m_autoInsert;
+    bool m_autoInsert = false;
 
 public:
-    AbbreviationEntry();
-    virtual ~AbbreviationEntry();
+    AbbreviationEntry() = default;
+    ~AbbreviationEntry() override = default;
 
 public:
-    virtual void DeSerialize(Archive& arch);
-    virtual void Serialize(Archive& arch);
+    void DeSerialize(Archive& arch) override;
+    void Serialize(Archive& arch) override;
 
     // Setters
     void SetEntries(const wxStringMap_t& entries) { this->m_entries = entries; }
@@ -55,19 +55,18 @@ public:
 class AbbreviationJSONEntry : public clConfigItem
 {
     wxStringMap_t m_entries;
-    bool m_autoInsert;
+    bool m_autoInsert = false;
 
 public:
     AbbreviationJSONEntry()
         : clConfigItem("Abbreviations")
-        , m_autoInsert(false)
     {
     }
 
-    virtual ~AbbreviationJSONEntry() {}
+    ~AbbreviationJSONEntry() override = default;
 
-    virtual void FromJSON(const JSONItem& json);
-    virtual JSONItem ToJSON() const;
+    void FromJSON(const JSONItem& json) override;
+    JSONItem ToJSON() const override;
 
     void SetEntries(const wxStringMap_t& entries) { this->m_entries = entries; }
     const wxStringMap_t& GetEntries() const { return m_entries; }

--- a/abbreviation/abbreviationssettingsdlg.cpp
+++ b/abbreviation/abbreviationssettingsdlg.cpp
@@ -40,13 +40,11 @@ AbbreviationsSettingsDlg::AbbreviationsSettingsDlg(wxWindow* parent, IManager* m
     : AbbreviationsSettingsBase(parent)
     , m_mgr(mgr)
     , m_data()
-    , m_dirty(false)
-    , m_currSelection(wxNOT_FOUND)
     , m_config("abbreviations.conf")
 {
     SetName("AbbreviationsSettingsDlg");
     WindowAttrManager::Load(this);
-    if(!m_config.ReadItem(&m_data)) {
+    if (!m_config.ReadItem(&m_data)) {
         // merge the data from the old configuration
         AbbreviationEntry data;
         m_mgr->GetConfigTool()->ReadObject(wxT("AbbreviationsData"), &data);
@@ -58,21 +56,23 @@ AbbreviationsSettingsDlg::AbbreviationsSettingsDlg(wxWindow* parent, IManager* m
     DoPopulateItems();
 }
 
-AbbreviationsSettingsDlg::~AbbreviationsSettingsDlg() {}
-
 void AbbreviationsSettingsDlg::OnItemSelected(wxCommandEvent& event)
 {
-    if(m_dirty) { DoSaveCurrent(); }
+    if (m_dirty) {
+        DoSaveCurrent();
+    }
     DoSelectItem(event.GetSelection());
 }
 
 void AbbreviationsSettingsDlg::OnNew(wxCommandEvent& e)
 {
-    if(m_dirty) { DoSaveCurrent(); }
+    if (m_dirty) {
+        DoSaveCurrent();
+    }
 
     wxString name = wxGetTextFromUser(_("Abbreviation Name:"), _("New abbreviation..."), wxT(""), this);
-    if(name.IsEmpty() == false) {
-        if(m_listBoxAbbreviations->FindString(name) != wxNOT_FOUND) {
+    if (name.IsEmpty() == false) {
+        if (m_listBoxAbbreviations->FindString(name) != wxNOT_FOUND) {
             wxMessageBox(wxString::Format(_("An abbreviation with this name already exists!")));
             return;
         }
@@ -91,10 +91,12 @@ void AbbreviationsSettingsDlg::OnNew(wxCommandEvent& e)
 
 void AbbreviationsSettingsDlg::OnDelete(wxCommandEvent& event)
 {
-    if(m_activeItemName.IsEmpty() || m_currSelection == wxNOT_FOUND) { return; }
+    if (m_activeItemName.IsEmpty() || m_currSelection == wxNOT_FOUND) {
+        return;
+    }
 
-    if(wxMessageBox(wxString::Format(_("Are you sure you want to delete '%s'"), m_activeItemName.c_str()),
-                    _("CodeLite"), wxYES_NO | wxCANCEL | wxCENTER | wxICON_QUESTION, this) != wxYES) {
+    if (wxMessageBox(wxString::Format(_("Are you sure you want to delete '%s'"), m_activeItemName.c_str()),
+                     _("CodeLite"), wxYES_NO | wxCANCEL | wxCENTER | wxICON_QUESTION, this) != wxYES) {
         return;
     }
 
@@ -107,8 +109,8 @@ void AbbreviationsSettingsDlg::OnDelete(wxCommandEvent& event)
     m_textCtrlName->Clear();
 
     // select the previous item in the list
-    if(m_listBoxAbbreviations->IsEmpty() == false) {
-        switch(m_currSelection) {
+    if (m_listBoxAbbreviations->IsEmpty() == false) {
+        switch (m_currSelection) {
         case 0:
             m_currSelection = 0;
             m_activeItemName = m_listBoxAbbreviations->GetString(0);
@@ -123,7 +125,7 @@ void AbbreviationsSettingsDlg::OnDelete(wxCommandEvent& event)
         m_currSelection = wxNOT_FOUND;
     }
 
-    if(m_currSelection != wxNOT_FOUND) {
+    if (m_currSelection != wxNOT_FOUND) {
         m_listBoxAbbreviations->SetSelection(m_currSelection);
         DoSelectItem(m_currSelection);
     }
@@ -138,7 +140,9 @@ void AbbreviationsSettingsDlg::OnDeleteUI(wxUpdateUIEvent& event)
 void AbbreviationsSettingsDlg::OnSave(wxCommandEvent& event)
 {
     wxUnusedVar(event);
-    if(m_dirty) { DoSaveCurrent(); }
+    if (m_dirty) {
+        DoSaveCurrent();
+    }
     m_data.SetAutoInsert(m_checkBoxImmediateInsert->IsChecked());
     m_config.WriteItem(&m_data);
 }
@@ -147,13 +151,11 @@ void AbbreviationsSettingsDlg::DoPopulateItems()
 {
     m_listBoxAbbreviations->Clear();
     m_stc->ClearAll();
-    wxStringMap_t entries = m_data.GetEntries();
-    wxStringMap_t::iterator iter = entries.begin();
-    for(; iter != entries.end(); ++iter) {
-        m_listBoxAbbreviations->Append(iter->first);
+    for (const auto& [name, code] : m_data.GetEntries()) {
+        m_listBoxAbbreviations->Append(name);
     }
 
-    if(m_listBoxAbbreviations->IsEmpty() == false) {
+    if (m_listBoxAbbreviations->IsEmpty() == false) {
         m_listBoxAbbreviations->Select(0);
         DoSelectItem(0);
     }
@@ -164,7 +166,7 @@ void AbbreviationsSettingsDlg::DoPopulateItems()
 
 void AbbreviationsSettingsDlg::DoSelectItem(int item)
 {
-    if(item >= 0) {
+    if (item >= 0) {
         wxString name = m_listBoxAbbreviations->GetString(item);
         m_activeItemName = name;
         m_currSelection = item;
@@ -173,19 +175,25 @@ void AbbreviationsSettingsDlg::DoSelectItem(int item)
 
         wxStringMap_t entries = m_data.GetEntries();
         wxStringMap_t::iterator iter = entries.find(name);
-        if(iter != entries.end()) { m_stc->SetText(iter->second); }
+        if (iter != entries.end()) {
+            m_stc->SetText(iter->second);
+        }
         m_dirty = false;
     }
 }
 
 void AbbreviationsSettingsDlg::DoSaveCurrent()
 {
-    if(m_currSelection == wxNOT_FOUND) { return; }
+    if (m_currSelection == wxNOT_FOUND) {
+        return;
+    }
 
     // search for the old item
     wxStringMap_t entries = m_data.GetEntries();
     wxStringMap_t::iterator iter = entries.find(m_activeItemName);
-    if(iter != entries.end()) { entries.erase(iter); }
+    if (iter != entries.end()) {
+        entries.erase(iter);
+    }
 
     // insert the new item
     entries[m_textCtrlName->GetValue()] = m_stc->GetText();
@@ -205,7 +213,9 @@ void AbbreviationsSettingsDlg::DoDeleteEntry(const wxString& name)
     // search for the old item
     wxStringMap_t entries = m_data.GetEntries();
     wxStringMap_t::iterator iter = entries.find(name);
-    if(iter != entries.end()) { entries.erase(iter); }
+    if (iter != entries.end()) {
+        entries.erase(iter);
+    }
     m_data.SetEntries(entries);
 }
 
@@ -214,20 +224,23 @@ void AbbreviationsSettingsDlg::OnSaveUI(wxUpdateUIEvent& event) { event.Enable(m
 void AbbreviationsSettingsDlg::OnMarkDirty(wxStyledTextEvent& event)
 {
     event.Skip();
-    if(m_activeItemName.IsEmpty() == false) { m_dirty = true; }
+    if (m_activeItemName.IsEmpty() == false) {
+        m_dirty = true;
+    }
 }
 
 void AbbreviationsSettingsDlg::OnExport(wxCommandEvent& event)
 {
     wxString path = ::wxDirSelector();
-    if(path.IsEmpty()) return;
+    if (path.IsEmpty())
+        return;
 
     // Construct the output file name
     wxFileName fn(path, "abbreviations.conf");
-    if(fn.FileExists()) {
-        if(::wxMessageBox(
-               _("This folder already contains a file named 'abbreviations.conf' - would you like to overrite it?"),
-               "wxCrafter", wxYES_NO | wxCANCEL | wxCENTER | wxICON_QUESTION) != wxYES)
+    if (fn.FileExists()) {
+        if (::wxMessageBox(
+                _("This folder already contains a file named 'abbreviations.conf' - would you like to overwrite it?"),
+                "wxCrafter", wxYES_NO | wxCANCEL | wxCENTER | wxICON_QUESTION) != wxYES)
             return;
     }
     m_config.Save(fn);
@@ -238,12 +251,13 @@ void AbbreviationsSettingsDlg::OnExport(wxCommandEvent& event)
 void AbbreviationsSettingsDlg::OnImport(wxCommandEvent& event)
 {
     wxString path = ::wxFileSelector();
-    if(path.IsEmpty()) return;
+    if (path.IsEmpty())
+        return;
 
     // load the imported configuration
     clConfig cfg(path);
     AbbreviationJSONEntry data, curData;
-    if(!cfg.ReadItem(&data)) {
+    if (!cfg.ReadItem(&data)) {
         ::wxMessageBox(_("The file does not seem to contain a valid abbreviations entries"), "wxCrafter",
                        wxOK | wxICON_WARNING | wxCENTER);
         return;
@@ -263,7 +277,7 @@ void AbbreviationsSettingsDlg::OnImport(wxCommandEvent& event)
 }
 void AbbreviationsSettingsDlg::OnHelp(wxCommandEvent& event)
 {
-    MacrosDlg dlg(this, MacrosDlg::MacrosProject, NULL, NULL);
+    MacrosDlg dlg(this, MacrosDlg::MacrosProject, nullptr, nullptr);
     dlg.ShowModal();
 }
 

--- a/abbreviation/abbreviationssettingsdlg.h
+++ b/abbreviation/abbreviationssettingsdlg.h
@@ -40,24 +40,24 @@ class AbbreviationsSettingsDlg : public AbbreviationsSettingsBase
 {
     IManager* m_mgr;
     AbbreviationJSONEntry m_data;
-    bool m_dirty;
+    bool m_dirty = false;
     wxString m_activeItemName;
-    int m_currSelection;
+    int m_currSelection = wxNOT_FOUND;
     clConfig m_config;
 
 protected:
-    virtual void OnImmediateInsert(wxCommandEvent& event);
-    virtual void OnHelp(wxCommandEvent& event);
-    virtual void OnExport(wxCommandEvent& event);
-    virtual void OnImport(wxCommandEvent& event);
-    virtual void OnMarkDirty(wxStyledTextEvent& event);
-    virtual void OnSaveUI(wxUpdateUIEvent& event);
+    void OnImmediateInsert(wxCommandEvent& event) override;
+    void OnHelp(wxCommandEvent& event) override;
+    void OnExport(wxCommandEvent& event) override;
+    void OnImport(wxCommandEvent& event) override;
+    void OnMarkDirty(wxStyledTextEvent& event) override;
+    void OnSaveUI(wxUpdateUIEvent& event) override;
     // Handlers for AbbreviationsSettingsBase events.
-    void OnItemSelected(wxCommandEvent& event);
-    void OnNew(wxCommandEvent& e);
-    void OnDelete(wxCommandEvent& event);
-    void OnDeleteUI(wxUpdateUIEvent& event);
-    void OnSave(wxCommandEvent& event);
+    void OnItemSelected(wxCommandEvent& event) override;
+    void OnNew(wxCommandEvent& e) override;
+    void OnDelete(wxCommandEvent& event) override;
+    void OnDeleteUI(wxUpdateUIEvent& event) override;
+    void OnSave(wxCommandEvent& event) override;
 
 private:
     void DoPopulateItems();
@@ -68,7 +68,7 @@ private:
 public:
     /** Constructor */
     AbbreviationsSettingsDlg(wxWindow* parent, IManager* mgr);
-    virtual ~AbbreviationsSettingsDlg();
+    ~AbbreviationsSettingsDlg() override = default;
 };
 
 #endif // __abbreviationssettingsdlg__

--- a/translations/codelite.pot
+++ b/translations/codelite.pot
@@ -16361,7 +16361,7 @@ msgstr ""
 #: abbreviation/abbreviationssettingsdlg.cpp:227
 msgid ""
 "This folder already contains a file named 'abbreviations.conf' - would you "
-"like to overrite it?"
+"like to overwrite it?"
 msgstr ""
 
 #: abbreviation/abbreviationssettingsdlg.cpp:232

--- a/translations/ja_JP/LC_MESSAGES/codelite.po
+++ b/translations/ja_JP/LC_MESSAGES/codelite.po
@@ -17080,7 +17080,7 @@ msgstr "'%s' を削除しますか"
 #: abbreviation/abbreviationssettingsdlg.cpp:227
 msgid ""
 "This folder already contains a file named 'abbreviations.conf' - would you "
-"like to overrite it?"
+"like to overwrite it?"
 msgstr ""
 "このフォルダーには、既に 'abbreviations.conf' という名前のファイルが含まれて"
 "います - 上書きしますか？"

--- a/translations/ru_RU/LC_MESSAGES/ru.po
+++ b/translations/ru_RU/LC_MESSAGES/ru.po
@@ -17277,7 +17277,7 @@ msgstr "Вы уверены, что хотите удалить «%s»?"
 #: abbreviation/abbreviationssettingsdlg.cpp:227
 msgid ""
 "This folder already contains a file named 'abbreviations.conf' - would you "
-"like to overrite it?"
+"like to overwrite it?"
 msgstr ""
 "Эта папка уже содержит файл с именем «abbreviations.conf». Перезаписать его?"
 

--- a/translations/zh_CN/LC_MESSAGES/codelite.po
+++ b/translations/zh_CN/LC_MESSAGES/codelite.po
@@ -16165,7 +16165,7 @@ msgstr "你确定要删除“%s”"
 #: abbreviation/abbreviationssettingsdlg.cpp:252
 msgid ""
 "This folder already contains a file named 'abbreviations.conf' - would you "
-"like to overrite it?"
+"like to overwrite it?"
 msgstr "该文件夹已包含一个名为“abbreviations.conf”的文件 - 你想要覆盖它吗？"
 
 #: abbreviation/abbreviationssettingsdlg.cpp:256


### PR DESCRIPTION
- remove commented code and empty functions.
- use `explicit`
- add `override`
- replace output parameter by return type
- replace `NULL` by `nullptr`
- replace `std::for_each` by for-range
- fix typo (indenation -> indentation; overrite -> overwrite)
- clang-format