### PR TITLE
Statusbar: ensure that statusbar elements can be controlled via preferences - make field properly sized for its contents

### DIFF
--- a/CodeLite/cl_config.h
+++ b/CodeLite/cl_config.h
@@ -82,6 +82,7 @@ public:
 #define kConfigStatusbarShowPosition "StatusbarShowPosition"
 #define kConfigStatusbarShowLength "StatusbarShowLength"
 #define kConfigStatusbarShowSelectedChars "StatusbarShowSelChars"
+#define kConfigStatusbarShowSelectedLines "StatusbarShowSelLines"
 #define kConfigToolbarGroupSpacing "ToolbarGroupSpacing"
 #define kConfigAutoDetectCompilerOnStartup "AutoDetectCompilerOnStartup"
 #define kConfigBootstrapCompleted "BootstrapCompleted"

--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -1500,9 +1500,11 @@ void clEditor::OnSciUpdateUI(wxStyledTextEvent& event)
         if (m_statusBarFields & kShowLen) {
             message << (!message.empty() ? ", " : "") << "Len " << GetLength();
         }
-
         if ((m_statusBarFields & kShowSelectedChars) && selectionSize) {
-            message << (!message.empty() ? ", " : "") << "Sel " << selectionSize << ", SelLn " << selectionLn;
+            message << (!message.empty() ? ", " : "") << "Sel " << selectionSize;
+        }
+        if ((m_statusBarFields & kShowSelectedLines) && selectionSize && selectionLn) {
+            message << (!message.empty() ? ", " : "") << "SelLn " << selectionLn;
         }
 
         // Always update the status bar with event, calling it directly causes performance degradation
@@ -6134,6 +6136,9 @@ void clEditor::PreferencesChanged()
     }
     if (clConfig::Get().Read(kConfigStatusbarShowSelectedChars, true)) {
         m_statusBarFields |= kShowSelectedChars;
+    }
+    if (clConfig::Get().Read(kConfigStatusbarShowSelectedLines, true)) {
+        m_statusBarFields |= kShowSelectedLines;
     }
 }
 

--- a/LiteEditor/cl_editor.h
+++ b/LiteEditor/cl_editor.h
@@ -231,6 +231,7 @@ private:
         kShowPosition = (1 << 2),
         kShowLen = (1 << 3),
         kShowSelectedChars = (1 << 4),
+        kShowSelectedLines = (1 << 5),
     };
 
     enum eLineStatus : short {

--- a/LiteEditor/editorsettingsmiscpanel.cpp
+++ b/LiteEditor/editorsettingsmiscpanel.cpp
@@ -89,6 +89,8 @@ EditorSettingsMiscPanel::EditorSettingsMiscPanel(wxWindow* parent, OptionsConfig
                 UPDATE_CLCONFIG_BOOL_CB(kConfigStatusbarShowLength));
     AddProperty(_("Show number of selected chars"), clConfig::Get().Read(kConfigStatusbarShowSelectedChars, true),
                 UPDATE_CLCONFIG_BOOL_CB(kConfigStatusbarShowSelectedChars));
+    AddProperty(_("Show number of selected lines"), clConfig::Get().Read(kConfigStatusbarShowSelectedLines, true),
+                UPDATE_CLCONFIG_BOOL_CB(kConfigStatusbarShowSelectedLines));
 
     AddHeader(_("Tool bar"));
     AddProperty(_("Space between button groups"), clConfig::Get().Read(kConfigToolbarGroupSpacing, 30),

--- a/Plugin/clStatusBar.cpp
+++ b/Plugin/clStatusBar.cpp
@@ -99,7 +99,7 @@ clStatusBar::clStatusBar(wxWindow* parent, IManager* mgr)
         new wxCustomStatusBarBitmapField(this, clGetScaledSize(30) + lable_width));
     STATUSBAR_SCM_IDX = AddField(sourceControl);
 
-    int lineColWidth = GetTextWidth("Ln 100000, Col 999, Pos 12345678, Len 4821182");
+    const int lineColWidth = GetTextWidth("Ln 123456, Col 123, Pos 12345678, Len 12345678, Sel 1234567, SelLn 12345");
     wxCustomStatusBarField::Ptr_t lineCol(new wxCustomStatusBarFieldText(this, lineColWidth));
     STATUSBAR_LINE_COL_IDX = AddField(lineCol);
 


### PR DESCRIPTION
It gets rather lengthy...

```
-    int lineColWidth = GetTextWidth("Ln 100000, Col 999, Pos 12345678, Len 4821182");
+    int lineColWidth = GetTextWidth("Ln 123456, Col 123, Pos 12345678, Len 12345678, Sel 1234567, SelLn 12345");
```

Another approach could be to not display "Pos" and "Len" - if a selection is ongoing ?
