### PR TITLE
Remember Find/Replace dialog position and ideal size

### DIFF
--- a/LiteEditor/quickfindbar.cpp
+++ b/LiteEditor/quickfindbar.cpp
@@ -250,13 +250,12 @@ QuickFindBar::QuickFindBar(wxWindow* parent, wxWindowID id)
     if (clConfig::Get().Read("FindBar/Width", dlg_width) && clConfig::Get().Read("FindBar/Height", dlg_height)) {
         SetSize(dlg_width, dlg_height);
         SetSizeHints(dlg_width, dlg_height);
-        SetMinClientSize(min_size);
     } else {
         // first time, place it at the top
         Move(wxNOT_FOUND, parent->GetPosition().y);
-        SetMinClientSize(min_size);
-        GetSizer()->Fit(this);
     }
+    SetMinClientSize(min_size);
+    GetSizer()->Fit(this);
     Layout();
 }
 


### PR DESCRIPTION
This change makes Find/Replace dialog remember its position between restarts.
Also is rearranges the dialog to its ideal height and width - where all buttons and fields are visible
