### PR TITLE
Removed font size multiplier

### DIFF
--- a/Plugin/clScrolledPanel.cpp
+++ b/Plugin/clScrolledPanel.cpp
@@ -384,7 +384,7 @@ wxFont clScrolledPanel::GetDefaultFont()
     f.SetFractionalPointSize(pointSize);
 #elif defined(__WXMSW__)
     // wxMSW
-    float pointSize = f.GetFractionalPointSize() * 1.2;
+    float pointSize = f.GetFractionalPointSize();
     f.SetFractionalPointSize(pointSize);
 #endif
     return f;

--- a/Plugin/clScrolledPanel.cpp
+++ b/Plugin/clScrolledPanel.cpp
@@ -379,11 +379,9 @@ void clScrolledPanel::DoCancelDrag()
 wxFont clScrolledPanel::GetDefaultFont()
 {
     wxFont f = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
-    float pointSize = f.GetFractionalPointSize();
 #if defined(__WXMAC__)
-    pointSize *= 1.2;
+    f.SetFractionalPointSize(1.2 * f.GetFractionalPointSize());
 #endif
-    f.SetFractionalPointSize(pointSize);
     return f;
 }
 

--- a/Plugin/clScrolledPanel.cpp
+++ b/Plugin/clScrolledPanel.cpp
@@ -379,14 +379,11 @@ void clScrolledPanel::DoCancelDrag()
 wxFont clScrolledPanel::GetDefaultFont()
 {
     wxFont f = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
-#if defined(__WXMAC__)
-    float pointSize = f.GetFractionalPointSize() * 1.2;
-    f.SetFractionalPointSize(pointSize);
-#elif defined(__WXMSW__)
-    // wxMSW
     float pointSize = f.GetFractionalPointSize();
-    f.SetFractionalPointSize(pointSize);
+#if defined(__WXMAC__)
+    pointSize *= 1.2;
 #endif
+    f.SetFractionalPointSize(pointSize);
     return f;
 }
 


### PR DESCRIPTION
On Windows, IDE fonts in a project tree, editor tabs etc are noticeably larger than a system font. That was because an IDE font was 20% bigger than a system one. Tested it on 4K and 1080p.