### PR TITLE
[cleanup] (C++) Modernize Interfaces/*.*

### DIFF
--- a/Interfaces/IWorkspace.h
+++ b/Interfaces/IWorkspace.h
@@ -44,11 +44,11 @@ protected:
     wxString m_workspaceType;
 
 public:
-    typedef std::list<IWorkspace*> List_t;
+    using List_t = std::list<IWorkspace*>;
 
 public:
-    IWorkspace() {}
-    virtual ~IWorkspace() {}
+    IWorkspace() = default;
+    ~IWorkspace() override = default;
 
     /**
      * @brief return the workspace name
@@ -101,7 +101,7 @@ public:
     /**
      * @brief return the project name of a file.
      * If the workspace does not support projects, return an empty string
-     * If the we could not match a project for the given filename, return empty string
+     * If we could not match a project for the given filename, return empty string
      */
     virtual wxString GetProjectFromFile(const wxFileName& filename) const = 0;
 

--- a/Interfaces/debugger.h
+++ b/Interfaces/debugger.h
@@ -67,59 +67,46 @@ struct StackEntry {
     wxString function;
     wxString file;
     wxString line;
-    bool active;
+    bool active = false;
 };
 
 struct ThreadEntry {
-    bool active;
-    long dbgid;
+    bool active = false;
+    long dbgid = 0;
     wxString file;
     wxString line;
     wxString function;
 };
 
 struct VariableObjChild {
-    int numChilds;    // If this child has children (i.e. is this child a node or leaf)
-    wxString varName; // the name of the variable object node
-    wxString gdbId;   // A unique name given by gdb which holds this node information for further queries
+    int numChilds = 0; // If this child has children (i.e. is this child a node or leaf)
+    wxString varName;  // the name of the variable object node
+    wxString gdbId;    // A unique name given by gdb which holds this node information for further queries
     wxString value;
-    bool isAFake; // Sets to true of this variable object is a fake node
+    bool isAFake = false; // Sets to true of this variable object is a fake node
     wxString type;
-    VariableObjChild()
-        : numChilds(0)
-        , isAFake(false)
-    {
-    }
+
+    VariableObjChild() = default;
 };
 
 struct VariableObject {
-    bool isPtr;        // if this variable object is of type pointer
-    bool isPtrPtr;     // if this variable object is of type pointer pointer
-    wxString gdbId;    // GDB unique identifier for this variable object
-    wxString typeName; // the type of this variable object
-    int numChilds;     // Number of children
-    bool has_more;     // has_nore?
-    VariableObject()
-        : isPtr(false)
-        , isPtrPtr(false)
-        , numChilds(0)
-        , has_more(false)
-    {
-    }
+    bool isPtr = false;    // if this variable object is of type pointer
+    bool isPtrPtr = false; // if this variable object is of type pointer pointer
+    wxString gdbId;        // GDB unique identifier for this variable object
+    wxString typeName;     // the type of this variable object
+    int numChilds = 0;     // Number of children
+    bool has_more = false; // has_more?
+    VariableObject() = default;
 };
 
 struct LocalVariable {
     wxString name;
     wxString value;
     wxString type;
-    bool updated;
+    bool updated = false;
     wxString gdbId; // Mac generates variable object for locals as well...
 
-    LocalVariable()
-        : updated(false)
-    {
-    }
-    ~LocalVariable() {}
+    LocalVariable() = default;
 };
 
 struct VariableObjectUpdateInfo {
@@ -128,7 +115,6 @@ struct VariableObjectUpdateInfo {
 };
 
 struct DisassembleEntry {
-public:
     wxString m_address;
     wxString m_function;
     wxString m_offset;
@@ -140,17 +126,17 @@ struct DbgRegister {
     wxString reg_value;
 };
 
-typedef std::vector<VariableObjChild> VariableObjChildren;
-typedef std::vector<StackEntry> StackEntryArray;
-typedef std::vector<ThreadEntry> ThreadEntryArray;
-typedef std::vector<LocalVariable> LocalVariables;
-typedef std::vector<DisassembleEntry> DisassembleEntryVec_t;
-typedef std::vector<DbgRegister> DbgRegistersVec_t;
+using VariableObjChildren = std::vector<VariableObjChild>;
+using StackEntryArray = std::vector<StackEntry>;
+using ThreadEntryArray = std::vector<ThreadEntry>;
+using LocalVariables = std::vector<LocalVariable>;
+using DisassembleEntryVec_t = std::vector<DisassembleEntry>;
+using DbgRegistersVec_t = std::vector<DbgRegister>;
 
 #define READ_CONFIG_PARAM(name, value) \
     {                                  \
         decltype(value) dummy;         \
-        if(arch.Read(name, dummy)) {   \
+        if (arch.Read(name, dummy)) {  \
             value = dummy;             \
         }                              \
     }
@@ -165,56 +151,32 @@ public:
 
     wxString name;
     wxString path;
-    bool enableDebugLog;
-    bool enablePendingBreakpoints;
-    bool breakAtWinMain;
-    bool showTerminal;
-    wxString consoleCommand;
-    bool useRelativeFilePaths;
-    int maxCallStackFrames;
-    bool catchThrow;
-    bool showTooltipsOnlyWithControlKeyIsDown;
-    bool debugAsserts;
+    bool enableDebugLog = false;
+    bool enablePendingBreakpoints = true;
+    bool breakAtWinMain = false;
+    bool showTerminal = false;
+    wxString consoleCommand = TERMINAL_CMD;
+    bool useRelativeFilePaths = false;
+    int maxCallStackFrames = 500;
+    bool catchThrow = false;
+    bool showTooltipsOnlyWithControlKeyIsDown = true;
+    bool debugAsserts = false;
     wxString initFileCommands;
     int maxDisplayStringSize = 200;
     int maxDisplayElements = 100;
-    bool resolveLocals;
-    bool autoExpandTipItems;
-    bool applyBreakpointsAfterProgramStarted;
-    bool whenBreakpointHitRaiseCodelite;
+    bool resolveLocals = true;
+    bool autoExpandTipItems = true;
+    bool applyBreakpointsAfterProgramStarted = false;
+    bool whenBreakpointHitRaiseCodelite = true;
     wxString cygwinPathCommand;
-    bool charArrAsPtr;
-    bool enableGDBPrettyPrinting;
-    bool defaultHexDisplay;
-    size_t flags; // see eGdbFlags
+    bool charArrAsPtr = false;
+    bool enableGDBPrettyPrinting = true;
+    bool defaultHexDisplay = false;
+    size_t flags = 0; // see eGdbFlags
 
 public:
-    DebuggerInformation()
-        : name(wxEmptyString)
-        , path(wxEmptyString)
-        , enableDebugLog(false)
-        , enablePendingBreakpoints(true)
-        , breakAtWinMain(false)
-        , showTerminal(false)
-        , consoleCommand(TERMINAL_CMD)
-        , useRelativeFilePaths(false)
-        , maxCallStackFrames(500)
-        , catchThrow(false)
-        , showTooltipsOnlyWithControlKeyIsDown(true)
-        , debugAsserts(false)
-        , initFileCommands(wxEmptyString)
-        , resolveLocals(true)
-        , autoExpandTipItems(true)
-        , applyBreakpointsAfterProgramStarted(false)
-        , whenBreakpointHitRaiseCodelite(true)
-        , charArrAsPtr(false)
-        , enableGDBPrettyPrinting(true)
-        , defaultHexDisplay(false)
-        , flags(0)
-    {
-    }
-
-    virtual ~DebuggerInformation() {}
+    DebuggerInformation() = default;
+    ~DebuggerInformation() override = default;
 
     void Serialize(Archive& arch)
     {
@@ -291,28 +253,19 @@ class DebuggerStartupInfo
 public:
     enum DebugType { DebugProject = 1, AttachProcess = 2, QuickDebug = 3 };
 
-    long pid;
+    long pid = wxNOT_FOUND;
     wxString project;
-    IDebugger* debugger;
+    IDebugger* debugger = nullptr;
 
-    DebuggerStartupInfo()
-        : pid(wxNOT_FOUND)
-        , project(wxEmptyString)
-        , debugger(NULL)
-    {
-    }
+    DebuggerStartupInfo() = default;
 
-    DebuggerStartupInfo(long pid)
+    explicit DebuggerStartupInfo(long pid)
         : pid(pid)
-        , project(wxEmptyString)
-        , debugger(NULL)
     {
     }
 
-    DebuggerStartupInfo(const wxString& project)
-        : pid(wxNOT_FOUND)
-        , project(project)
-        , debugger(NULL)
+    explicit DebuggerStartupInfo(const wxString& project)
+        : project(project)
     {
     }
 
@@ -362,28 +315,23 @@ class EnvironmentConfig;
 class IDebugger
 {
 protected:
-    IDebuggerObserver* m_observer;
+    IDebuggerObserver* m_observer = nullptr;
     DebuggerInformation m_info;
-    EnvironmentConfig* m_env;
+    EnvironmentConfig* m_env = nullptr;
     wxString m_name;
-    bool m_isRemoteDebugging;
-    bool m_isRemoteExtended;
+    bool m_isRemoteDebugging = false;
+    bool m_isRemoteExtended = false;
     bool m_isSSHDebugging = false;
     wxString m_debuggeeProjectName;
     wxString m_sshAccount;
-    
+
     //! Command to execute right after connect to the remote target
     wxString m_debuggerPostRemoteConnectCommands;
 
 public:
-    IDebugger()
-        : m_observer(NULL)
-        , m_env(NULL)
-        , m_isRemoteDebugging(false)
-        , m_isRemoteExtended(false)
-    {}
+    IDebugger() = default;
 
-    virtual ~IDebugger(){};
+    virtual ~IDebugger() = default;
     void SetProjectName(const wxString& project) { m_debuggeeProjectName = project; }
     void SetName(const wxString& name) { m_name = name; }
     wxString GetName() const { return m_name; }
@@ -401,13 +349,15 @@ public:
 
     void SetIsRemoteDebugging(bool isRemoteDebugging) { this->m_isRemoteDebugging = isRemoteDebugging; }
     void SetIsRemoteExtended(bool isRemoteExtended) { this->m_isRemoteExtended = isRemoteExtended; }
-    void SetPostRemoteConnectCommands(const wxString& commands) { this->m_debuggerPostRemoteConnectCommands = commands; }
-    
-    
+    void SetPostRemoteConnectCommands(const wxString& commands)
+    {
+        this->m_debuggerPostRemoteConnectCommands = commands;
+    }
+
     bool GetIsRemoteDebugging() const { return m_isRemoteDebugging; }
     bool GetIsRemoteExtended() const { return m_isRemoteExtended; }
     const wxString& GetPostRemoteConnectCommands() const { return this->m_debuggerPostRemoteConnectCommands; }
-    
+
     void SetIsSSHDebugging(bool isSSHDebugging) { this->m_isSSHDebugging = isSSHDebugging; }
     bool IsSSHDebugging() const { return m_isSSHDebugging; }
     void SetSshAccount(const wxString& sshAccount) { this->m_sshAccount = sshAccount; }
@@ -720,7 +670,7 @@ public:
 //-----------------------------------------------------------
 // Each debugger module must implement these two functions
 //-----------------------------------------------------------
-typedef IDebugger* (*GET_DBG_CREATE_FUNC)();
-typedef DebuggerInfo (*GET_DBG_INFO_FUNC)();
+using GET_DBG_CREATE_FUNC = IDebugger* (*)();
+using GET_DBG_INFO_FUNC = DebuggerInfo (*)();
 
 #endif // DEBUGGER_H

--- a/Interfaces/debuggerobserver.h
+++ b/Interfaces/debuggerobserver.h
@@ -88,51 +88,34 @@ enum UserReason { DBG_USERR_QUICKWACTH = 0, DBG_USERR_WATCHTABLE, DBG_USERR_LOCA
 class DebuggerEventData : public wxClientData
 {
 public:
-    DebuggerUpdateReason m_updateReason; // Event reason - the reason why this event was sent
+    DebuggerUpdateReason m_updateReason = DBG_UR_INVALID; // Event reason - the reason why this event was sent
     // ==================================================
     // Available when the following UpdateReason are set:
     // ==================================================
-    DebuggerReasons m_controlReason; // DBG_UR_GOT_CONTROL
-    wxString m_file;                 //
-    int m_line;                      //
-    wxString m_text;                 // DBG_UR_ADD_LINE, DBG_UR_REMOTE_TARGET_CONNECTED, DBG_UR_ASCII_VIEWER
-    int m_bpInternalId;              // DBG_UR_BP_ADDED
-    int m_bpDebuggerId;              // DBG_UR_BP_ADDED, DBG_UR_BP_HIT
-    LocalVariables m_locals;         // DBG_UR_LOCALS
-    wxString m_expression; // DBG_UR_EXPRESSION, DBG_UR_TYPE_RESOLVED, DBG_UR_ASCII_VIEWER, DBG_UR_WATCHMEMORY,
-                           // DBG_UR_VARIABLEOBJ
-    // DBG_UR_EVALVARIABLEOBJ, DBG_UR_FUNCTIONFINISHED
+    DebuggerReasons m_controlReason = DBG_UNKNOWN; // DBG_UR_GOT_CONTROL
+    wxString m_file;                               //
+    int m_line = wxNOT_FOUND;                      //
+    wxString m_text;                  // DBG_UR_ADD_LINE, DBG_UR_REMOTE_TARGET_CONNECTED, DBG_UR_ASCII_VIEWER
+    int m_bpInternalId = wxNOT_FOUND; // DBG_UR_BP_ADDED
+    int m_bpDebuggerId = wxNOT_FOUND; // DBG_UR_BP_ADDED, DBG_UR_BP_HIT
+    LocalVariables m_locals;          // DBG_UR_LOCALS
+    wxString m_expression;   // DBG_UR_EXPRESSION, DBG_UR_TYPE_RESOLVED, DBG_UR_ASCII_VIEWER, DBG_UR_WATCHMEMORY,
+                             // DBG_UR_VARIABLEOBJ, DBG_UR_EVALVARIABLEOBJ, DBG_UR_FUNCTIONFINISHED
     wxString m_evaluated;    // DBG_UR_EXPRESSION, DBG_UR_TYPE_RESOLVED, DBG_UR_WATCHMEMORY, DBG_UR_EVALVARIABLEOBJ
     StackEntryArray m_stack; // DBG_UR_UPDATE_STACK_LIST
     std::vector<clDebuggerBreakpoint> m_bpInfoList; // DBG_UR_RECONCILE_BPTS
-    bool m_onlyIfLogging;                           // DBG_UR_ADD_LINE
+    bool m_onlyIfLogging = false;                   // DBG_UR_ADD_LINE
     ThreadEntryArray m_threads;                     // DBG_UR_LISTTHRAEDS
     VariableObjChildren m_varObjChildren;           // DBG_UR_LISTCHILDREN
     VariableObject m_variableObject;                // DBG_UR_VARIABLEOBJ
-    int m_userReason;       // User reason as provided in the calling API which triggered the DebuggerUpdate call
+    int m_userReason =
+        wxNOT_FOUND;        // User reason as provided in the calling API which triggered the DebuggerUpdate call
     StackEntry m_frameInfo; // DBG_UR_FRAMEINFO
     VariableObjectUpdateInfo m_varObjUpdateInfo; // DBG_UR_VAROBJUPDATE
     DisassembleEntryVec_t m_disassembleLines;    // None
     DbgRegistersVec_t m_registers;               // Sent with event wxEVT_DEBUGGER_LIST_REGISTERS
-    DebuggerEventData()
-        : m_updateReason(DBG_UR_INVALID)
-        , m_controlReason(DBG_UNKNOWN)
-        , m_file(wxEmptyString)
-        , m_line(wxNOT_FOUND)
-        , m_text(wxEmptyString)
-        , m_bpInternalId(wxNOT_FOUND)
-        , m_bpDebuggerId(wxNOT_FOUND)
-        , m_expression(wxEmptyString)
-        , m_evaluated(wxEmptyString)
-        , m_onlyIfLogging(false)
-        , m_userReason(wxNOT_FOUND)
-    {
-        m_stack.clear();
-        m_bpInfoList.clear();
-        m_threads.clear();
-        m_varObjChildren.clear();
-        m_registers.clear();
-    }
+
+    DebuggerEventData() = default;
 };
 
 /**
@@ -144,8 +127,8 @@ public:
 class IDebuggerObserver
 {
 public:
-    IDebuggerObserver(){};
-    virtual ~IDebuggerObserver(){};
+    IDebuggerObserver() = default;
+    virtual ~IDebuggerObserver() = default;
 
     /**
      * @brief the reporting method of the debugger. Must be implemented by any 'DebuggerObserver'

--- a/Interfaces/iconfigtool.h
+++ b/Interfaces/iconfigtool.h
@@ -45,8 +45,8 @@
 class IConfigTool
 {
 public:
-    IConfigTool() {}
-    virtual ~IConfigTool() {}
+    IConfigTool() = default;
+    virtual ~IConfigTool() = default;
 
     /**
      * @brief read an object from the configuration file and place it into obj

--- a/Interfaces/imanager.h
+++ b/Interfaces/imanager.h
@@ -116,8 +116,8 @@ class IManager
     wxArrayString m_outputTabs;
 
 public:
-    IManager() {}
-    virtual ~IManager() {}
+    IManager() = default;
+    virtual ~IManager() = default;
 
     /**
      * @brief return a list of all possible output tabs registered by the user
@@ -257,7 +257,7 @@ public:
     OpenFile(const wxString& fileName, const wxString& bmpResourceName, const wxString& tooltip = wxEmptyString) = 0;
 
     /**
-     * @brief load a remote file content (represented by the local_path) into an `IEdtor`
+     * @brief load a remote file content (represented by the local_path) into an `IEditor`
      */
     virtual IEditor* OpenRemoteFile(const wxString& local_path,
                                     const wxString& remote_path,
@@ -296,7 +296,6 @@ public:
     virtual TreeItemInfo GetSelectedTreeItemInfo(TreeType type) = 0;
     /**
      * @brief returns a pointer to wxTreeCtrl by type
-     * @param type the type of tree
      * @sa TreeType
      */
     virtual clTreeCtrl* GetFileExplorerTree() = 0;
@@ -577,7 +576,7 @@ public:
                          bool selected = false) = 0;
 
     /**
-     * @brief select a window in mainbook
+     * @brief select a page in mainbook
      */
     virtual bool SelectPage(wxWindow* win) = 0;
 
@@ -587,7 +586,7 @@ public:
     virtual void SetPageTitle(wxWindow* win, const wxString& title) = 0;
 
     /**
-     * @brief set the page's title
+     * @brief get the page's title
      */
     virtual wxString GetPageTitle(wxWindow* win) const = 0;
 
@@ -611,7 +610,7 @@ public:
 
     /**
      * @brief search the mainbook for an editor representing a given filename
-     * return IEditor* or NULL if no match was found
+     * return IEditor* or nullptr if no match was found
      */
     virtual IEditor* FindEditor(const wxString& filename) const = 0;
 
@@ -663,7 +662,7 @@ public:
     virtual void SetBreakpoints(const clDebuggerBreakpoint::Vec_t& breakpoints) = 0;
 
     /**
-     * @brief process a standard edit event ( wxID_COPY, wxID_PASTE etc)
+     * @brief process a standard edit event (wxID_COPY, wxID_PASTE etc)
      * @param e the event to process
      * @param editor the editor
      */

--- a/Interfaces/plugin.h
+++ b/Interfaces/plugin.h
@@ -55,12 +55,7 @@
 #define EXPORT
 #endif
 
-#if defined(__WXMSW__) || defined(__WXGTK__)
 #define CL_PLUGIN_API extern "C" EXPORT
-#else
-// OSX
-#define CL_PLUGIN_API extern "C" EXPORT
-#endif
 
 class IManager;
 
@@ -102,10 +97,10 @@ protected:
      */
     void DeletePluginMenu(wxWindowID id)
     {
-        if(!GetPluginsMenu()) {
+        if (!GetPluginsMenu()) {
             return;
         }
-        if(GetPluginsMenu()->FindItem(id)) {
+        if (GetPluginsMenu()->FindItem(id)) {
             GetPluginsMenu()->Delete(id);
         }
     }
@@ -115,7 +110,7 @@ public:
         : m_mgr(manager)
     {
     }
-    virtual ~IPlugin() {}
+    ~IPlugin() override = default;
 
     //-----------------------------------------------
     // The interface
@@ -170,8 +165,8 @@ public:
      * @param notebook the parent
      * @param configName the associated configuration name
      */
-    virtual void HookProjectSettingsTab(wxBookCtrlBase* notebook, const wxString& projectName,
-                                        const wxString& configName)
+    virtual void
+    HookProjectSettingsTab(wxBookCtrlBase* notebook, const wxString& projectName, const wxString& configName)
     {
         wxUnusedVar(notebook);
         wxUnusedVar(projectName);
@@ -183,8 +178,8 @@ public:
      * @param notebook the parent
      * @param configName the associated configuration name
      */
-    virtual void UnHookProjectSettingsTab(wxBookCtrlBase* notebook, const wxString& projectName,
-                                          const wxString& configName)
+    virtual void
+    UnHookProjectSettingsTab(wxBookCtrlBase* notebook, const wxString& projectName, const wxString& configName)
     {
         wxUnusedVar(notebook);
         wxUnusedVar(projectName);
@@ -192,14 +187,14 @@ public:
     }
 };
 
-#define CHECK_CL_SHUTDOWN()               \
-    {                                     \
-        if(m_mgr->IsShutdownInProgress()) \
-            return;                       \
+#define CHECK_CL_SHUTDOWN()                \
+    {                                      \
+        if (m_mgr->IsShutdownInProgress()) \
+            return;                        \
     }
 
 // Every dll must contain at least this function
-typedef IPlugin* (*GET_PLUGIN_CREATE_FUNC)(IManager*);
-typedef PluginInfo* (*GET_PLUGIN_INFO_FUNC)();
-typedef int (*GET_PLUGIN_INTERFACE_VERSION_FUNC)();
+using GET_PLUGIN_CREATE_FUNC = IPlugin* (*)(IManager*);
+using GET_PLUGIN_INFO_FUNC = PluginInfo* (*)();
+using GET_PLUGIN_INTERFACE_VERSION_FUNC = int (*)();
 #endif // PLUGIN_H

--- a/LanguageServer/LanguageServerCluster.cpp
+++ b/LanguageServer/LanguageServerCluster.cpp
@@ -894,7 +894,7 @@ void LanguageServerCluster::OnSetDiagnostics(LSPEvent& event)
 
         for (const LSP::Diagnostic& d : event.GetDiagnostics()) {
             // LSP uses 1 based line numbers
-            CompilerMessage cm{ d.GetMessage(), new DiagnosticsData(d) };
+            CompilerMessage cm{ d.GetMessage(), std::make_unique<DiagnosticsData>(d) };
             switch (d.GetSeverity()) {
             case LSP::DiagnosticSeverity::Error:
                 editor->SetErrorMarker(d.GetRange().GetStart().GetLine(), std::move(cm));

--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -1531,7 +1531,7 @@ void clEditor::OnMarginClick(wxStyledTextEvent& event)
             if ((MarkerGet(nLine) & mmt_compiler) && m_compilerMessagesMap.count(nLine)) {
                 // user clicked on compiler error, fire an event
                 clEditorEvent event_error_clicked{ wxEVT_EDITOR_MARGIN_CLICKED };
-                event_error_clicked.SetUserData(m_compilerMessagesMap.find(nLine)->second.userData);
+                event_error_clicked.SetUserData(m_compilerMessagesMap.find(nLine)->second.userData.get());
                 event_error_clicked.SetFileName(GetRemotePathOrLocal());
                 event_error_clicked.SetLineNumber(nLine);
                 // use process here and not AddPendingEvent or QueueEvent
@@ -3408,7 +3408,7 @@ void clEditor::CreateRemote(const wxString& local_path, const wxString& remote_p
     SetProject(wxEmptyString);
     SetSyntaxHighlight(false);
     // mark this file as remote by setting a remote data
-    IEditor::SetClientData("sftp", new SFTPClientData(local_path, remote_path, ssh_account));
+    IEditor::SetClientData("sftp", std::make_unique<SFTPClientData>(local_path, remote_path, ssh_account));
     OpenFile();
 }
 

--- a/SFTP/sftp.cpp
+++ b/SFTP/sftp.cpp
@@ -340,8 +340,7 @@ void SFTP::FileDownloadedSuccessfully(const SFTPClientData& cd)
     IEditor* editor = m_mgr->OpenFile(cd.GetLocalPath(), "download", tooltip);
     if (editor) {
         // Tag this editor as a remote file
-        SFTPClientData* pcd = new SFTPClientData(cd);
-        editor->SetClientData("sftp", pcd);
+        editor->SetClientData("sftp", std::make_unique<SFTPClientData>(cd));
         // set the line number
         if (cd.GetLineNumber() != wxNOT_FOUND) {
             editor->GetCtrl()->GotoLine(cd.GetLineNumber());


### PR DESCRIPTION
- `using` instead of `typedef`
- `nullptr` instead of `NULL`
- Use in-class member initialization
- use `= default;`
- add `override`
- add `explicit`
- use `std::unique_ptr`