### PR TITLE
[CMake][CI] Allow to build DatabaseExplorer plugin with mariaDb (mysql)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,7 +44,7 @@ jobs:
         mkdir build-release
         cd build-release
         brew install autoconf automake libtool gettext
-        cmake .. -DCMAKE_BUILD_TYPE=Release -Wno-dev -DBUILD_TESTING=1
+        cmake .. -DCMAKE_BUILD_TYPE=Release -Wno-dev -DWITH_MYSQL=1 -DBUILD_TESTING=1
         cmake --build . -j $(sysctl -n hw.physicalcpu)
         cmake --build . --target install
         ctest --output-on-failure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Codelite's dependencies
       run: |
         # brew update && brew upgrade # fails somehow
-        brew install git cmake libssh hunspell bison flex
+        brew install git cmake libssh hunspell bison flex mariadb
 
     # WxWidgets
     - name: Checkout

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -30,6 +30,7 @@ jobs:
           mingw-w64-clang-x86_64-openssl
           mingw-w64-clang-x86_64-sqlite3
           mingw-w64-clang-x86_64-llvm-openmp
+          mingw-w64-clang-x86_64-libmariadbclient
           bison
           flex
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     - name: install dependencies for wxWidgets
       run: |
         sudo apt-get update
-        sudo apt-get install build-essential cmake git libedit-dev libgtk-3-dev libhunspell-dev libsqlite3-dev libssh-dev pkg-config xterm
+        sudo apt-get install build-essential cmake git libedit-dev libgtk-3-dev libhunspell-dev libsqlite3-dev libssh-dev pkg-config xterm libmariadb-dev
 
     - name: Checkout WxWidgets
       uses: actions/checkout@v4

--- a/DatabaseExplorer/CMakeLists.txt
+++ b/DatabaseExplorer/CMakeLists.txt
@@ -29,6 +29,10 @@ if(WITH_MYSQL)
 
     if(MINGW)
         install(FILES "${MSYS2_BASE}/clang64/bin/libmariadb.dll" DESTINATION "${CMAKE_INSTALL_PREFIX}")
+        msys_list_deps(${MSYS2_BASE}/clang64/bin/libmariadb.dll LIBMARIA_DEPS)
+        foreach(DEP ${LIBMARIA_DEPS})
+            install(FILES "${DEP}" DESTINATION "${CMAKE_INSTALL_PREFIX}")
+        endforeach()
     endif()
 endif(WITH_MYSQL)
 

--- a/DatabaseExplorer/CMakeLists.txt
+++ b/DatabaseExplorer/CMakeLists.txt
@@ -26,6 +26,10 @@ if(WITH_MYSQL)
         message("-- LIBMYSQLCLIENT is set to ${LIBMYSQLCLIENT}")
     endif(${LIBMYSQLCLIENT} STREQUAL "LIBMYSQLCLIENT-NOTFOUND")
     add_definitions(-DDBL_USE_MYSQL=1)
+
+    if(MINGW)
+        install(FILES "${MSYS2_BASE}/clang64/bin/libmariadb.dll" DESTINATION "${CMAKE_INSTALL_PREFIX}")
+    endif()
 endif(WITH_MYSQL)
 
 # On UNIX we require GTK

--- a/docs/docs/build/build_from_sources.md
+++ b/docs/docs/build/build_from_sources.md
@@ -16,6 +16,7 @@ pacman -S mingw-w64-clang-x86_64-zlib     \
           mingw-w64-clang-x86_64-hunspell \
           mingw-w64-clang-x86_64-openssl  \
           mingw-w64-clang-x86_64-sqlite3  \
+          mingw-w64-clang-x86_64-libmariadbclient \
           flex bison
 ```
 
@@ -62,8 +63,9 @@ cd build-release/install
 
 ```bash
     sudo apt install build-essential            \
-                     git cmake flex             \
+                     git cmake                  \
                      libssh-dev libsqlite3-dev  \
+                     libmariadb-dev             \
                      libpcre2-dev bison flex
 ```
 
@@ -130,6 +132,7 @@ brew install git        \
              autoconf   \
              automake   \
              libtool    \
+             mariadb    \
              gettext
 ```
 

--- a/docs/docs/build/build_from_sources.md
+++ b/docs/docs/build/build_from_sources.md
@@ -154,7 +154,7 @@ source $HOME/.$(basename $SHELL)rc
     git submodule update --init --recursive
     mkdir build-release
     cd $_
-    cmake .. -DCMAKE_BUILD_TYPE=Release
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DWITH_MYSQL=1
     make -j$(sysctl -n hw.physicalcpu) install
 ```
 

--- a/sdk/databaselayer/CMakeLists.txt
+++ b/sdk/databaselayer/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Our project is called 'databaselayersqlite' this is how it will be called in visual studio, and in our makefiles.
 project(databaselayersqlite)
 
+option(WITH_MYSQL "Enable support of MySQL for DatabaseExplorer plugin" ON)
+
 # It was noticed that when using MinGW gcc it is essential that 'core' is mentioned before 'base'.
 
 # wxWidgets include (this will do all the magic to configure everything)

--- a/sdk/databaselayer/CMakeLists.txt
+++ b/sdk/databaselayer/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Our project is called 'databaselayersqlite' this is how it will be called in visual studio, and in our makefiles.
 project(databaselayersqlite)
 
-option(WITH_MYSQL "Enable support of MySQL for DatabaseExplorer plugin" ON)
+if (APPLE)
+    option(WITH_MYSQL "Enable support of MySQL for DatabaseExplorer plugin" OFF)
+else ()
+    option(WITH_MYSQL "Enable support of MySQL for DatabaseExplorer plugin" ON)
+endif ()
 
 # It was noticed that when using MinGW gcc it is essential that 'core' is mentioned before 'base'.
 

--- a/sdk/databaselayer/include/wx/dblayer/include/MysqlDatabaseLayer.h
+++ b/sdk/databaselayer/include/wx/dblayer/include/MysqlDatabaseLayer.h
@@ -85,15 +85,15 @@ private:
   void ParseServerAndPort(const wxString& strServer);
 
 #ifndef DONT_USE_DYNAMIC_DATABASE_LAYER_LINKING
-  MysqlInterface* m_pInterface;
+  MysqlInterface* m_pInterface = nullptr;
 #endif
   wxString m_strServer;
   wxString m_strDatabase;
   wxString m_strUser;
   wxString m_strPassword;
-  int m_iPort;
-    
-  void* m_pDatabase;
+  int m_iPort = 0;
+
+  void* m_pDatabase = nullptr;
 
 #if wxUSE_UNICODE
   PointerLookupMap m_ResultSets;

--- a/sdk/databaselayer/src/dblayer/MysqlDatabaseLayer.cpp
+++ b/sdk/databaselayer/src/dblayer/MysqlDatabaseLayer.cpp
@@ -12,100 +12,38 @@
 
 // ctor
 MysqlDatabaseLayer::MysqlDatabaseLayer()
- : DatabaseLayer()
+    : MysqlDatabaseLayer(wxT("localhost:3306"), wxT(""), wxT(""), wxT(""))
 {
-#ifndef DONT_USE_DYNAMIC_DATABASE_LAYER_LINKING
-  m_pInterface = new MysqlInterface();
-  if (!m_pInterface->Init())
-  {
-    SetErrorCode(DATABASE_LAYER_ERROR_LOADING_LIBRARY);
-    SetErrorMessage(wxT("Error loading MySQL library"));
-    ThrowDatabaseException();
-    return;
-  }
-#endif
-  InitDatabase();
-  m_strServer = _("localhost");
-  m_iPort = 3306; // default
-  m_strDatabase = wxT("");
-  m_strUser = wxT("");
-  m_strPassword = wxT("");
 }
 
 MysqlDatabaseLayer::MysqlDatabaseLayer(const wxString& strDatabase)
- : DatabaseLayer()
+    : MysqlDatabaseLayer(wxT("localhost:3306"), strDatabase, wxT(""), wxT(""))
 {
-#ifndef DONT_USE_DYNAMIC_DATABASE_LAYER_LINKING
-  m_pInterface = new MysqlInterface();
-  if (!m_pInterface->Init())
-  {
-    SetErrorCode(DATABASE_LAYER_ERROR_LOADING_LIBRARY);
-    SetErrorMessage(wxT("Error loading MySQL library"));
-    ThrowDatabaseException();
-    return;
-  }
-#endif
-  InitDatabase();
-  m_strServer = _("localhost");
-  m_iPort = 3306; // default
-  m_strUser = wxT("");
-  m_strPassword = wxT("");
-  Open(strDatabase);
 }
 
 MysqlDatabaseLayer::MysqlDatabaseLayer(const wxString& strServer, const wxString& strDatabase)
- : DatabaseLayer()
+    : MysqlDatabaseLayer(strServer, strDatabase, wxT(""), wxT(""))
 {
-#ifndef DONT_USE_DYNAMIC_DATABASE_LAYER_LINKING
-  m_pInterface = new MysqlInterface();
-  if (!m_pInterface->Init())
-  {
-    SetErrorCode(DATABASE_LAYER_ERROR_LOADING_LIBRARY);
-    SetErrorMessage(wxT("Error loading MySQL library"));
-    ThrowDatabaseException();
-    return;
-  }
-#endif
-  InitDatabase();
-  ParseServerAndPort(strServer);
-  m_strUser = wxT("");
-  m_strPassword = wxT("");
-  Open(strDatabase);
 }
 
 MysqlDatabaseLayer::MysqlDatabaseLayer(const wxString& strDatabase, const wxString& strUser, const wxString& strPassword)
- : DatabaseLayer()
+    : MysqlDatabaseLayer(wxT("localhost:3306"), strDatabase, strUser, strPassword)
 {
-#ifndef DONT_USE_DYNAMIC_DATABASE_LAYER_LINKING
-  m_pInterface = new MysqlInterface();
-  if (!m_pInterface->Init())
-  {
-    SetErrorCode(DATABASE_LAYER_ERROR_LOADING_LIBRARY);
-    SetErrorMessage(wxT("Error loading MySQL library"));
-    ThrowDatabaseException();
-    return;
-  }
-#endif
-  InitDatabase();
-  m_strServer = _("localhost");
-  m_iPort = 3306; // default
-  m_strUser = strUser;
-  m_strPassword = strPassword;
-  Open(strDatabase);
 }
 
 MysqlDatabaseLayer::MysqlDatabaseLayer(const wxString& strServer, const wxString& strDatabase, const wxString& strUser, const wxString& strPassword)
  : DatabaseLayer()
 {
 #ifndef DONT_USE_DYNAMIC_DATABASE_LAYER_LINKING
-  m_pInterface = new MysqlInterface();
-  if (!m_pInterface->Init())
-  {
-    SetErrorCode(DATABASE_LAYER_ERROR_LOADING_LIBRARY);
-    SetErrorMessage(wxT("Error loading MySQL library5"));
-    ThrowDatabaseException();
-    return;
-  }
+    try {
+        m_pInterface = new MysqlInterface();
+        m_pInterface->Init();
+    } catch (const wxString& error) {
+        SetErrorCode(DATABASE_LAYER_ERROR_LOADING_LIBRARY);
+        SetErrorMessage(wxT("Error loading MySQL library : ") + error);
+        ThrowDatabaseException();
+        return;
+    }
 #endif
   InitDatabase();
   ParseServerAndPort(strServer);

--- a/sdk/databaselayer/src/dblayer/MysqlInterface.cpp
+++ b/sdk/databaselayer/src/dblayer/MysqlInterface.cpp
@@ -1,306 +1,57 @@
 #include "../include/MysqlInterface.h"
 
+namespace
+{
+template <typename SigPtr>
+SigPtr loadSymbol(wxDynamicLibrary& dll, const wxString& symbol)
+{
+    if (!dll.HasSymbol(symbol)) {
+        throw wxT("Cannot find symbol ") + symbol;
+    }
+    return reinterpret_cast<SigPtr>(dll.GetSymbol(symbol));
+}
+} // namespace
+
 bool MysqlInterface::Init()
 {
 #ifdef __WIN32__
-  bool bLoaded = m_MysqlDLL.Load(wxT("libmariadb.dll"), wxDL_VERBATIM);
+    bool bLoaded = m_MysqlDLL.Load(wxT("libmariadb.dll"), wxDL_VERBATIM);
 #else
-  bool bLoaded = m_MysqlDLL.Load(wxDynamicLibrary::CanonicalizeName(wxT("mysqlclient")));
+    bool bLoaded = m_MysqlDLL.Load(wxDynamicLibrary::CanonicalizeName(wxT("mysqlclient")));
 #endif
-  if (!bLoaded)
-  {
-    return false;
-  }
+    if (!bLoaded) {
+        throw wxString(wxT("dll not found"));
+    }
 
-  wxString symbol = wxT("mysql_server_end");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlServerEnd = (MysqlServerEndType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
+    m_pMysqlServerEnd = loadSymbol<MysqlServerEndType>(m_MysqlDLL, wxT("mysql_server_end"));
+    m_pMysqlInit = loadSymbol<MysqlInitType>(m_MysqlDLL, wxT("mysql_init"));
+    m_pMysqlRealConnect = loadSymbol<MysqlRealConnectType>(m_MysqlDLL, wxT("mysql_real_connect"));
+    m_pMysqlRealQuery = loadSymbol<MysqlRealQueryType>(m_MysqlDLL, wxT("mysql_real_query"));
+    m_pMysqlError = loadSymbol<MysqlErrorType>(m_MysqlDLL, wxT("mysql_error"));
+    m_pMysqlErrno = loadSymbol<MysqlErrnoType>(m_MysqlDLL, wxT("mysql_errno"));
+    m_pMysqlClose = loadSymbol<MysqlCloseType>(m_MysqlDLL, wxT("mysql_close"));
+    m_pMysqlAutoCommit = loadSymbol<MysqlAutoCommitType>(m_MysqlDLL, wxT("mysql_autocommit"));
+    m_pMysqlCommit = loadSymbol<MysqlCommitType>(m_MysqlDLL, wxT("mysql_commit"));
+    m_pMysqlRollback = loadSymbol<MysqlRollbackType>(m_MysqlDLL, wxT("mysql_rollback"));
+    m_pMysqlQuery = loadSymbol<MysqlQueryType>(m_MysqlDLL, wxT("mysql_query"));
+    m_pMysqlAffectedRows = loadSymbol<MysqlAffectedRowsType>(m_MysqlDLL, wxT("mysql_affected_rows"));
+    m_pMysqlStmtInit = loadSymbol<MysqlStmtInitType>(m_MysqlDLL, wxT("mysql_stmt_init"));
+    m_pMysqlStmtPrepare = loadSymbol<MysqlStmtPrepareType>(m_MysqlDLL, wxT("mysql_stmt_prepare"));
+    m_pMysqlStmtExecute = loadSymbol<MysqlStmtExecuteType>(m_MysqlDLL, wxT("mysql_stmt_execute"));
+    m_pMysqlStmtError = loadSymbol<MysqlStmtErrorType>(m_MysqlDLL, wxT("mysql_stmt_error"));
+    m_pMysqlStmtErrno = loadSymbol<MysqlStmtErrnoType>(m_MysqlDLL, wxT("mysql_stmt_errno"));
+    m_pMysqlStmtFreeResult = loadSymbol<MysqlStmtFreeResultType>(m_MysqlDLL, wxT("mysql_stmt_free_result"));
+    m_pMysqlStmtClose = loadSymbol<MysqlStmtCloseType>(m_MysqlDLL, wxT("mysql_stmt_close"));
+    m_pMysqlListTables = loadSymbol<MysqlListTablesType>(m_MysqlDLL, wxT("mysql_list_tables"));
+    m_pMysqlFetchRow = loadSymbol<MysqlFetchRowType>(m_MysqlDLL, wxT("mysql_fetch_row"));
+    m_pMysqlFreeResult = loadSymbol<MysqlFreeResultType>(m_MysqlDLL, wxT("mysql_free_result"));
+    m_pMysqlGetServerVersion = loadSymbol<MysqlGetServerVersionType>(m_MysqlDLL, wxT("mysql_get_server_version"));
+    m_pMysqlStmtResultMetadata = loadSymbol<MysqlStmtResultMetadataType>(m_MysqlDLL, wxT("mysql_stmt_result_metadata"));
+    m_pMysqlNumFields = loadSymbol<MysqlNumFieldsType>(m_MysqlDLL, wxT("mysql_num_fields"));
+    m_pMysqlStmtParamCount = loadSymbol<MysqlStmtParamCountType>(m_MysqlDLL, wxT("mysql_stmt_param_count"));
+    m_pMysqlStmtBindParam = loadSymbol<MysqlStmtBindParamType>(m_MysqlDLL, wxT("mysql_stmt_bind_param"));
+    m_pMysqlStmtFetch = loadSymbol<MysqlStmtFetchType>(m_MysqlDLL, wxT("mysql_stmt_fetch"));
+    m_pMysqlStmtBindResult = loadSymbol<MysqlStmtBindResultType>(m_MysqlDLL, wxT("mysql_stmt_bind_result"));
 
-  symbol = wxT("mysql_init");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlInit = (MysqlInitType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_real_connect");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlRealConnect = (MysqlRealConnectType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_real_query");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlRealQuery = (MysqlRealQueryType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_error");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlError = (MysqlErrorType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_errno");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlErrno = (MysqlErrnoType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_close");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlClose = (MysqlCloseType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_autocommit");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlAutoCommit = (MysqlAutoCommitType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_commit");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlCommit = (MysqlCommitType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_rollback");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlRollback = (MysqlRollbackType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_query");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlQuery = (MysqlQueryType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_affected_rows");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlAffectedRows = (MysqlAffectedRowsType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_init");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtInit = (MysqlStmtInitType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_prepare");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtPrepare = (MysqlStmtPrepareType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_execute");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtExecute = (MysqlStmtExecuteType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_error");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtError = (MysqlStmtErrorType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_errno");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtErrno = (MysqlStmtErrnoType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_free_result");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtFreeResult = (MysqlStmtFreeResultType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_close");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtClose = (MysqlStmtCloseType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_list_tables");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlListTables = (MysqlListTablesType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_fetch_row");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlFetchRow = (MysqlFetchRowType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_free_result");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlFreeResult = (MysqlFreeResultType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_get_server_version");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlGetServerVersion = (MysqlGetServerVersionType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_result_metadata");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtResultMetadata = (MysqlStmtResultMetadataType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_num_fields");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlNumFields = (MysqlNumFieldsType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_param_count");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtParamCount = (MysqlStmtParamCountType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_bind_param");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtBindParam = (MysqlStmtBindParamType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_fetch");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtFetch = (MysqlStmtFetchType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  symbol = wxT("mysql_stmt_bind_result");
-  if (m_MysqlDLL.HasSymbol(symbol))
-  {
-    m_pMysqlStmtBindResult = (MysqlStmtBindResultType)m_MysqlDLL.GetSymbol(symbol);
-  }
-  else
-  {
-    return false;
-  }
-
-  return true;
+    return true;
 }

--- a/sdk/databaselayer/src/dblayer/MysqlInterface.cpp
+++ b/sdk/databaselayer/src/dblayer/MysqlInterface.cpp
@@ -3,7 +3,7 @@
 bool MysqlInterface::Init()
 {
 #ifdef __WIN32__
-  bool bLoaded = m_MysqlDLL.Load(wxT("libmySQL.dll"), wxDL_VERBATIM);
+  bool bLoaded = m_MysqlDLL.Load(wxT("libmariadb.dll"), wxDL_VERBATIM);
 #else
   bool bLoaded = m_MysqlDLL.Load(wxDynamicLibrary::CanonicalizeName(wxT("mysqlclient")));
 #endif

--- a/sdk/databaselayer/src/dblayer/MysqlPreparedStatementResultSet.cpp
+++ b/sdk/databaselayer/src/dblayer/MysqlPreparedStatementResultSet.cpp
@@ -133,7 +133,7 @@ wxString MysqlPreparedStatementResultSet::GetResultString(int nField)
   MYSQL_BIND* pResultBinding = GetResultBinding(nField);
   if (pResultBinding != NULL)
   {
-    if ((*(pResultBinding->is_null) == false))
+    if (*(pResultBinding->is_null) == false)
     {
       strValue = ConvertFromUnicodeStream((char*)(pResultBinding->buffer));
     }
@@ -147,7 +147,7 @@ long MysqlPreparedStatementResultSet::GetResultLong(int nField)
   MYSQL_BIND* pResultBinding = GetResultBinding(nField);
   if (pResultBinding != NULL)
   {
-    if ((*(pResultBinding->is_null) == false))
+    if (*(pResultBinding->is_null) == false)
     {
       int nType = pResultBinding->buffer_type;/*
       if (nType == MYSQL_TYPE_LONGLONG)
@@ -189,7 +189,7 @@ bool MysqlPreparedStatementResultSet::GetResultBool(int nField)
   MYSQL_BIND* pResultBinding = GetResultBinding(nField);
   if (pResultBinding != NULL)
   {
-    if ((*(pResultBinding->is_null) == false))
+    if (*(pResultBinding->is_null) == false)
       bValue = (*((int*)(pResultBinding->buffer)) != 0);
   }
   return bValue;
@@ -201,7 +201,7 @@ wxDateTime MysqlPreparedStatementResultSet::GetResultDate(int nField)
   MYSQL_BIND* pResultBinding = GetResultBinding(nField);
   if (pResultBinding != NULL)
   {
-    if ((*(pResultBinding->is_null) == false))
+    if (*(pResultBinding->is_null) == false)
     {
       MYSQL_TIME* pDate = (MYSQL_TIME*)(pResultBinding->buffer);
 	  if(pDate->year > 0 && pDate->month > 0 && pDate->day > 0)
@@ -217,7 +217,7 @@ void* MysqlPreparedStatementResultSet::GetResultBlob(int nField, wxMemoryBuffer&
   MYSQL_BIND* pResultBinding = GetResultBinding(nField);
   if (pResultBinding != NULL)
   {
-    if ((*(pResultBinding->is_null) == false))
+    if (*(pResultBinding->is_null) == false)
     {
       unsigned long nBufferLength = 0;
       if (pResultBinding->length)
@@ -260,7 +260,7 @@ double MysqlPreparedStatementResultSet::GetResultDouble(int nField)
   MYSQL_BIND* pResultBinding = GetResultBinding(nField);
   if (pResultBinding != NULL)
   {
-    if ((*(pResultBinding->is_null) == false))
+    if (*(pResultBinding->is_null) == false)
     {
       int nType = pResultBinding->buffer_type;
       switch (nType)

--- a/sdk/databaselayer/src/dblayer/MysqlPreparedStatementWrapper.cpp
+++ b/sdk/databaselayer/src/dblayer/MysqlPreparedStatementWrapper.cpp
@@ -100,7 +100,7 @@ int MysqlPreparedStatementWrapper::RunQuery()
   }
   wxDELETEA(pBoundParameters);
 
-  return (m_pStatement->affected_rows);
+  return (m_pStatement->mysql->affected_rows);
 }
 
 DatabaseResultSet* MysqlPreparedStatementWrapper::RunQueryWithResults()


### PR DESCRIPTION
Compile DatabaseExplorer with mysql (mariaDb) enabled by default (but MacOS which default to OFF).

Note: I cannot test behavior for Ubuntu/MacOS.
I did minimal checks on minGW (connect to empty DB).