### PR TITLE
Configurable "Find next"/"Find previous" behavior

### DIFF
--- a/LiteEditor/editorsettingsdockingwidows.cpp
+++ b/LiteEditor/editorsettingsdockingwidows.cpp
@@ -99,4 +99,8 @@ EditorSettingsDockingWindows::EditorSettingsDockingWindows(wxWindow* parent, Opt
     AddProperty(_("When searching, don't override search string with current selection"),
                 m_options->GetDontOverrideSearchStringWithSelection(),
                 UPDATE_BOOL_CB(SetDontOverrideSearchStringWithSelection));
+    AddHeader(_("Find next/Find previous"));
+    AddProperty(_("Find next/Find previous actions override search string with current selection (like Find next at caret/prev at caret)"),
+                m_options->GetFindNextOrPreviousUseSelection(),
+                UPDATE_BOOL_CB(SetFindNextOrPreviousUseSelection));
 }

--- a/LiteEditor/frame.cpp
+++ b/LiteEditor/frame.cpp
@@ -416,9 +416,9 @@ EVT_UPDATE_UI(XRCID("id_replace"), clMainFrame::OnIncrementalSearchUI)
 EVT_UPDATE_UI(XRCID("select_previous"), clMainFrame::OnFileExistUpdateUI)
 EVT_UPDATE_UI(XRCID("select_next"), clMainFrame::OnFileExistUpdateUI)
 EVT_UPDATE_UI(XRCID("find_next"), clMainFrame::OnFileExistUpdateUI)
-EVT_MENU(XRCID("find_next"), clMainFrame::OnFindSelection)
+EVT_MENU(XRCID("find_next"), clMainFrame::OnFindNext)
 EVT_UPDATE_UI(XRCID("find_previous"), clMainFrame::OnFileExistUpdateUI)
-EVT_MENU(XRCID("find_previous"), clMainFrame::OnFindSelectionPrev)
+EVT_MENU(XRCID("find_previous"), clMainFrame::OnFindPrevious)
 EVT_UPDATE_UI(XRCID("find_next_at_caret"), clMainFrame::OnFileExistUpdateUI)
 EVT_UPDATE_UI(XRCID("find_previous_at_caret"), clMainFrame::OnFileExistUpdateUI)
 EVT_UPDATE_UI(XRCID("incremental_search"), clMainFrame::OnIncrementalSearchUI)
@@ -5965,33 +5965,40 @@ void clMainFrame::OnMainBookMovePage(wxCommandEvent& e)
     GetMainBook()->MovePage(e.GetId() == XRCID("wxEVT_BOOK_MOVE_TAB_RIGHT"));
 }
 
-void clMainFrame::OnFindSelection(wxCommandEvent& event)
+void clMainFrame::OnFindNext(wxCommandEvent& event)
 {
     event.Skip();
-    clEditor* editor = GetMainBook()->GetActiveEditor();
-    CHECK_PTR_RET(editor);
+    auto stc = dynamic_cast<wxStyledTextCtrl*>(wxWindow::FindFocus());
+    CHECK_PTR_RET(stc);
     event.Skip(false);
 
     auto find_bar = GetMainBook()->GetFindBar();
-    wxString selection =
-        editor->GetSelection().IsEmpty() ? GetMainBook()->GetFindBar()->GetFindWhat() : editor->GetSelection();
-    find_bar->SetFindWhat(selection);
+    OptionsConfigPtr opts = EditorConfigST::Get()->GetOptions();
+    if (opts->GetFindNextOrPreviousUseSelection()) {
+        wxString selection =
+            stc->GetSelectedText().IsEmpty() ? GetMainBook()->GetFindBar()->GetFindWhat() : stc->GetSelectedText();
+        find_bar->SetFindWhat(selection);
+    }
     find_bar->FindNext();
 }
 
-void clMainFrame::OnFindSelectionPrev(wxCommandEvent& event)
+void clMainFrame::OnFindPrevious(wxCommandEvent& event)
 {
     event.Skip();
-    clEditor* editor = GetMainBook()->GetActiveEditor();
-    CHECK_PTR_RET(editor);
+    auto stc = dynamic_cast<wxStyledTextCtrl*>(wxWindow::FindFocus());
+    CHECK_PTR_RET(stc);
     event.Skip(false);
 
     auto find_bar = GetMainBook()->GetFindBar();
-    wxString selection =
-        editor->GetSelection().IsEmpty() ? GetMainBook()->GetFindBar()->GetFindWhat() : editor->GetSelection();
-    find_bar->SetFindWhat(selection);
+    OptionsConfigPtr opts = EditorConfigST::Get()->GetOptions();
+    if (opts->GetFindNextOrPreviousUseSelection()) {
+        wxString selection =
+            stc->GetSelectedText().IsEmpty() ? GetMainBook()->GetFindBar()->GetFindWhat() : stc->GetSelectedText();
+        find_bar->SetFindWhat(selection);
+    }
     find_bar->FindPrevious();
 }
+
 
 void clMainFrame::OnCustomiseToolbar(wxCommandEvent& event)
 {

--- a/LiteEditor/frame.h
+++ b/LiteEditor/frame.h
@@ -663,8 +663,8 @@ protected:
     void OnProjectRenamed(clCommandEvent& event);
 
     // Search handlers
-    void OnFindSelection(wxCommandEvent& event);
-    void OnFindSelectionPrev(wxCommandEvent& event);
+    void OnFindNext(wxCommandEvent& event);
+    void OnFindPrevious(wxCommandEvent& event);
 
     DECLARE_EVENT_TABLE()
 };

--- a/Plugin/optionsconfig.cpp
+++ b/Plugin/optionsconfig.cpp
@@ -114,6 +114,7 @@ OptionsConfig::OptionsConfig(wxXmlNode* node)
     , m_caretLineAlpha(15)
     , m_dontAutoFoldResults(true)
     , m_dontOverrideSearchStringWithSelection(false)
+    , m_findNextOrPreviousUseSelection(true)
     , m_showDebugOnRun(true)
     , m_caretUseCamelCase(true)
     , m_wordWrap(false)
@@ -208,6 +209,8 @@ OptionsConfig::OptionsConfig(wxXmlNode* node)
         m_dontAutoFoldResults = XmlUtils::ReadBool(node, wxT("DontAutoFoldResults"), m_dontAutoFoldResults);
         m_dontOverrideSearchStringWithSelection = XmlUtils::ReadBool(
             node, wxT("DontOverrideSearchStringWithSelection"), m_dontOverrideSearchStringWithSelection);
+        m_findNextOrPreviousUseSelection = XmlUtils::ReadBool(
+            node, wxT("FindNextOrPreviousUseSelection"), m_findNextOrPreviousUseSelection);
         m_showDebugOnRun = XmlUtils::ReadBool(node, wxT("ShowDebugOnRun"), m_showDebugOnRun);
         m_caretUseCamelCase = XmlUtils::ReadBool(node, wxT("m_caretUseCamelCase"), m_caretUseCamelCase);
         m_wordWrap = XmlUtils::ReadBool(node, wxT("m_wordWrap"), m_wordWrap);
@@ -310,6 +313,8 @@ wxXmlNode* OptionsConfig::ToXml() const
     n->AddAttribute(wxT("DontAutoFoldResults"), BoolToString(m_dontAutoFoldResults));
     n->AddAttribute(wxT("DontOverrideSearchStringWithSelection"),
                     BoolToString(m_dontOverrideSearchStringWithSelection));
+    n->AddAttribute(wxT("FindNextOrPreviousUseSelection"),
+                    BoolToString(m_findNextOrPreviousUseSelection));
     n->AddAttribute(wxT("ShowDebugOnRun"), BoolToString(m_showDebugOnRun));
     n->AddAttribute(wxT("ConsoleCommand"), m_programConsoleCommand);
     n->AddAttribute(wxT("EOLMode"), m_eolMode);

--- a/Plugin/optionsconfig.h
+++ b/Plugin/optionsconfig.h
@@ -141,6 +141,7 @@ protected:
     int m_caretLineAlpha;
     bool m_dontAutoFoldResults;
     bool m_dontOverrideSearchStringWithSelection;
+    bool m_findNextOrPreviousUseSelection;
     bool m_showDebugOnRun;
     bool m_caretUseCamelCase;
     bool m_dontTrimCaretLine;
@@ -226,6 +227,11 @@ public:
         m_dontOverrideSearchStringWithSelection = dontOverrideSearchStringWithSelection;
     }
     bool GetDontOverrideSearchStringWithSelection() const { return m_dontOverrideSearchStringWithSelection; }
+    void SetFindNextOrPreviousUseSelection(bool findNextOrPreviousUseSelection)
+    {
+        m_findNextOrPreviousUseSelection = findNextOrPreviousUseSelection;
+    }
+    bool GetFindNextOrPreviousUseSelection() const { return m_findNextOrPreviousUseSelection; }
     void SetShowDebugOnRun(bool showDebugOnRun) { this->m_showDebugOnRun = showDebugOnRun; }
     bool GetShowDebugOnRun() const { return m_showDebugOnRun; }
     bool GetDisableSemicolonShift() const { return m_disableSemicolonShift; }


### PR DESCRIPTION
Subject: Configurable "Find next"/"Find previous" behavior

"Find next"/"Find previous" behavior can now be configured

"Find next as caret"/"Find previous at caret" behavior is unchanged

"Find next"/"Find previous" actions:

Existing behavior: selected text is used as new search text - (like "Find next as caret"/"Find previous at caret")

New optional behavior: selected text is ignored - existing search text is used

The new optional behavior also solves problem reported in issue #3568:
Where regex find patterns are deleted by selected text upon repeating Find next/Find previous