### PR TITLE
Toolchain warning

### DIFF
--- a/LiteEditor/BuildTab.cpp
+++ b/LiteEditor/BuildTab.cpp
@@ -100,8 +100,17 @@ void BuildTab::OnBuildStarted(clBuildEvent& e)
     // get the toolchain from the event and attempt to load the compiler
     const wxString& toolchain = e.GetToolchain();
     if(!toolchain.empty() && BuildSettingsConfigST::Get()->IsCompilerExist(toolchain)) {
-        m_activeCompiler = BuildSettingsConfigST::Get()->GetCompiler(toolchain);
-        clDEBUG() << "Active compiler is set to:" << m_activeCompiler->GetName() << endl;
+      m_activeCompiler = BuildSettingsConfigST::Get()->GetCompiler(toolchain);
+      clDEBUG() << "Active compiler is set to:" << m_activeCompiler->GetName() << endl;
+
+    } else {
+      clDEBUG() << "Compiler not selected in the workspace build settings or not available" << endl;
+
+      // toolchain not selected in build configuration or unavailable
+      m_view->AppendItem(wxT("\n"));
+      m_view->AppendItem(WrapLineInColour(wxT("> WARNING: No toolchain selected. Build log highlighting will not be available!\n"), AnsiColours::Yellow()));
+      m_view->AppendItem(WrapLineInColour(wxT("           Check toolchain properly selected in the workspace build settings.\n"), AnsiColours::Yellow()));
+      m_view->AppendItem(wxT("\n"));
     }
 
     // notify the plugins that the build had started

--- a/Plugin/bitmap_loader.cpp
+++ b/Plugin/bitmap_loader.cpp
@@ -578,7 +578,7 @@ static wxBitmap LoadSidebarBitmapInternal(const wxString& name, wxWindow* win, b
         return wxNullBitmap;
     }
 
-    wxSize button_size{ 32, 32 };
+    wxSize button_size{ 24, 24 };
 
     auto bmpbundle = wxBitmapBundle::FromSVGFile(svg_path.GetFullPath(), button_size);
     if (!bmpbundle.IsOk()) {


### PR DESCRIPTION
Build log highlighting will not work without any errors when unavailable toolchain selected in the build settings.
Notify user by printing warning message at beginning of the build log.