### PR TITLE
Fix plugin cppchecker plugin when WorkspacePath contains space.

### DIFF
--- a/cppchecker/cppchecker.cpp
+++ b/cppchecker/cppchecker.cpp
@@ -224,7 +224,7 @@ wxString CppCheckPlugin::DoGetCommand()
         // Create the cache dir if required
         wxString cache_dir;
         if (line.StartsWith("--cppcheck-build-dir=", &cache_dir)) {
-            cache_dir.Trim().Trim(false);
+            cache_dir.Trim().Trim(false).Replace("\"", "");
             wxFileName::Mkdir(cache_dir, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
         }
         cmd << line << " ";


### PR DESCRIPTION
When `WorkspacePath` contains spaces, surrounded double quote are added, but then `wxFileName::Mkdir` fails to create the directory (at least on Windows).
Cannot use `StringUtils::StripDoubleQuotes` as the double quote appears in the middle after substitution.

`${WorkspacePath}/.codelite/cppcheker` ->`"C:\path with space"/.codelite/cppcheker`