### PR TITLE
Use `SYSTEM EXCLUDE_FROM_ALL` for `add_subdirectory` of third party

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -890,12 +890,12 @@ endif()
 # add the dtl module include path before we include Plugin folder
 include_directories(submodules/dtl)
 
-add_subdirectory(sdk/wxsqlite3)
-add_subdirectory(sdk/wxshapeframework)
-add_subdirectory(sdk/databaselayer)
+add_subdirectory(sdk/wxsqlite3 SYSTEM) # EXCLUDE_FROM_ALL)
+add_subdirectory(sdk/wxshapeframework SYSTEM EXCLUDE_FROM_ALL)
+add_subdirectory(sdk/databaselayer SYSTEM EXCLUDE_FROM_ALL)
 
 if(NOT APPLE)
-    add_subdirectory(submodules/yaml-cpp)
+    add_subdirectory(submodules/yaml-cpp SYSTEM EXCLUDE_FROM_ALL)
     set(LIBYAML_CPP "yaml-cpp")
 endif()
 
@@ -905,7 +905,7 @@ add_subdirectory(Plugin)
 add_subdirectory(PCH)
 
 set(WITHOUT_INSTALL ON)
-add_subdirectory(submodules/cc-wrapper)
+add_subdirectory(submodules/cc-wrapper SYSTEM EXCLUDE_FROM_ALL)
 
 # include the yaml-cpp directory
 include_directories("${CL_SRC_ROOT}/submodules/yaml-cpp/include")
@@ -919,19 +919,19 @@ if(APPLE)
     set(CMAKE_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}")
 endif()
 
-add_subdirectory("${CL_SRC_ROOT}/submodules/llama.cpp")
-add_subdirectory("${CL_SRC_ROOT}/submodules/llama.cpp/examples/main")
+add_subdirectory("${CL_SRC_ROOT}/submodules/llama.cpp" SYSTEM EXCLUDE_FROM_ALL)
+add_subdirectory("${CL_SRC_ROOT}/submodules/llama.cpp/examples/main" SYSTEM EXCLUDE_FROM_ALL)
 
 if(WXC_APP)
     add_subdirectory(wxcrafter)
 else()
-    add_subdirectory(submodules/ctags)
+    add_subdirectory(submodules/ctags SYSTEM EXCLUDE_FROM_ALL)
     install(TARGETS ctags DESTINATION ${CL_INSTALL_BIN})
     install(TARGETS llama-cli DESTINATION ${CL_INSTALL_BIN})
 
     if(MINGW)
         # build wx-config for Windows
-        add_subdirectory(submodules/wx-config-msys2)
+        add_subdirectory(submodules/wx-config-msys2 SYSTEM EXCLUDE_FROM_ALL)
         install(TARGETS wx-config DESTINATION ${CL_INSTALL_BIN})
     endif()
 
@@ -1020,8 +1020,13 @@ else()
     add_dependencies(libcodelite wxshapeframework databaselayersqlite wxsqlite3)
     add_dependencies(plugin libcodelite)
     add_dependencies(codelite plugin)
+    add_dependencies(codelite ctags)
     add_dependencies(codelite ctagsd)
-
+    add_dependencies(codelite llama-cli)
+    add_dependencies(codelite cc-wrapper)
+    if(MINGW)
+        add_dependencies(codelite wx-config)
+    endif()
     if(NOT APPLE)
         add_dependencies(codelite yaml-cpp)
     endif()

--- a/CxxParserTests/CMakeLists.txt
+++ b/CxxParserTests/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable(CxxLocalVariables ${SRCS})
 target_precompile_headers(CxxLocalVariables REUSE_FROM abbreviation)
 
 # Remove the "lib" prefix from the plugin name
-target_link_libraries(CxxLocalVariables ${LINKER_OPTIONS} ${wxWidgets_LIBRARIES} libcodelite plugin)
+target_link_libraries(CxxLocalVariables ${LINKER_OPTIONS} ${wxWidgets_LIBRARIES} libcodelite plugin wxsqlite3)
 add_definitions(-DCXX_TEST_DIR=\"${CL_SRC_ROOT}/CxxParserTests/Test/\")
 cl_install_executable(CxxLocalVariables)
 

--- a/DebugAdapterClient/CMakeLists.txt
+++ b/DebugAdapterClient/CMakeLists.txt
@@ -3,7 +3,7 @@ add_definitions(-std=c++17)
 set(PLUGIN_NAME "DebugAdapterClient")
 project(DebugAdapterClient)
 
-add_subdirectory("${CL_SRC_ROOT}/submodules/wxdap/dap" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+add_subdirectory("${CL_SRC_ROOT}/submodules/wxdap/dap" ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} SYSTEM EXCLUDE_FROM_ALL)
 
 # wxWidgets include (this will do all the magic to configure everything)
 include("${wxWidgets_USE_FILE}")

--- a/codelitephp/CMakeLists.txt
+++ b/codelitephp/CMakeLists.txt
@@ -67,7 +67,9 @@ if(BUILD_TESTING)
         libcodelite
         plugin
         ${ADDITIONAL_LIBRARIES}
-        ${wxWidgets_LIBRARIES})
+        ${wxWidgets_LIBRARIES}
+        wxsqlite3
+    )
 
     add_test(NAME "PHPUnitTests" COMMAND PHPUnitTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/PHPParserUnitTests/Tests)
 endif(BUILD_TESTING)

--- a/ctagsd/CMakeLists.txt
+++ b/ctagsd/CMakeLists.txt
@@ -74,6 +74,7 @@ if(BUILD_TESTING)
     -L"${CL_LIBPATH}"
     libcodelite
     plugin
+    wxsqlite3
     ${UTIL_LIB})
 
   add_test(NAME "ctagsd-tests" COMMAND ctagsd-tests)


### PR DESCRIPTION
So basically
- treat 3rd party header as system header (so no warnings from their header)
- Avoid to install 3rd party from their CMakeFile.txt, in particular llama.cpp's include/lib/cmake are non longer in msys installer)
(didn't succeed to do it properly for wxsqlite3 because of UT requiring .so file)