### PR TITLE
Fix: ensure that macro WorkspaceRealPath is always resolved to realpath (forced)

### DIFF
--- a/Plugin/macromanager.cpp
+++ b/Plugin/macromanager.cpp
@@ -256,7 +256,7 @@ wxString MacroManager::DoExpand(const wxString& expression, IManager* manager, c
         wspName = clWorkspaceManager::Get().GetWorkspace()->GetName();
     }
 
-    wxString wspRealPath = FileUtils::RealPath(wspPath);
+    wxString wspRealPath = FileUtils::RealPath(wspPath, true);
 
     size_t retries = 0;
     wxString dummyname, dummfullname;


### PR DESCRIPTION
Fix: ensure that macro `WorkspaceRealPath` is always resolved to realpath (forced)

With the recently improved symlink handling in place - the macro `WorkspaceRealPath` will have to force the call to realpath() - otherwise the clangd path-mapping configuration will not work
(`--path-mappings=$(WorkspacePath)=$(WorkspaceRealPath)`)