### PR TITLE
[cleanup] Clean Zoom Navigator

### DIFF
--- a/ZoomNavigator/znSettingsDlg.cpp
+++ b/ZoomNavigator/znSettingsDlg.cpp
@@ -27,7 +27,6 @@
 
 #include "cl_config.h"
 #include "event_notifier.h"
-#include "windowattrmanager.h"
 #include "zn_config_item.h"
 
 wxDEFINE_EVENT(wxEVT_ZN_SETTINGS_UPDATED, wxCommandEvent);
@@ -37,7 +36,7 @@ znSettingsDlg::znSettingsDlg(wxWindow* parent)
 {
     znConfigItem data;
     clConfig conf("zoom-navigator.conf");
-    if(conf.ReadItem(&data)) {
+    if (conf.ReadItem(&data)) {
         m_checkBoxEnableZN->SetValue(data.IsEnabled());
         m_colourPickerHighlightColour->SetColour(wxColour(data.GetHighlightColour()));
         m_checkBoxUseVScrollbar->SetValue(data.IsUseScrollbar());
@@ -47,8 +46,6 @@ znSettingsDlg::znSettingsDlg(wxWindow* parent)
     GetSizer()->Fit(this);
     CentreOnParent();
 }
-
-znSettingsDlg::~znSettingsDlg() {}
 
 void znSettingsDlg::OnOK(wxCommandEvent& event)
 {

--- a/ZoomNavigator/znSettingsDlg.h
+++ b/ZoomNavigator/znSettingsDlg.h
@@ -33,9 +33,10 @@ wxDECLARE_EVENT(wxEVT_ZN_SETTINGS_UPDATED, wxCommandEvent);
 class znSettingsDlg : public znSettingsDlgBase
 {
 public:
-    znSettingsDlg(wxWindow* parent);
-    virtual ~znSettingsDlg();
+    explicit znSettingsDlg(wxWindow* parent);
+    ~znSettingsDlg() override = default;
+
 protected:
-    virtual void OnOK(wxCommandEvent& event);
+    void OnOK(wxCommandEvent& event) override;
 };
 #endif // ZNSETTINGSDLG_H

--- a/ZoomNavigator/zn_config_item.cpp
+++ b/ZoomNavigator/zn_config_item.cpp
@@ -28,13 +28,8 @@
 znConfigItem::znConfigItem()
     : clConfigItem("ZoomNavigator")
     , m_highlightColour("LIGHT GREY")
-    , m_enabled(false)
-    , m_zoomFactor(-10)
-    , m_useScrollbar(true)
 {
 }
-
-znConfigItem::~znConfigItem() {}
 
 void znConfigItem::FromJSON(const JSONItem& json)
 {

--- a/ZoomNavigator/zn_config_item.h
+++ b/ZoomNavigator/zn_config_item.h
@@ -31,17 +31,17 @@
 class znConfigItem : public clConfigItem
 {
     wxString m_highlightColour;
-    bool m_enabled;
-    int m_zoomFactor;
-    bool m_useScrollbar;
+    bool m_enabled = false;
+    int m_zoomFactor = -10;
+    bool m_useScrollbar = true;
 
 public:
-    znConfigItem(); 
-    virtual ~znConfigItem();
+    znConfigItem();
+    ~znConfigItem() override = default;
 
 public:
-    virtual void FromJSON(const JSONItem& json);
-    virtual JSONItem ToJSON() const;
+    void FromJSON(const JSONItem& json) override;
+    JSONItem ToJSON() const override;
 
     void SetEnabled(bool enabled) { this->m_enabled = enabled; }
     void SetHighlightColour(const wxString& highlightColour) { this->m_highlightColour = highlightColour; }

--- a/ZoomNavigator/zoomnavigator.h
+++ b/ZoomNavigator/zoomnavigator.h
@@ -35,27 +35,20 @@
 
 #include "cl_command_event.h"
 #include "plugin.h"
-#include "zoomtext.h"
 
-#include <set>
-#include <wx/timer.h>
-
-extern const wxString ZOOM_PANE_TITLE;
-
-class ZoomNavUpdateTimer;
+class wxTimer;
+class ZoomText;
 
 class ZoomNavigator : public IPlugin
 {
-    IManager* mgr;
-    wxPanel* m_zoompane;
-    wxEvtHandler* m_topWindow;
-    ZoomText* m_text;
+    wxPanel* m_zoompane = nullptr;
+    wxEvtHandler* m_topWindow = nullptr;
+    ZoomText* m_text = nullptr;
     int m_markerFirstLine = wxNOT_FOUND;
     int m_markerLastLine = wxNOT_FOUND;
-    bool m_enabled;
-    clConfig* m_config;
-    int m_lastLine;
-    bool m_startupCompleted;
+    bool m_enabled = false;
+    clConfig* m_config = nullptr;
+    bool m_startupCompleted = false;
     wxString m_curfile;
     wxTimer* m_timer = nullptr;
 
@@ -63,25 +56,24 @@ protected:
     void DoInitialize();
     void PatchUpHighlights(const int first, const int last);
     void SetEditorText(IEditor* editor);
-    void SetZoomTextScrollPosToMiddle(wxStyledTextCtrl* stc);
+    void SetZoomTextScrollPosToMiddle(wxStyledTextCtrl& stc);
     void DoUpdate();
     void DoCleanup();
     void OnTimer(wxTimerEvent& event);
 
 public:
-    ZoomNavigator(IManager* manager);
-    ~ZoomNavigator();
+    explicit ZoomNavigator(IManager* manager);
+    ~ZoomNavigator() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 
     void OnIdle(wxIdleEvent& e);
-
     void OnShowHideClick(wxCommandEvent& e);
     void OnPreviewClicked(wxMouseEvent& e);
     void OnSettings(wxCommandEvent& e);

--- a/ZoomNavigator/zoomtext.h
+++ b/ZoomNavigator/zoomtext.h
@@ -36,19 +36,21 @@
 #include "ieditor.h"
 
 #include <wx/stc/stc.h>
-#include <wx/timer.h>
+
+class wxTimer;
+class wxTimerEvent;
 
 class ZoomText : public wxStyledTextCtrl
 {
     int m_zoomFactor;
     wxColour m_colour;
     wxString m_filename;
-    wxTimer* m_timer;
+    wxTimer* m_timer = nullptr;
 
 public:
-    enum MarkerType {
-        MARKER_ERROR,
-        MARKER_WARNING,
+    enum class MarkerType {
+        Error,
+        Warning,
     };
 
 protected:
@@ -59,15 +61,14 @@ protected:
                            const wxString& others);
 
 public:
-    ZoomText(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition,
-             const wxSize& size = wxDefaultSize, long style = 0, const wxString& name = wxSTCNameStr);
-    virtual ~ZoomText();
+    explicit ZoomText(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition,
+                      const wxSize& size = wxDefaultSize, long style = 0, const wxString& name = wxSTCNameStr);
+    ~ZoomText() override;
     void UpdateLexer(IEditor* editor);
     void OnSettingsChanged(wxCommandEvent& e);
     void UpdateText(IEditor* editor);
     void HighlightLines(int start, int end);
     void UpdateMarkers(const std::vector<int>& lines, MarkerType type);
-    void DeleteAllMarkers();
     void Startup();
 };
 


### PR DESCRIPTION
- clang-format
- add missing `explicit`
- add missing `override` (and remove `virtual`)
- add extra `const`
- use `= default`
- use member initialization
- Replace `NULL` by `nullptr`
- use reference instead of pointer
- use enum class for `ZoomText::MarkerType`
- remove some unneeded `#include` and use some forward declarations
- add some sub-functions
- replace output parameter by return type