### PR TITLE
[CI] "Fix" CI for msys, wxWidget doesn't compile with clang-19 because …

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -50,7 +50,7 @@ jobs:
         mkdir wxWidgets/build-release
         cd wxWidgets/build-release
         sed -i "s/typedef wxUint32 wxChar32;/#include <uchar.h>\n    typedef char32_t wxChar32;/g" ../include/wx/defs.h
-        cmake .. -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$HOME/root" -DwxBUILD_DEBUG_LEVEL=0 -DwxBUILD_MONOLITHIC=1 -DwxBUILD_SAMPLES=SOME
+        cmake .. -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$HOME/root" -DwxBUILD_DEBUG_LEVEL=0 -DwxBUILD_MONOLITHIC=1 -DwxBUILD_SAMPLES=SOME -DwxUSE_STL=1
         mingw32-make -j$(nproc) && PATH="/clang64/bin:$PATH" mingw32-make install
 
     # wx-config-msys2

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wx-version: ['v3.2.5', 'master']
+        wx-version: ['fd0f60daea24e9c62d372d774be9e32ce2b0849d', 'master'] # <v3.2.7 cannot be compiled with clang-19
 
     steps:
     - uses: msys2/setup-msys2@v2

--- a/docs/docs/build/build_wx_widgets.md
+++ b/docs/docs/build/build_wx_widgets.md
@@ -20,9 +20,9 @@ git submodule update --init
 ```bash
 mkdir build-release
 cd build-release
-cmake .. -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release \
-         -DwxBUILD_DEBUG_LEVEL=0                        \
-         -DwxBUILD_MONOLITHIC=1 -DwxBUILD_SAMPLES=SOME  \
+cmake .. -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release                 \
+         -DwxBUILD_DEBUG_LEVEL=0                                        \
+         -DwxBUILD_MONOLITHIC=1 -DwxBUILD_SAMPLES=SOME -DwxUSE_STL=1    \
          -DCMAKE_INSTALL_PREFIX=$HOME/root
 mingw32-make -j$(nproc) install
 ```
@@ -33,8 +33,8 @@ mingw32-make -j$(nproc) install
 mkdir build-debug
 cd build-debug
 cmake .. -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DwxBUILD_DEBUG_LEVEL=1 \
-    -DwxBUILD_SAMPLES=SOME  -DwxBUILD_MONOLITHIC=1                            \
-    -DCMAKE_INSTALL_PREFIX=$HOME/root
+    -DwxBUILD_SAMPLES=SOME  -DwxBUILD_MONOLITHIC=1  -DwxUSE_STL=1             \
+    -DCMAKE_INSTALL_PREFIX=$HOME/root  
 mingw32-make -j$(nproc) install
 ```
 


### PR DESCRIPTION
…of an very old bug in template.

It has been fixed by d275dd4ba8c07cf1b05077ebf2c1c2e67655d633 by lauri Nurmi the Oct 28th 2024 (for 3.2.7) See https://github.com/wxWidgets/wxWidgets/pull/24922 for more details