### PR TITLE
DRAFT: Improved FSW symlink handling

### DIFF
--- a/CodeLite/CMakeLists.txt
+++ b/CodeLite/CMakeLists.txt
@@ -34,6 +34,8 @@ target_include_directories(libcodelite
     "${CL_SRC_ROOT}/CodeLite"
     "${CL_SRC_ROOT}/CodeLite/ssh"
     "${CL_SRC_ROOT}/PCH"
+    "${CL_SRC_ROOT}/Interfaces"
+    "${CL_SRC_ROOT}/Plugin"
     PRIVATE
     "${CL_SRC_ROOT}/submodules/asio/asio/include"
     "${CL_SRC_ROOT}/submodules/websocketpp"

--- a/CodeLite/clFilesCollector.cpp
+++ b/CodeLite/clFilesCollector.cpp
@@ -2,6 +2,7 @@
 
 #include "file_logger.h"
 #include "fileutils.h"
+#include "globals.h"
 
 #include <queue>
 #include <unordered_set>
@@ -110,19 +111,19 @@ size_t clFilesScanner::Scan(const wxString& rootFolder, std::vector<wxString>& f
             filename.MakeLower();
 #endif
             bool isDirectory = wxFileName::DirExists(fullpath);
-            // Use FileUtils::RealPath() here to cope with symlinks on Linux
+            // Use CLRealPath() here to cope with symlinks on Linux
             bool isExcludeDir =
                 isDirectory &&
                 (
 #if defined(__FreeBSD__)
-                    ((FileUtils::IsSymlink(fullpath) && excludeFolders.count(FileUtils::RealPath(fullpath)))
+                    ((FileUtils::IsSymlink(fullpath) && excludeFolders.count(CLRealPath(fullpath)))
 #else
-                    (excludeFolders.count(FileUtils::RealPath(fullpath))
+                    (excludeFolders.count(CLRealPath(fullpath))
 #endif
                      || IsRelPathContainedInSpec(rootFolder, fullpath, excludeFolders)));
             if (isDirectory && !isExcludeDir) {
                 // Traverse into this folder
-                wxString realPath = FileUtils::RealPath(fullpath);
+                wxString realPath = CLRealPath(fullpath);
                 if (Visited.insert(realPath).second) {
                     Q.push(fullpath);
                 }
@@ -153,8 +154,8 @@ size_t clFilesScanner::Scan(const wxString& rootFolder, const wxString& filespec
     std::queue<wxString> Q;
     std::unordered_set<wxString> Visited;
 
-    Q.push(FileUtils::RealPath(rootFolder));
-    Visited.insert(FileUtils::RealPath(rootFolder));
+    Q.push(CLRealPath(rootFolder));
+    Visited.insert(CLRealPath(rootFolder));
 
     size_t nCount = 0;
     while (!Q.empty()) {
@@ -174,11 +175,11 @@ size_t clFilesScanner::Scan(const wxString& rootFolder, const wxString& filespec
             fullpath << dir.GetNameWithSep() << filename;
             bool isDirectory = wxFileName::DirExists(fullpath);
             bool isFile = !isDirectory;
-            // Use FileUtils::RealPath() here to cope with symlinks on Linux
+            // Use CLRealPath() here to cope with symlinks on Linux
             if (isDirectory /* a folder */ &&
                 !FileUtils::WildMatch(excludeFoldersSpecArr, filename) /* does not match the exclude folder spec */) {
                 // Traverse into this folder
-                wxString real_path = FileUtils::RealPath(fullpath);
+                wxString real_path = CLRealPath(fullpath);
                 if (Visited.count(real_path) == 0) {
                     Visited.insert(real_path);
                     Q.push(fullpath);
@@ -259,8 +260,8 @@ void clFilesScanner::ScanWithCallbacks(const wxString& rootFolder, std::function
     std::vector<wxString> Q;
     std::unordered_set<wxString> Visited;
 
-    Q.push_back(FileUtils::RealPath(rootFolder));
-    Visited.insert(FileUtils::RealPath(rootFolder));
+    Q.push_back(CLRealPath(rootFolder));
+    Visited.insert(CLRealPath(rootFolder));
 
     while (!Q.empty()) {
         wxString dirpath = Q.front();
@@ -299,7 +300,7 @@ void clFilesScanner::ScanWithCallbacks(const wxString& rootFolder, std::function
 
                 if (on_folder_cb && on_folder_cb(fullpath)) {
                     // Traverse into this folder
-                    wxString real_path = FileUtils::RealPath(fullpath);
+                    wxString real_path = CLRealPath(fullpath);
                     if (Visited.insert(real_path).second) {
                         Q.push_back(fullpath);
                     }

--- a/Plugin/globals.cpp
+++ b/Plugin/globals.cpp
@@ -104,6 +104,8 @@
 #include "SFTPBrowserDlg.h"
 #endif
 
+static const char* pEnv_CL_RealPath = getenv("CL_REALPATH");
+
 const wxEventType wxEVT_COMMAND_CL_INTERNAL_0_ARGS = ::wxNewEventType();
 const wxEventType wxEVT_COMMAND_CL_INTERNAL_1_ARGS = ::wxNewEventType();
 
@@ -928,7 +930,7 @@ wxFileName wxReadLink(const wxFileName& filename)
     if (wxIsFileSymlink(filename)) {
 #if defined(__WXGTK__)
         // Use 'realpath' on Linux, otherwise this breaks on relative symlinks, and (untested) on symlinks-to-symlinks
-        return wxFileName(CLRealPath(filename.GetFullPath()));
+        return wxFileName(CLRealPath(filename.GetFullPath(), true));
 
 #else  // OSX
         wxFileName realFileName;
@@ -948,10 +950,14 @@ wxFileName wxReadLink(const wxFileName& filename)
 #endif
 }
 
-wxString CLRealPath(const wxString& filepath) // This is readlink on steroids: it also makes-absolute, and dereferences
+wxString CLRealPath(const wxString& filepath, bool force) // This is readlink on steroids: it also makes-absolute, and dereferences
                                               // any symlinked dirs in the path
 {
-    return FileUtils::RealPath(filepath);
+    if (force || pEnv_CL_RealPath) {
+        return FileUtils::RealPath(filepath);
+    } else {
+        return filepath;
+    }
 }
 
 int wxStringToInt(const wxString& str, int defval, int minval, int maxval)

--- a/Plugin/globals.h
+++ b/Plugin/globals.h
@@ -336,7 +336,7 @@ WXDLLIMPEXP_SDK wxFileName wxReadLink(const wxFileName& filename);
 /**
  * @brief makes-absolute filepath, and dereferences it and any symlinked dirs in the path
  */
-WXDLLIMPEXP_SDK wxString CLRealPath(const wxString& filepath);
+WXDLLIMPEXP_SDK wxString CLRealPath(const wxString& filepath, bool force=false);
 
 /**
  * @brief convert string to integer using range validation and default value


### PR DESCRIPTION
DRAFT: Improved FSW symlink handling

This is *NOT* a real PR - it is only meant for discussion

In continuation of our talk on issue #3544 

I've for more than 2 years used/applied this patch on top of CodeLite

This patch enables me to use CodeLite on projects that have symlinks in the path leading up to the FSW project root.

There are several problems in respect to symlinks and the use of realpath() calls that this patch approaches:

 - Clangd LSP returns realpath() paths - this can be solved with the LSP solution outlined in issue #3544
 - mainbook uses realpath() extensively to figure out if a file is already opened (in another tab).
 - CodeLite Find-In-Files uses realpath() extensively (and in the end - clicking on the found file opens it)
 - etc...

This patch have worked for me without any problems for more than 2 years.

It basically fakes the use of CLRealPath() calls - on most occasions just returning the unmodified path.
An optional argument to CLRealPath() (defaults to false) can force the realpath() conversion (this is only used in very few occasions in my patch)

For compatibility reasons (and easy testing) the original behavior of CLRealPath() can be reestablished/reenabled by starting CodeLite with the environment variable `CL_REALPATH` defined.

eg:

```
CL_REALPATH=xxx codelite
```

I've used this handle to do extensive testing of this feature - it makes it easy to compare behavior with or without the realpath manipulation - and hence evaluate the end-user experience of the functionality of this patch.

My plan was to make a CL GUI option within the FSW project configuration for "FSW symlink/realpath handling" - so that end-users would be able to enable/disable this feature based on their project setup (just for compatibilty - as there may be some scenarios that I haven't thought of)

Anyway - I've not yet come around to make as GUI option for this - mainly because the patch as-is solves all my personal issues with FSW projects and symlinks

This is just meant to inspire you to how FSW symlink handling can easily be improved - see it as a starting-point for a discussion

At some point I hope that this patch or similar functionality can be included into CodeLite :-)
 