### PR TITLE
Add new macro `WorkspaceRealPath`

### DIFF
--- a/Plugin/macromanager.cpp
+++ b/Plugin/macromanager.cpp
@@ -35,6 +35,7 @@
 #include "project.h"
 #include "workspace.h"
 #include "wxStringHash.h"
+#include "fileutils.h"
 
 #include <wx/regex.h>
 
@@ -156,6 +157,7 @@ const std::unordered_set<wxString> CODELITE_MACROS = {
     "WorkspaceName",
     "WorkspaceConfiguration",
     "WorkspacePath",
+    "WorkspaceRealPath",
     "OutputDirectory",
     "ProjectOutputFile",
     "OutputFile",
@@ -254,6 +256,8 @@ wxString MacroManager::DoExpand(const wxString& expression, IManager* manager, c
         wspName = clWorkspaceManager::Get().GetWorkspace()->GetName();
     }
 
+    wxString wspRealPath = FileUtils::RealPath(wspPath);
+
     size_t retries = 0;
     wxString dummyname, dummfullname;
     while((retries < 5) && FindVariable(expandedString, dummyname, dummyname)) {
@@ -262,6 +266,7 @@ wxString MacroManager::DoExpand(const wxString& expression, IManager* manager, c
         expandedString.Replace("$(WorkspaceName)", wspName);
         expandedString.Replace("$(WorkspaceConfiguration)", wspConfig);
         expandedString.Replace("$(WorkspacePath)", wspPath);
+        expandedString.Replace("$(WorkspaceRealPath)", wspRealPath);
 
         if(workspace) {
             ProjectPtr proj = workspace->GetProject(project);

--- a/Plugin/macrosdlg.cpp
+++ b/Plugin/macrosdlg.cpp
@@ -81,6 +81,7 @@ void MacrosDlg::Initialize()
     case MacrosProject:
         AddMacro("$(ProjectPath)", _("Expands to project's path"));
         AddMacro("$(WorkspacePath)", _("Expands to workspace's path"));
+        AddMacro("$(WorkspaceRealPath)", _("Expands to workspace's real path (with symlinks resolved)"));
         AddMacro("$(WorkspaceConfiguration)", _("Expands to the workspace selected configuration"));
         AddMacro("$(ProjectName)", _("Expands to the current project name as appears in the 'File View'"));
         AddMacro("$(IntermediateDirectory)",

--- a/docs/docs/settings/macros.md
+++ b/docs/docs/settings/macros.md
@@ -11,6 +11,7 @@ Below is a list of supported macros by CodeLite:
  `$(WorkspaceName)`|The current workspace name
  `$(WorkspaceConfiguration)`|The workspace configuration (e.g. `Debug`)
  `$(WorkspacePath)`|The workspace path. For remote workspaces, this expands to the remote workspace path
+ `$(WorkspaceRealPath)`|The workspace path (with symlinks resolved). For remote workspaces, this expands to the remote workspace path
  `$(ProjectName)`|Current project name
  `$(IntermediateDirectory)`|The location where CodeLite places object files (`.o`)
  `$(ConfigurationName)`|The current **project** configuration name. e.g. (`Debug`)
@@ -30,8 +31,3 @@ Below is a list of supported macros by CodeLite:
  `$(SSH_AccountName)`| When a remote workspace is loaded, this expands to the current account name connected
  `$(SSH_Host)`| When a remote workspace is loaded, this expands to the current host connected
  `$(SSH_User)`| When a remote workspace is loaded, this expands to the SSH'd user
-
-
-
-
-


### PR DESCRIPTION

Add new macro `WorkspaceRealPath`

The `WorkspaceRealPath` macro is identical to `WorkspacePath` - but just expanded/converted by calling FileUtils::RealPath (`realpath()`) - this means that any symlink present in the path is resolved.

Reasoning for introduction of `WorkspaceRealPath` macro:

I have a number of (FSW) projects that have to be placed on a  network drive with a special and extremely long/deep directory layout (not my choice)

In order to eliminate the long/deep path leading to the project dirs of these projects - I have created a local project root with symlinks to the real projects - mission accomplished...

This has worked well with CodeLite until the switch from ctags to clangd (LSP)...


Here is an example of one the problems (there are actually more):

Clangd (LSP) returns filepaths as expanded (real)paths.

With a FSW project opened with a shortend (symlink) path - the Workspace pane file-tree does not recognize the expanded (real)path as a part of the FSW project - and hence it will not sync the file returned by LSP with the workspace pane file-tree.

But clangd (LSP) has a fix for that - `path-mappings` will translate a remote path into a local path (just what we (I) need)

By adding the following into the clangd (LSP) command every thing works again:

`--path-mappings=$(WorkspacePath)=$(WorkspaceRealPath)`

Summary:

By introducing the `WorkspaceRealPath` macro the problems of mapping between "virtual" symlink paths and (real)paths are automatically handled
