### PR TITLE
[cleanup] Use `return` instead of output parameter for std containers

### DIFF
--- a/CodeLite/AsyncProcess/winprocess_impl.cpp
+++ b/CodeLite/AsyncProcess/winprocess_impl.cpp
@@ -700,17 +700,16 @@ void WinProcessImpl::Cleanup()
 
     // terminate the process
     if(IsAlive()) {
-        std::map<unsigned long, bool> tree;
-        ProcUtils::GetProcTree(tree, GetPid());
+        const auto tree = ProcUtils::GetProcTree(GetPid());
 
-        for(const auto& vt : tree) {
+        for (const auto& pid : tree) {
             // don't kill ourself
-            if((long)vt.first == GetPid()) {
+            if ((long)pid == GetPid()) {
                 continue;
             }
             wxLogNull NoLog;
             wxKillError rc;
-            wxKill(vt.first, wxSIGKILL, &rc);
+            wxKill(pid, wxSIGKILL, &rc);
         }
         ::TerminateProcess(piProcInfo.hProcess, 0);
     }
@@ -790,16 +789,15 @@ void WinProcessImpl::Terminate()
 {
     // terminate the process
     if(IsAlive()) {
-        std::map<unsigned long, bool> tree;
-        ProcUtils::GetProcTree(tree, GetPid());
+        const std::set<unsigned long> tree = ProcUtils::GetProcTree(GetPid());
 
-        for(const auto& vt : tree) {
-            if((long)vt.first == GetPid()) {
+        for (const auto& pid : tree) {
+            if ((long)pid == GetPid()) {
                 continue;
             }
             wxLogNull NoLOG;
             wxKillError rc;
-            wxKill(vt.first, wxSIGKILL, &rc);
+            wxKill(pid, wxSIGKILL, &rc);
         }
         TerminateProcess(piProcInfo.hProcess, 0);
     }

--- a/CodeLite/Cxx/cpp_comment_creator.cpp
+++ b/CodeLite/Cxx/cpp_comment_creator.cpp
@@ -57,9 +57,8 @@ wxString CppCommentCreator::FunctionComment()
     wxString comment;
 
     // parse the function signature
-    std::vector<TagEntryPtr> tags;
     Language* lang = LanguageST::Get();
-    lang->GetLocalVariables(m_tag->GetSignature(), tags, true);
+    const std::vector<TagEntryPtr> tags = lang->GetLocalVariables(m_tag->GetSignature(), true);
 
     comment << wxT("$(FunctionPattern)\n");
     for(size_t i = 0; i < tags.size(); i++)

--- a/CodeLite/language.cpp
+++ b/CodeLite/language.cpp
@@ -268,8 +268,8 @@ bool Language::VariableFromPattern(const wxString& in, const wxString& name, Var
 
 bool Language::FunctionFromPattern(TagEntryPtr tag, clFunction& foo) { return false; }
 
-void Language::GetLocalVariables(const wxString& in, std::vector<TagEntryPtr>& tags, bool isFuncSignature,
-                                 const wxString& name, size_t flags)
+std::vector<TagEntryPtr> Language::GetLocalVariables(const wxString& in, bool isFuncSignature, const wxString& name,
+                                                     size_t flags)
 {
     wxString pattern(in);
     pattern = pattern.Trim().Trim(false);
@@ -283,6 +283,7 @@ void Language::GetLocalVariables(const wxString& in, std::vector<TagEntryPtr>& t
                                isFuncSignature);
     CxxVariable::Vec_t locals = scanner.GetVariables(false);
 
+    std::vector<TagEntryPtr> tags;
     for(CxxVariable::Ptr_t local : locals) {
         const wxString& tagName = local->GetName();
 
@@ -316,6 +317,7 @@ void Language::GetLocalVariables(const wxString& in, std::vector<TagEntryPtr>& t
         tag->SetPattern(local->ToString());
         tags.push_back(tag);
     }
+    return tags;
 }
 
 void Language::SetTagsManager(TagsManager* tm) { m_tm = tm; }

--- a/CodeLite/language.h
+++ b/CodeLite/language.h
@@ -134,13 +134,12 @@ public:
     /**
      * Collect local variables from given scope text (in) and an optional symbol name
      * @param in scope to search for
-     * @param tags output, since we dont have full information about each token, all local variables returned are of
-     *type
-     *			   'variable' with public access
      * @param name optional name to look for (name can be partial).
+     * @return since we dont have full information about each token,
+     * all local variables returned are of type 'variable' with public access
      */
-    void GetLocalVariables(const wxString& in, std::vector<TagEntryPtr>& tags, bool isFuncSignature,
-                           const wxString& name = wxEmptyString, size_t flag = PartialMatch);
+    std::vector<TagEntryPtr> GetLocalVariables(const wxString& in, bool isFuncSignature,
+                                               const wxString& name = wxEmptyString, size_t flag = PartialMatch);
 
     wxString ApplyCtagsReplacementTokens(const wxString& in);
 

--- a/CodeLite/procutils.h
+++ b/CodeLite/procutils.h
@@ -28,6 +28,7 @@
 #include "codelite_exports.h"
 
 #include <map>
+#include <set>
 #include <vector>
 #include <wx/arrstr.h>
 #include <wx/defs.h>
@@ -88,7 +89,7 @@ public:
 
     static wxString& WrapInShell(wxString& cmd);
 
-    static void GetProcTree(std::map<unsigned long, bool>& parentsMap, long pid);
+    static std::set<unsigned long> GetProcTree(long pid);
     static void ExecuteCommand(const wxString& command, wxArrayString& output,
                                long flags = wxEXEC_NODISABLE | wxEXEC_SYNC);
     static void ExecuteInteractiveCommand(const wxString& command);

--- a/CodeLite/procutils.h
+++ b/CodeLite/procutils.h
@@ -94,7 +94,7 @@ public:
                                long flags = wxEXEC_NODISABLE | wxEXEC_SYNC);
     static void ExecuteInteractiveCommand(const wxString& command);
     static wxString GetProcessNameByPid(long pid);
-    static void GetProcessList(std::vector<ProcessEntry>& proclist);
+    static std::vector<ProcessEntry> GetProcessList();
     static void GetChildren(long pid, std::vector<long>& children);
     static bool Shell(const wxString& programConsoleCommand);
     static bool Locate(const wxString& name, wxString& where);

--- a/LiteEditor/DebuggerDisassemblyTab.cpp
+++ b/LiteEditor/DebuggerDisassemblyTab.cpp
@@ -101,9 +101,8 @@ void DebuggerDisassemblyTab::OnOutput(clCommandEvent& e)
     DoClearDisassembleView();
     m_stc->SetReadOnly(false);
 
-    clDebuggerBreakpoint::Vec_t memBps;
     wxStringSet_t addressSet;
-    ManagerST::Get()->GetBreakpointsMgr()->GetAllMemoryBreakpoints(memBps);
+    const auto memBps = ManagerST::Get()->GetBreakpointsMgr()->GetAllMemoryBreakpoints();
     for(size_t i = 0; i < memBps.size(); ++i) {
         addressSet.insert(memBps.at(i).memory_address);
     }

--- a/LiteEditor/ImportFilesDialogNew.cpp
+++ b/LiteEditor/ImportFilesDialogNew.cpp
@@ -244,7 +244,12 @@ void ImportFilesDialogNew::OnItemExpanding(wxDataViewEvent& event)
     }
 }
 
-void ImportFilesDialogNew::GetDirectories(wxStringBoolMap_t& dirs) { DoGetCheckedDirs(m_root, dirs); }
+wxStringBoolMap_t ImportFilesDialogNew::GetDirectories()
+{
+    wxStringBoolMap_t dirs;
+    DoGetCheckedDirs(m_root, dirs);
+    return dirs;
+}
 
 void ImportFilesDialogNew::DoGetCheckedDirs(const wxDataViewItem& parent, wxStringBoolMap_t& dirs)
 {

--- a/LiteEditor/ImportFilesDialogNew.h
+++ b/LiteEditor/ImportFilesDialogNew.h
@@ -51,7 +51,7 @@ protected:
 public:
     ImportFilesDialogNew(wxWindow* parent);
     virtual ~ImportFilesDialogNew();
-    void GetDirectories(wxStringBoolMap_t &dirs);
+    wxStringBoolMap_t GetDirectories();
     bool ExtlessFiles();
     wxString GetFileMask();
     wxString GetBaseDir();

--- a/LiteEditor/attachdbgprocdlg.cpp
+++ b/LiteEditor/attachdbgprocdlg.cpp
@@ -70,8 +70,7 @@ void AttachDbgProcDlg::RefreshProcessesList(wxString filter)
     filter.Trim().Trim(false);
 
     // Populate the list with list of processes
-    std::vector<ProcessEntry> proclist;
-    ProcUtils::GetProcessList(proclist);
+    const std::vector<ProcessEntry> proclist = ProcUtils::GetProcessList();
 
     filter.MakeLower();
     for(size_t i = 0; i < proclist.size(); ++i) {

--- a/LiteEditor/batchbuilddlg.cpp
+++ b/LiteEditor/batchbuilddlg.cpp
@@ -163,8 +163,9 @@ void BatchBuildDlg::OnClose( wxCommandEvent& event )
     EndModal(wxID_CANCEL);
 }
 
-void BatchBuildDlg::GetBuildInfoList(std::list<QueueCommand>& buildInfoList)
+std::list<QueueCommand> BatchBuildDlg::GetBuildInfoList() const
 {
+    std::list<QueueCommand> buildInfoList;
     bool clean_log(true);
     for (unsigned int i=0; i<m_checkListConfigurations->GetCount(); i++) {
         if (m_checkListConfigurations->IsChecked(i)) {
@@ -198,6 +199,7 @@ void BatchBuildDlg::GetBuildInfoList(std::list<QueueCommand>& buildInfoList)
             }
         }
     }
+    return buildInfoList;
 }
 
 void BatchBuildDlg::DoInitialize()

--- a/LiteEditor/batchbuilddlg.h
+++ b/LiteEditor/batchbuilddlg.h
@@ -63,7 +63,7 @@ protected:
 public:
 	/** Constructor */
 	BatchBuildDlg( wxWindow* parent );
-	void GetBuildInfoList(std::list<QueueCommand> &buildInfoList);
+	std::list<QueueCommand> GetBuildInfoList() const;
 
 };
 

--- a/LiteEditor/breakpointsmgr.cpp
+++ b/LiteEditor/breakpointsmgr.cpp
@@ -143,10 +143,10 @@ void BreakptMgr::AddBreakpoint()
     }
 }
 
-void BreakptMgr::GetBreakpoints(clDebuggerBreakpoint::Vec_t& li)
+clDebuggerBreakpoint::Vec_t BreakptMgr::GetBreakpoints()
 {
     DoRemoveDuplicateBreakpoints();
-    li = m_bps;
+    return m_bps;
 }
 
 // Get all known breakpoints for this line/file
@@ -1150,12 +1150,11 @@ void BreakptMgr::DoRemoveDuplicateBreakpoints()
 
 int BreakptMgr::DelBreakpointByAddress(const wxString& address)
 {
-    std::vector<clDebuggerBreakpoint> allBps; // Start by finding all on the line
-    GetBreakpoints(allBps);
+    const auto allBps = GetBreakpoints(); // Start by finding all on the line
 
     int breakpointsRemoved = 0;
     for (size_t i = 0; i < allBps.size(); i++) {
-        clDebuggerBreakpoint& bp = allBps.at(i);
+        const clDebuggerBreakpoint& bp = allBps.at(i);
         if (bp.memory_address == address) {
             int bpId = (bp.debugger_id == -1 ? bp.internal_id : bp.debugger_id);
 
@@ -1173,11 +1172,10 @@ int BreakptMgr::DelBreakpointByAddress(const wxString& address)
 clDebuggerBreakpoint::Vec_t BreakptMgr::GetAllMemoryBreakpoints()
 {
     clDebuggerBreakpoint::Vec_t memoryBps;
-    clDebuggerBreakpoint::Vec_t allBps; // Start by finding all on the line
-    GetBreakpoints(allBps);
+    const auto allBps = GetBreakpoints(); // Start by finding all on the line
 
     for (size_t i = 0; i < allBps.size(); i++) {
-        clDebuggerBreakpoint& bp = allBps.at(i);
+        const clDebuggerBreakpoint& bp = allBps.at(i);
         if (!bp.memory_address.IsEmpty()) {
             memoryBps.push_back(bp);
         }

--- a/LiteEditor/breakpointsmgr.cpp
+++ b/LiteEditor/breakpointsmgr.cpp
@@ -1170,8 +1170,9 @@ int BreakptMgr::DelBreakpointByAddress(const wxString& address)
     return breakpointsRemoved;
 }
 
-void BreakptMgr::GetAllMemoryBreakpoints(clDebuggerBreakpoint::Vec_t& memoryBps)
+clDebuggerBreakpoint::Vec_t BreakptMgr::GetAllMemoryBreakpoints()
 {
+    clDebuggerBreakpoint::Vec_t memoryBps;
     clDebuggerBreakpoint::Vec_t allBps; // Start by finding all on the line
     GetBreakpoints(allBps);
 
@@ -1181,6 +1182,7 @@ void BreakptMgr::GetAllMemoryBreakpoints(clDebuggerBreakpoint::Vec_t& memoryBps)
             memoryBps.push_back(bp);
         }
     }
+    return memoryBps;
 }
 
 void BreakptMgr::OnWorkspaceClosed(wxCommandEvent& event)

--- a/LiteEditor/breakpointsmgr.cpp
+++ b/LiteEditor/breakpointsmgr.cpp
@@ -224,8 +224,7 @@ void BreakptMgr::GetTooltip(const wxString& fileName, int lineno, wxString& tip,
 // Done before refreshing after a delete or edit, lest it was the last bp in a file
 void BreakptMgr::DeleteAllBreakpointMarkers()
 {
-    clEditor::Vec_t editors;
-    clMainFrame::Get()->GetMainBook()->GetAllEditors(editors, MainBook::kGetAll_Default);
+    auto editors = clMainFrame::Get()->GetMainBook()->GetAllEditors(MainBook::kGetAll_Default);
     for (size_t i = 0; i < editors.size(); ++i) {
         editors.at(i)->DelAllBreakpointMarkers();
     }
@@ -234,8 +233,7 @@ void BreakptMgr::DeleteAllBreakpointMarkers()
 // Refresh all line-type breakpoint markers in all editors
 void BreakptMgr::RefreshBreakpointMarkers()
 {
-    std::vector<clEditor*> editors;
-    clMainFrame::Get()->GetMainBook()->GetAllEditors(editors, MainBook::kGetAll_Default);
+    auto editors = clMainFrame::Get()->GetMainBook()->GetAllEditors(MainBook::kGetAll_Default);
 
     for (size_t i = 0; i < editors.size(); i++) {
         DoRefreshFileBreakpoints(editors.at(i));

--- a/LiteEditor/breakpointsmgr.h
+++ b/LiteEditor/breakpointsmgr.h
@@ -220,7 +220,7 @@ public:
     /**
      * return list of breakpoints
      */
-    void GetBreakpoints(clDebuggerBreakpoint::Vec_t& li);
+    clDebuggerBreakpoint::Vec_t GetBreakpoints();
 
     /**
      * When a breakpoint is added, the debugger_id it returns finally arrives here

--- a/LiteEditor/breakpointsmgr.h
+++ b/LiteEditor/breakpointsmgr.h
@@ -204,9 +204,8 @@ public:
     bool AddBreakpointByAddress(const wxString& address);
     /**
      * @brief return list of allmemory breakpoints
-     * @param memoryBps
      */
-    void GetAllMemoryBreakpoints(clDebuggerBreakpoint::Vec_t& memoryBps);
+    clDebuggerBreakpoint::Vec_t GetAllMemoryBreakpoints();
 
     /**
      * Summon the BreakptProperties dialog for a bp

--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -6316,8 +6316,7 @@ void clEditor::OnZoom(wxStyledTextEvent& event)
     // User triggered this zoom
     int curzoom = GetZoom();
 
-    clEditor::Vec_t editors;
-    clMainFrame::Get()->GetMainBook()->GetAllEditors(editors, MainBook::kGetAll_Default);
+    auto editors = clMainFrame::Get()->GetMainBook()->GetAllEditors(MainBook::kGetAll_Default);
 
     for (auto editor : editors) {
         editor->SetZoomFactor(curzoom);

--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -5352,7 +5352,7 @@ int clEditor::GetCharAtPos(int pos) { return wxStyledTextCtrl::GetCharAt(pos); }
 
 int clEditor::PositionBeforePos(int pos) { return wxStyledTextCtrl::PositionBefore(pos); }
 
-void clEditor::GetChanges(std::vector<int>& changes) { m_deltas->GetChanges(changes); }
+std::vector<int> clEditor::GetChanges() { return m_deltas->GetChanges(); }
 
 void clEditor::OnFindInFiles() { m_deltas->Clear(); }
 

--- a/LiteEditor/cl_editor.h
+++ b/LiteEditor/cl_editor.h
@@ -1087,7 +1087,7 @@ public:
     /**
      * Get a vector of relevant position changes. Used for 'GoTo next/previous FindInFiles match'
      */
-    void GetChanges(std::vector<int>& changes);
+    std::vector<int> GetChanges();
 
     /**
      * Tells the EditorDeltasHolder that there's been (another) FindInFiles call

--- a/LiteEditor/fileview.cpp
+++ b/LiteEditor/fileview.cpp
@@ -1562,7 +1562,6 @@ void FileViewTree::OnImportDirectory(wxCommandEvent& e)
     ProjectPtr proj = ManagerST::Get()->GetProject(project);
 
     bool extlessFiles(false);
-    wxStringBoolMap_t dirs;
     wxArrayString files;
     wxArrayString all_files;
     wxString filespec;
@@ -1573,7 +1572,7 @@ void FileViewTree::OnImportDirectory(wxCommandEvent& e)
     }
 
     extlessFiles = dlg.ExtlessFiles();
-    dlg.GetDirectories(dirs);
+    wxStringBoolMap_t dirs = dlg.GetDirectories();
     filespec = dlg.GetFileMask();
 
     // get list of all files based on the checked directories

--- a/LiteEditor/findinfilesdlg.cpp
+++ b/LiteEditor/findinfilesdlg.cpp
@@ -330,8 +330,7 @@ SearchData FindInFilesDialog::DoGetSearchData()
                 files.Add(editor->GetFileName().GetFullPath());
             }
         } else if ((rootDir == wxGetTranslation(SEARCH_IN_OPEN_FILES)) || (rootDir == SEARCH_IN_OPEN_FILES)) {
-            std::vector<clEditor*> editors;
-            clMainFrame::Get()->GetMainBook()->GetAllEditors(editors, MainBook::kGetAll_Default);
+            std::vector<clEditor*> editors = clMainFrame::Get()->GetMainBook()->GetAllEditors(MainBook::kGetAll_Default);
 
             for (size_t n = 0; n < editors.size(); ++n) {
                 clEditor* editor = dynamic_cast<clEditor*>(*(editors.begin() + n));

--- a/LiteEditor/findresultstab.cpp
+++ b/LiteEditor/findresultstab.cpp
@@ -221,8 +221,7 @@ void FindResultsTab::OnSearchEnded(wxCommandEvent& e)
     // We need to tell all editors that there's been a (new) search
     // This lets them clear any already-saved line-changes,
     // which a new save will have taken into account
-    clEditor::Vec_t editors;
-    clMainFrame::Get()->GetMainBook()->GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    auto editors = clMainFrame::Get()->GetMainBook()->GetAllEditors(MainBook::kGetAll_IncludeDetached);
     for(size_t n = 0; n < editors.size(); ++n) {
         clEditor* editor = dynamic_cast<clEditor*>(*(editors.begin() + n));
         if(editor) {

--- a/LiteEditor/findresultstab.cpp
+++ b/LiteEditor/findresultstab.cpp
@@ -347,8 +347,7 @@ void FindResultsTab::DoOpenSearchResult(const SearchResult& result, wxStyledText
         if(editor && result.GetLen() >= 0) {
             // Update the destination position if there have been subsequent changes in the editor
             int position = editor->PositionFromLine(result.GetLineNumber() - 1) + result.GetColumn();
-            std::vector<int> changes;
-            editor->GetChanges(changes);
+            const std::vector<int> changes = editor->GetChanges();
             unsigned int changesTotal = changes.size();
             int changePosition = 0;
             int changeLength = 0;
@@ -542,7 +541,7 @@ void FindResultsTab::BindSearchEvents(wxEvtHandler* binder)
 
 /////////////////////////////////////////////////////////////////////////////////
 
-void EditorDeltasHolder::GetChanges(std::vector<int>& changes)
+std::vector<int> EditorDeltasHolder::GetChanges()
 {
     // There may have been net +ve or -ve position changes (i.e. undos) subsequent to a last save
     // and some of these may have then been overwritten by different ones. So we need to add both the originals and
@@ -552,10 +551,11 @@ void EditorDeltasHolder::GetChanges(std::vector<int>& changes)
     // none since the last save,
     // but it may also mean that there have been n undos, followed by n different alterations. So we have to treat all
     // array sizes the same
-    changes.clear();
+    std::vector<int> changes;
     for(int index = m_changesForCurrentMatches.size() - 2; index >= 0; index -= 2) {
         changes.push_back(m_changesForCurrentMatches.at(index));      // position
         changes.push_back(-m_changesForCurrentMatches.at(index + 1)); // length
     }
     changes.insert(changes.end(), m_changes.begin(), m_changes.end());
+    return changes;
 }

--- a/LiteEditor/findresultstab.h
+++ b/LiteEditor/findresultstab.h
@@ -171,7 +171,7 @@ public:
 
     void OnFileSaved() { m_changesAtLastSave = m_changes; }
     void OnFileInFiles() { m_changesForCurrentMatches = m_changesAtLastSave; }
-    void GetChanges(std::vector<int>& changes);
+    std::vector<int> GetChanges();
 
 protected:
     std::vector<int> m_changes;

--- a/LiteEditor/frame.cpp
+++ b/LiteEditor/frame.cpp
@@ -4145,15 +4145,9 @@ void clMainFrame::OnBatchBuild(wxCommandEvent& e)
     BatchBuildDlg* batchBuild = new BatchBuildDlg(this);
     if (batchBuild->ShowModal() == wxID_OK) {
         // build the projects
-        std::list<QueueCommand> buildInfoList;
-        batchBuild->GetBuildInfoList(buildInfoList);
-        if (buildInfoList.empty() == false) {
-            std::list<QueueCommand>::iterator iter = buildInfoList.begin();
-
-            // add all build items to queue
-            for (; iter != buildInfoList.end(); iter++) {
-                ManagerST::Get()->PushQueueCommand(*iter);
-            }
+        // add all build items to queue
+        for (const auto& queueCommand : batchBuild->GetBuildInfoList()) {
+            ManagerST::Get()->PushQueueCommand(queueCommand);
         }
     }
     batchBuild->Destroy();

--- a/LiteEditor/frame.cpp
+++ b/LiteEditor/frame.cpp
@@ -1995,8 +1995,7 @@ void clMainFrame::OnFileLoadTabGroup(wxCommandEvent& WXUNUSED(event))
     LoadTabGroupDlg dlg(this, path, previousgroups);
 
     // Disable the 'Replace' checkbox if there aren't any editors to replace
-    std::vector<clEditor*> editors;
-    GetMainBook()->GetAllEditors(editors, MainBook::kGetAll_Default);
+    const auto editors = GetMainBook()->GetAllEditors(MainBook::kGetAll_Default);
     dlg.EnableReplaceCheck(editors.size());
 
     if (dlg.ShowModal() != wxID_OK) {
@@ -2203,11 +2202,10 @@ void clMainFrame::OnFileSaveTabGroup(wxCommandEvent& WXUNUSED(event))
 
     SaveTabGroupDlg dlg(this, previousgroups);
 
-    std::vector<clEditor*> editors;
     wxArrayString filepaths;
-    GetMainBook()->GetAllEditors(editors, MainBook::kGetAll_RetainOrder); // We'll want the order of intArr
-                                                                          // to match the order in
-                                                                          // MainBook::SaveSession
+    const auto editors = GetMainBook()->GetAllEditors(MainBook::kGetAll_RetainOrder); // We'll want the order of intArr
+                                                                                      // to match the order in
+                                                                                      // MainBook::SaveSession
     for (size_t i = 0; i < editors.size(); ++i) {
         filepaths.Add(editors[i]->GetFileName().GetFullPath());
     }
@@ -5437,8 +5435,7 @@ void clMainFrame::OnSettingsChanged(wxCommandEvent& e)
     m_pluginsToolbar->SetGroupSpacing(clConfig::Get().Read(kConfigToolbarGroupSpacing, 50));
     m_pluginsToolbar->Realize();
 
-    clEditor::Vec_t editors;
-    GetMainBook()->GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    auto editors = GetMainBook()->GetAllEditors(MainBook::kGetAll_IncludeDetached);
 
     std::for_each(editors.begin(), editors.end(), [&](clEditor* editor) { editor->PreferencesChanged(); });
     m_mainFrameTitleTemplate = clConfig::Get().Read(kConfigFrameTitlePattern, wxString("$workspace $fullpath"));

--- a/LiteEditor/frame.cpp
+++ b/LiteEditor/frame.cpp
@@ -3240,8 +3240,7 @@ void clMainFrame::OnDebugStopUI(wxUpdateUIEvent& e)
 void clMainFrame::OnDebugManageBreakpointsUI(wxUpdateUIEvent& e)
 {
     if (e.GetId() == XRCID("delete_all_breakpoints")) {
-        std::vector<clDebuggerBreakpoint> bps;
-        ManagerST::Get()->GetBreakpointsMgr()->GetBreakpoints(bps);
+        const std::vector<clDebuggerBreakpoint> bps = ManagerST::Get()->GetBreakpointsMgr()->GetBreakpoints();
         e.Enable(bps.size());
     } else if (e.GetId() == XRCID("disable_all_breakpoints")) {
         e.Enable(ManagerST::Get()->GetBreakpointsMgr()->AreThereEnabledBreakpoints());
@@ -4357,8 +4356,7 @@ void clMainFrame::OnStartQuickDebug(clDebugEvent& e)
             return;
         }
 
-        clDebuggerBreakpoint::Vec_t bpList;
-        ManagerST::Get()->GetBreakpointsMgr()->GetBreakpoints(bpList);
+        clDebuggerBreakpoint::Vec_t bpList = ManagerST::Get()->GetBreakpointsMgr()->GetBreakpoints();
         if (!eventStarting.GetBreakpoints().empty()) {
             // one or some plugins sent us list of breakpoints, use them instead
             bpList.swap(eventStarting.GetBreakpoints());

--- a/LiteEditor/mainbook.cpp
+++ b/LiteEditor/mainbook.cpp
@@ -415,9 +415,9 @@ void MainBook::GetAllTabs(clTab::Vec_t& tabs)
 #endif
 }
 
-void MainBook::GetAllEditors(clEditor::Vec_t& editors, size_t flags)
+clEditor::Vec_t MainBook::GetAllEditors(size_t flags)
 {
-    editors.clear();
+    clEditor::Vec_t editors;
     editors.reserve(m_book->GetPageCount());
 
     // Collect booked editors
@@ -427,6 +427,7 @@ void MainBook::GetAllEditors(clEditor::Vec_t& editors, size_t flags)
             editors.push_back(editor);
         }
     }
+    return editors;
 }
 
 int MainBook::FindEditorIndexByFullPath(const wxString& fullpath)
@@ -784,8 +785,7 @@ bool MainBook::UserSelectFiles(std::vector<std::pair<wxFileName, bool>>& files, 
 bool MainBook::SaveAll(bool askUser, bool includeUntitled)
 {
     // turn the 'saving all' flag on so we could 'Veto' all focus events
-    clEditor::Vec_t editors;
-    GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    clEditor::Vec_t editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
 
     std::vector<std::pair<wxFileName, bool>> files;
     size_t n = 0;
@@ -829,8 +829,7 @@ void MainBook::ReloadExternallyModified(bool prompt)
         return;
     }
 
-    clEditor::Vec_t editors;
-    GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    clEditor::Vec_t editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
 
     time_t workspaceModifiedTimeBefore = clCxxWorkspaceST::Get()->GetFileLastModifiedTime();
 
@@ -893,8 +892,7 @@ void MainBook::ReloadExternallyModified(bool prompt)
     }
 
     // See issue: https://github.com/eranif/codelite/issues/663
-    clEditor::Vec_t editorsAgain;
-    GetAllEditors(editorsAgain, MainBook::kGetAll_IncludeDetached);
+    clEditor::Vec_t editorsAgain = GetAllEditors(MainBook::kGetAll_IncludeDetached);
 
     // Make sure that the tabs that we have opened
     // are still available in the main book
@@ -943,8 +941,7 @@ bool MainBook::CloseAllButThis(wxWindow* page)
     wxBusyCursor bc;
     wxWindowUpdateLocker locker{ m_book };
 
-    clEditor::Vec_t editors;
-    GetAllEditors(editors, kGetAll_IncludeDetached);
+    clEditor::Vec_t editors = GetAllEditors(kGetAll_IncludeDetached);
 
     std::vector<std::pair<wxFileName, bool>> files;
     std::unordered_map<wxString, clEditor*> M;
@@ -983,10 +980,9 @@ bool MainBook::CloseAllButThis(wxWindow* page)
 bool MainBook::CloseAll(bool cancellable)
 {
     wxBusyCursor bc;
-    clEditor::Vec_t editors;
     clWindowUpdateLocker locker{ m_book };
 
-    GetAllEditors(editors, kGetAll_IncludeDetached);
+    clEditor::Vec_t editors = GetAllEditors(kGetAll_IncludeDetached);
 
     // filter list of editors for any that need to be saved
     std::vector<std::pair<wxFileName, bool>> files;
@@ -1062,8 +1058,7 @@ void MainBook::SetPageTitle(wxWindow* page, const wxString& name)
 void MainBook::ApplySettingsChanges()
 {
     DoUpdateEditorsThemes();
-    clEditor::Vec_t allEditors;
-    GetAllEditors(allEditors, MainBook::kGetAll_IncludeDetached);
+    clEditor::Vec_t allEditors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
     for (auto editor : allEditors) {
         editor->UpdateOptions();
     }
@@ -1082,8 +1077,7 @@ void MainBook::ApplyTabLabelChanges()
         EditorConfigST::Get()->GetOptions()->IsTabShowPath() != (bool)previousShowParentPath) {
         previousShowParentPath = EditorConfigST::Get()->GetOptions()->IsTabShowPath();
 
-        std::vector<clEditor*> editors;
-        GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+        std::vector<clEditor*> editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
         for (size_t i = 0; i < editors.size(); i++) {
             SetPageTitle(editors[i], editors[i]->GetFileName(), editors[i]->IsEditorModified());
         }
@@ -1092,8 +1086,7 @@ void MainBook::ApplyTabLabelChanges()
 
 void MainBook::UnHighlightAll()
 {
-    std::vector<clEditor*> editors;
-    GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    std::vector<clEditor*> editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
     for (size_t i = 0; i < editors.size(); i++) {
         editors[i]->UnHighlightAll();
     }
@@ -1101,8 +1094,7 @@ void MainBook::UnHighlightAll()
 
 void MainBook::DelAllBreakpointMarkers()
 {
-    std::vector<clEditor*> editors;
-    GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    std::vector<clEditor*> editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
     for (size_t i = 0; i < editors.size(); i++) {
         editors[i]->DelAllBreakpointMarkers();
     }
@@ -1110,8 +1102,7 @@ void MainBook::DelAllBreakpointMarkers()
 
 void MainBook::SetViewEOL(bool visible)
 {
-    std::vector<clEditor*> editors;
-    GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    std::vector<clEditor*> editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
     for (size_t i = 0; i < editors.size(); i++) {
         editors[i]->SetViewEOL(visible);
     }
@@ -1119,8 +1110,7 @@ void MainBook::SetViewEOL(bool visible)
 
 void MainBook::HighlightWord(bool hl)
 {
-    std::vector<clEditor*> editors;
-    GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    std::vector<clEditor*> editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
     for (size_t i = 0; i < editors.size(); i++) {
         editors[i]->HighlightWord(hl);
     }
@@ -1128,8 +1118,7 @@ void MainBook::HighlightWord(bool hl)
 
 void MainBook::ShowWhitespace(int ws)
 {
-    std::vector<clEditor*> editors;
-    GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    std::vector<clEditor*> editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
     for (size_t i = 0; i < editors.size(); i++) {
         editors[i]->SetViewWhiteSpace(ws);
     }
@@ -1137,8 +1126,7 @@ void MainBook::ShowWhitespace(int ws)
 
 void MainBook::UpdateColours()
 {
-    std::vector<clEditor*> editors;
-    GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    std::vector<clEditor*> editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
     for (size_t i = 0; i < editors.size(); i++) {
         editors[i]->UpdateColours();
     }
@@ -1146,8 +1134,7 @@ void MainBook::UpdateColours()
 
 void MainBook::UpdateBreakpoints()
 {
-    std::vector<clEditor*> editors;
-    GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    std::vector<clEditor*> editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
     for (size_t i = 0; i < editors.size(); i++) {
         editors[i]->UpdateBreakpoints();
     }
@@ -1228,8 +1215,7 @@ void MainBook::OnPageChanged(wxBookCtrlEvent& e)
     }
 
     // Cancel any tooltip
-    clEditor::Vec_t editors;
-    GetAllEditors(editors, MainBook::kGetAll_IncludeDetached);
+    clEditor::Vec_t editors = GetAllEditors(MainBook::kGetAll_IncludeDetached);
     for (size_t i = 0; i < editors.size(); ++i) {
         // Cancel any calltip when switching from the editor
         editors.at(i)->DoCancelCalltip();
@@ -1285,8 +1271,7 @@ void MainBook::OnPageChanging(wxBookCtrlEvent& e)
 
 void MainBook::SetViewWordWrap(bool b)
 {
-    std::vector<clEditor*> editors;
-    GetAllEditors(editors, MainBook::kGetAll_Default);
+    std::vector<clEditor*> editors = GetAllEditors(MainBook::kGetAll_Default);
     for (size_t i = 0; i < editors.size(); i++) {
         editors[i]->SetWrapMode(b ? wxSTC_WRAP_WORD : wxSTC_WRAP_NONE);
     }
@@ -1350,8 +1335,7 @@ FilesModifiedDlg* MainBook::GetFilesModifiedDlg()
 
 void MainBook::CreateSession(SessionEntry& session, wxArrayInt* excludeArr)
 {
-    std::vector<clEditor*> editors;
-    GetAllEditors(editors, kGetAll_RetainOrder);
+    std::vector<clEditor*> editors = GetAllEditors(kGetAll_RetainOrder);
 
     // Remove editors which belong to the SFTP
     std::vector<clEditor*> editorsTmp;
@@ -1559,8 +1543,7 @@ void MainBook::OnColoursAndFontsChanged(clCommandEvent& e)
 
 void MainBook::DoUpdateEditorsThemes()
 {
-    std::vector<clEditor*> editors;
-    GetAllEditors(editors, MainBook::kGetAll_Default);
+    std::vector<clEditor*> editors = GetAllEditors(MainBook::kGetAll_Default);
     for (size_t i = 0; i < editors.size(); i++) {
         editors[i]->SetSyntaxHighlight(editors[i]->GetContext()->GetName());
     }

--- a/LiteEditor/mainbook.h
+++ b/LiteEditor/mainbook.h
@@ -186,10 +186,9 @@ public:
     clEditor* GetActiveEditor();
     /**
      * @brief return vector of all editors in the notebook. This function only returns instances of type clEditor
-     * @param editors [output]
      * @param flags kGetAll_*
      */
-    void GetAllEditors(clEditor::Vec_t& editors, size_t flags);
+    clEditor::Vec_t GetAllEditors(size_t flags);
     /**
      * @brief return vector of all tabs in the notebook
      * @param tabs [output]

--- a/LiteEditor/manager.cpp
+++ b/LiteEditor/manager.cpp
@@ -2092,11 +2092,10 @@ void Manager::DbgStart(long attachPid)
     }
 
     // We can now get all the gathered breakpoints from the manager
-    std::vector<clDebuggerBreakpoint> bps;
 
     // since files may have been updated and the breakpoints may have been moved,
     // delete all the information
-    GetBreakpointsMgr()->GetBreakpoints(bps);
+    std::vector<clDebuggerBreakpoint> bps = GetBreakpointsMgr()->GetBreakpoints();
 
     // notify plugins that we're about to start debugging
     clDebugEvent eventStarting(wxEVT_DEBUG_STARTING);

--- a/LiteEditor/pluginmanager.cpp
+++ b/LiteEditor/pluginmanager.cpp
@@ -655,8 +655,7 @@ size_t PluginManager::GetAllEditors(IEditor::List_t& editors, bool inOrder)
 
 size_t PluginManager::GetAllBreakpoints(clDebuggerBreakpoint::Vec_t& breakpoints)
 {
-    breakpoints.clear();
-    ManagerST::Get()->GetBreakpointsMgr()->GetBreakpoints(breakpoints);
+    breakpoints = ManagerST::Get()->GetBreakpointsMgr()->GetBreakpoints();
     return breakpoints.size();
 }
 
@@ -938,7 +937,7 @@ void PluginManager::DisplayMessage(const wxString& message, int flags,
 
 void PluginManager::GetBreakpoints(std::vector<clDebuggerBreakpoint>& bpList)
 {
-    ManagerST::Get()->GetBreakpointsMgr()->GetBreakpoints(bpList);
+    bpList = ManagerST::Get()->GetBreakpointsMgr()->GetBreakpoints();
 }
 
 void PluginManager::ShowBuildMenu(clToolBar* toolbar, wxWindowID buttonId)

--- a/LiteEditor/pluginmanager.cpp
+++ b/LiteEditor/pluginmanager.cpp
@@ -642,13 +642,12 @@ size_t PluginManager::GetPageCount() const { return clMainFrame::Get()->GetMainB
 
 size_t PluginManager::GetAllEditors(IEditor::List_t& editors, bool inOrder)
 {
-    clEditor::Vec_t tmpEditors;
     size_t flags = MainBook::kGetAll_IncludeDetached;
     if (inOrder) {
         flags |= MainBook::kGetAll_RetainOrder;
     }
 
-    clMainFrame::Get()->GetMainBook()->GetAllEditors(tmpEditors, flags);
+    clEditor::Vec_t tmpEditors = clMainFrame::Get()->GetMainBook()->GetAllEditors(flags);
     editors.insert(editors.end(), tmpEditors.begin(), tmpEditors.end());
     return editors.size();
 }

--- a/LiteEditor/tabgroupspane.cpp
+++ b/LiteEditor/tabgroupspane.cpp
@@ -223,9 +223,8 @@ void TabgroupsPane::OnItemActivated(wxTreeEvent& event)
             return;
         }
 
-        std::vector<clEditor*> editors;
-        clMainFrame::Get()->GetMainBook()->GetAllEditors(editors, MainBook::kGetAll_IncludeDetached |
-                                                                      MainBook::kGetAll_RetainOrder);
+        std::vector<clEditor*> editors = clMainFrame::Get()->GetMainBook()->GetAllEditors(
+            MainBook::kGetAll_IncludeDetached | MainBook::kGetAll_RetainOrder);
         if(editors.size() > 0) {
             // If there are editors currently loaded, ask if they are to be replaced or added to
             wxString msg(_("Do you want to replace the existing editors? (Say 'No' to load the new ones alongside)"));


### PR DESCRIPTION
(N)RVO or move would apply.

Wx-types would be more problematic as they don't seems to have 'move' semantics; so not including them here.