### PR TITLE
[cleanup] Fix some English typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,7 +879,7 @@ endif()
 # add the dtl module include path before we include Plugin folder
 include_directories(submodules/dtl)
 
-# Extran lexers required by CodeLite
+# Extra lexers required by CodeLite
 add_subdirectory(submodules/lexilla)
 
 add_subdirectory(submodules)

--- a/CodeFormatter/PHPFormatterBuffer.cpp
+++ b/CodeFormatter/PHPFormatterBuffer.cpp
@@ -210,7 +210,7 @@ PHPFormatterBuffer& PHPFormatterBuffer::ProcessToken(const phpLexerToken& token)
             m_buffer << token.Text();
 
         } else if(token.type == '!') {
-            // dont add extrace space after the NOT operator
+            // dont add extra space after the NOT operator
             m_buffer << token.Text();
 
         } else if(token.type == kPHP_T_NS_SEPARATOR) {
@@ -293,7 +293,7 @@ wxString PHPFormatterBuffer::FormatDoxyComment(const wxString& comment)
         for(size_t i = 0; i < lines.GetCount(); ++i) {
             lines.Item(i).Trim().Trim(false);
             if(i) {
-                // preprend space + the indent string for every line except for the first line
+                // prepend space + the indent string for every line except for the first line
                 lines.Item(i).Prepend(" ");
                 lines.Item(i).Prepend(indent);
             }
@@ -351,7 +351,7 @@ void PHPFormatterBuffer::format()
             // if(..) <statement> -> if(..)
             //                            <statement>
             // etc.
-            // In addtion, we also handle here the following:
+            // In addition, we also handle here the following:
             // if(something) {} else <statement> =>
             //                                      if(something) {
             //                                      } else

--- a/CodeLite/AsyncProcess/TerminalEmulator.cpp
+++ b/CodeLite/AsyncProcess/TerminalEmulator.cpp
@@ -134,7 +134,7 @@ bool TerminalEmulator::ExecuteNoConsole(const wxString& commandToRun, const wxSt
 #else
     wxString tmpCmd = commandToRun;
     command << "/bin/bash -c '";
-    // escape any single quoutes
+    // escape any single quotes
     tmpCmd.Replace("'", "\\'");
     command << tmpCmd << "'";
 #endif

--- a/CodeLite/AsyncProcess/asyncprocess.h
+++ b/CodeLite/AsyncProcess/asyncprocess.h
@@ -148,7 +148,7 @@ public:
     virtual void Cleanup() = 0;
 
     // Terminate the process. It is recommended to use this method
-    // so it will invoke the 'Cleaup' procedure and the process
+    // so it will invoke the 'Cleanup' procedure and the process
     // termination event will be sent out
     virtual void Terminate() = 0;
 

--- a/CodeLite/AsyncProcess/winprocess_impl.h
+++ b/CodeLite/AsyncProcess/winprocess_impl.h
@@ -75,7 +75,7 @@ public:
     /**
      * @brief read data from stdout and error
      * @param buff check the buffer when true is returned
-     * @return return true on success or timeout, flase otherwise, incase of false the reader thread will terminate
+     * @return return true on success or timeout, false otherwise, incase of false the reader thread will terminate
      */
     bool Read(wxString& buff, wxString& buffErr, std::string& raw_buff, std::string& raw_buff_err) override;
 

--- a/CodeLite/CTags.cpp
+++ b/CodeLite/CTags.cpp
@@ -31,7 +31,7 @@ void WrapInShell(wxString& cmd)
     cmd = command;
 #else
     command << "/bin/sh -c '";
-    // escape any single quoutes
+    // escape any single quotes
     cmd.Replace("'", "\\'");
     command << cmd << "'";
     cmd = command;

--- a/CodeLite/Console/clConsoleBase.h
+++ b/CodeLite/Console/clConsoleBase.h
@@ -89,7 +89,7 @@ public:
     virtual wxString PrepareCommand() = 0;
 
     /**
-     * @brief return the best terminal for the OS. Pass an empty string to return the default temrinal for the OS
+     * @brief return the best terminal for the OS. Pass an empty string to return the default terminal for the OS
      */
     static clConsoleBase::Ptr_t GetTerminal();
 

--- a/CodeLite/Cxx/CxxCodeCompletion.cpp
+++ b/CodeLite/Cxx/CxxCodeCompletion.cpp
@@ -127,7 +127,7 @@ TagEntryPtr CxxCodeCompletion::resolve_compound_expression(std::vector<CxxExpres
         // return a dummy entry representing the global scope
         return create_global_scope_tag();
     } else if(expression.size() >= 2 && expression[0].type_name().empty() && expression[0].operand_string() == "::") {
-        // explicity requesting for the global namespace
+        // explicitly requesting for the global namespace
         // clear the `scopes` and use only the global namespace (empty string)
         scopes.clear();
         scopes.push_back(wxEmptyString);
@@ -174,7 +174,7 @@ void CxxCodeCompletion::shrink_scope(const wxString& text, std::unordered_map<wx
         m_lookup->GetParameters(m_current_function_tag->GetPath(), parameters);
         m_lookup->GetLambdas(m_current_function_tag->GetPath(), all_lambdas);
 
-        // read all lambdas paramteres
+        // read all lambdas parameters
         std::unordered_map<wxString, TagEntryPtr> lambda_parameters_map;
         std::unordered_map<wxString, TagEntryPtr> function_parameters_map;
 
@@ -188,12 +188,12 @@ void CxxCodeCompletion::shrink_scope(const wxString& text, std::unordered_map<wx
                 std::vector<TagEntryPtr> lambda_parameters;
                 m_lookup->GetParameters(lambda->GetPath(), lambda_parameters);
                 for(auto param : lambda_parameters) {
-                    // if a function parameter with this name alrady exists, skip it
+                    // if a function parameter with this name already exists, skip it
                     if(function_parameters_map.count(param->GetName())) {
                         continue;
                     }
 
-                    // if we already encoutered a lambda parameter with this name, replace it
+                    // if we already encountered a lambda parameter with this name, replace it
                     if(lambda_parameters_map.count(param->GetName())) {
                         lambda_parameters_map.erase(param->GetName());
                     }
@@ -202,7 +202,7 @@ void CxxCodeCompletion::shrink_scope(const wxString& text, std::unordered_map<wx
             }
         }
 
-        // all the lambda paramters to the list of parameters
+        // all the lambda parameters to the list of parameters
         for(const auto& vt : lambda_parameters_map) {
             parameters.emplace_back(vt.second);
         }
@@ -382,7 +382,7 @@ void CxxCodeCompletion::update_template_table(TagEntryPtr resolved, CxxExpressio
         return;
     }
 
-    // simple template instantiaion line
+    // simple template instantiation line
     if(curexpr.is_template()) {
         curexpr.parse_template_placeholders(resolved->GetTemplateDefinition());
         wxStringMap_t M = curexpr.get_template_placeholders_map();
@@ -670,7 +670,7 @@ TagEntryPtr CxxCodeCompletion::resolve_expression(CxxExpression& curexp, TagEntr
 TagEntryPtr CxxCodeCompletion::on_typedef(CxxExpression& curexp, TagEntryPtr tag,
                                           const std::vector<wxString>& visible_scopes)
 {
-    // substitude the type with the typeref
+    // substitute the type with the typedef
     wxString new_expr;
     if(!resolve_user_type(tag->GetPath(), visible_scopes, &new_expr)) {
         new_expr = typedef_from_tag(tag);
@@ -1102,7 +1102,7 @@ void TemplateManager::add_placeholders(const wxStringMap_t& table, const std::ve
             // lets try and avoid pushing values that are templates
             // consider
             // template <typename _Tp> class vector : protected _Vector_base<_Tp> {..}
-            // Looking at the definitio of _Vector_base:
+            // Looking at the definition of _Vector_base:
             // template <typename _Tp> class _Vector_base {...}
             // this will cause us to push {"_Tp", "_Tp"} (where _Tp is both the key and value)
             // if the resolve will fail, it will return vt.second unmodified
@@ -1210,7 +1210,7 @@ void CxxCodeCompletion::sort_tags(const std::vector<TagEntryPtr>& tags, std::vec
         } else if(access == "public") {
             if(tag->GetName().StartsWith("_") || tag->GetName().Contains("operator")) {
                 // methods starting with _ usually are meant to be private
-                // and also, put the "operator" methdos at the bottom
+                // and also, put the "operator" methods at the bottom
                 privateTags.push_back(tag);
             } else {
                 publicTags.push_back(tag);
@@ -1385,7 +1385,7 @@ size_t CxxCodeCompletion::find_definition(const wxString& filepath, int line, co
         word_complete(filepath, line, expression, text, visible_scopes, true, candidates);
         // filter all the tags
         if(candidates.empty() || (candidates.size() == 1 && (candidates[0]->GetLine() == wxNOT_FOUND))) {
-            clDEBUG() << "Unable to complete, checking on the current lcoation" << endl;
+            clDEBUG() << "Unable to complete, checking on the current location" << endl;
             candidates.clear();
             m_lookup->GetTagsByFileAndLine(filepath, line, candidates);
             if(candidates.empty()) {

--- a/CodeLite/Cxx/CxxCodeCompletion.hpp
+++ b/CodeLite/Cxx/CxxCodeCompletion.hpp
@@ -76,7 +76,7 @@ public:
     }
 
     /**
-     * @brief return all function paramters that match the filter
+     * @brief return all function parameters that match the filter
      * if filter is empty, return all of the parameters
      */
     std::vector<TagEntryPtr> get_function_parameters(const wxString& filter) const

--- a/CodeLite/Cxx/CxxExpression.cpp
+++ b/CodeLite/Cxx/CxxExpression.cpp
@@ -187,7 +187,7 @@ bool CxxExpression::handle_cxx_casting(CxxTokenizer& tokenizer, wxString* cast_t
         break;
     }
 
-    // did not find cast epxression
+    // did not find cast expression
     if(state == STATE_NORMAL) {
         tokenizer.UngetToken();
         return false;

--- a/CodeLite/Cxx/CxxExpression.hpp
+++ b/CodeLite/Cxx/CxxExpression.hpp
@@ -15,7 +15,7 @@
 /// std::string::size_
 ///
 /// Passing the above to CxxExpression::from_expression
-/// and assuming that the it succeed, the mainder will be:
+/// and assuming that the it succeed, the remainder will be:
 /// filter -> size_
 /// operand_string -> "::"
 struct WXDLLIMPEXP_CL CxxRemainder {
@@ -73,7 +73,7 @@ public:
     void parse_template_placeholders(const wxString& expr);
 
     /**
-     * @brief reutn template placeholders map
+     * @brief return template placeholders map
      */
     wxStringMap_t get_template_placeholders_map() const;
     /**

--- a/CodeLite/Cxx/CxxTokenizer.cpp
+++ b/CodeLite/Cxx/CxxTokenizer.cpp
@@ -115,7 +115,7 @@ wxString CxxTokenizer::GetVisibleScope(const wxString& inputString)
                 parenthesisDepth++;
                 currentScope << "(";
                 // Handle lambda
-                // If we are enterting lamda function defenition, collect the locals
+                // If we are entering lambda function definition, collect the locals
                 // this is exactly what we in 'catch' hence the state change to SCP_STATE_IN_CATCH
                 if(GetLastToken().GetType() == ']') {
                     state = SCP_STATE_IN_CATCH;

--- a/CodeLite/Cxx/CxxTokenizer.h
+++ b/CodeLite/Cxx/CxxTokenizer.h
@@ -17,8 +17,8 @@ public:
     virtual ~CxxTokenizer();
 
     /**
-     * @brief get the next token from the toknizer
-     * @reutrn false when reached EOF
+     * @brief get the next token from the tokenizer
+     * @return false when reached EOF
      */
     bool NextToken(CxxLexerToken& token);
 

--- a/CodeLite/JSON.h
+++ b/CodeLite/JSON.h
@@ -107,7 +107,7 @@ public:
     std::vector<int> toIntArray(const std::vector<int>& defaultValue = {}) const;
     JSONItem arrayItem(int pos) const;
 
-    // Retuen the object type
+    // Return the object type
     bool isNull() const;
     bool isBool() const;
     bool isString() const;
@@ -152,12 +152,12 @@ public:
     static JSONItem createArray(const wxString& name = wxT(""));
 
     /**
-     * @brief add array to this json and return a referece to the newly added array
+     * @brief add array to this json and return a reference to the newly added array
      */
     JSONItem AddArray(const wxString& name);
 
     /**
-     * @brief add object to this json and return a referece to the newly added object
+     * @brief add object to this json and return a reference to the newly added object
      */
     JSONItem AddObject(const wxString& name);
 

--- a/CodeLite/LSP/GotoDeclarationRequest.cpp
+++ b/CodeLite/LSP/GotoDeclarationRequest.cpp
@@ -43,7 +43,7 @@ void LSP::GotoDeclarationRequest::OnResponse(const LSP::ResponseMessage& respons
             event.SetFileName(m_filename);
             EventNotifier::Get()->AddPendingEvent(event);
         } else {
-            // We send the same event for declaraion as we do for definition
+            // We send the same event for declaration as we do for definition
             LSPEvent event{ wxEVT_LSP_DEFINITION };
             event.SetLocation(loc);
             event.SetFileName(m_filename);

--- a/CodeLite/LSP/GotoImplementationRequest.cpp
+++ b/CodeLite/LSP/GotoImplementationRequest.cpp
@@ -25,7 +25,7 @@ void LSP::GotoImplementationRequest::OnResponse(const LSP::ResponseMessage& resp
         loc.FromJSON(result);
     }
 
-    // We send the same event for declaraion as we do for definition
+    // We send the same event for declaration as we do for definition
     if(!loc.GetPath().IsEmpty()) {
         LSPEvent definitionEvent(wxEVT_LSP_DEFINITION);
         definitionEvent.SetLocation(loc);

--- a/CodeLite/LSP/Request.h
+++ b/CodeLite/LSP/Request.h
@@ -26,7 +26,7 @@ public:
     virtual void FromJSON(const JSONItem& json);
 
     /**
-     * @brief is this request position dependant? (i.e. the response should be diplsayed where the request was
+     * @brief is this request position dependant? (i.e. the response should be displayed where the request was
      * triggered?)
      */
     virtual bool IsPositionDependantRequest() const { return false; }

--- a/CodeLite/LSP/basic_types.h
+++ b/CodeLite/LSP/basic_types.h
@@ -669,7 +669,7 @@ WXDLLIMPEXP_CL wxString FileNameToURI(const wxString& filename);
 /// Return the log handle of this library
 WXDLLIMPEXP_CL clModuleLogger& GetLogHandle();
 
-/// Parse the text edit from a reponse "result" field
+/// Parse the text edit from a response "result" field
 WXDLLIMPEXP_CL std::unordered_map<wxString, std::vector<LSP::TextEdit>> ParseWorkspaceEdit(const JSONItem& result);
 
 };     // namespace LSP

--- a/CodeLite/PHP/PHPDocVisitor.cpp
+++ b/CodeLite/PHP/PHPDocVisitor.cpp
@@ -88,7 +88,7 @@ void PHPDocVisitor::OnEntity(PHPEntityBase::Ptr_t entity)
             wxString typeHint = docComment.GetParam(entity->GetFullName());
             const wxString& currentTypeHint = entity->Cast<PHPEntityVariable>()->GetTypeHint();
             if(!typeHint.IsEmpty() && currentTypeHint.IsEmpty()) {
-                // The typehint of a functin argument should have more value than the one provided
+                // The typehint of a function argument should have more value than the one provided
                 // in the documentation
                 entity->Cast<PHPEntityVariable>()->SetTypeHint(typeHint);
             }

--- a/CodeLite/PHP/PHPEntityClass.h
+++ b/CodeLite/PHP/PHPEntityClass.h
@@ -51,7 +51,7 @@ public:
     JSONItem ToJSON() const;
     
     /**
-     * @brief return an array of inheritance (extends, implementes and traits)
+     * @brief return an array of inheritance (extends, implements and traits)
      */
     wxArrayString GetInheritanceArray() const;
 

--- a/CodeLite/PHP/PHPEntityNamespace.cpp
+++ b/CodeLite/PHP/PHPEntityNamespace.cpp
@@ -137,6 +137,6 @@ void PHPEntityNamespace::FromJSON(const JSONItem& json)
 
 JSONItem PHPEntityNamespace::ToJSON() const
 {
-    JSONItem json = BaseToJSON("n"); // n stands for namesapce
+    JSONItem json = BaseToJSON("n"); // n stands for namespace
     return json;
 }

--- a/CodeLite/PHP/PHPEntityVisitor.h
+++ b/CodeLite/PHP/PHPEntityVisitor.h
@@ -31,7 +31,7 @@
 
 /**
  * @class PHPEntityVisitor
- * Accept as input a PHPEntitBase and visit all of its children
+ * Accept as input a PHPEntityBase and visit all of its children
  */
 class WXDLLIMPEXP_CL PHPEntityVisitor
 {
@@ -42,7 +42,7 @@ public:
     void Visit(PHPEntityBase::Ptr_t parent);
     
     /**
-     * @brief called whenver an entity is visited
+     * @brief called whenever an entity is visited
      * @param entity
      */
     virtual void OnEntity(PHPEntityBase::Ptr_t entity) = 0;

--- a/CodeLite/PHP/PHPExpression.cpp
+++ b/CodeLite/PHP/PHPExpression.cpp
@@ -276,7 +276,7 @@ PHPEntityBase::Ptr_t PHPExpression::Resolve(PHPLookupTable& lookpTable, const wx
 
         // If the current "part" of the expression ends with a scope resolving operator ("::") or
         // an object operator ("->") we need to resolve the operator to the actual type (
-        // incase of a functin it will be the return value, and in case of a variable it will be
+        // incase of a function it will be the return value, and in case of a variable it will be
         // the type hint)
         if(currentToken) {
             if(part.m_operator == kPHP_T_OBJECT_OPERATOR || part.m_operator == kPHP_T_PAAMAYIM_NEKUDOTAYIM) {
@@ -381,7 +381,7 @@ wxString PHPExpression::DoSimplifyExpression(int depth, PHPSourceFile::Ptr_t sou
                 // $this->getQuery()->fetchAll()->
                 // However, $this also need a replacement so eventually, it becomes like this:
                 // \MyClass->getQuery->fetchAll-> and this is something that we can evaluate easily using
-                // our lookup tables (note that the parenthessis are missing on purpose)
+                // our lookup tables (note that the parenthesis are missing on purpose)
                 PHPEntityBase::Ptr_t local = scope->FindChild(token.Text());
                 if(local && local->Cast<PHPEntityVariable>()) {
                     if(!local->Cast<PHPEntityVariable>()->GetTypeHint().IsEmpty()) {
@@ -448,7 +448,7 @@ wxString PHPExpression::DoSimplifyExpression(int depth, PHPSourceFile::Ptr_t sou
             if(!currentText.IsEmpty() && part.m_text.IsEmpty()) {
                 if(m_parts.empty() && token.type == kPHP_T_PAAMAYIM_NEKUDOTAYIM) {
                     // The first token in the "parts" list has a scope resolving operator ("::")
-                    // we need to make sure that the indetifier is provided in fullpath
+                    // we need to make sure that the identifier is provided in fullpath
                     part.m_text = sourceFile->MakeIdentifierAbsolute(currentText);
                 } else {
                     part.m_text = currentText;
@@ -456,7 +456,7 @@ wxString PHPExpression::DoSimplifyExpression(int depth, PHPSourceFile::Ptr_t sou
             }
 
             if(m_parts.empty()) {
-                // If the first token before the simplication was 'parent'
+                // If the first token before the simplification was 'parent'
                 // keyword, we need to carry this over
                 part.m_textType = firstTokenType;
             }

--- a/CodeLite/PHP/PHPExpression.h
+++ b/CodeLite/PHP/PHPExpression.h
@@ -89,13 +89,13 @@ public:
 
     const phpLexerToken::Vet_t& GetExpression() const { return m_expression; }
     /**
-     * @brief return the parse expression as string. Useful for debuggin purposes
+     * @brief return the parse expression as string. Useful for debugging purposes
      */
     wxString GetExpressionAsString() const;
 
     /**
      * @brief suggest matches for this expression.
-     * This function must be called after a successfull call to 'Resolve'
+     * This function must be called after a successful call to 'Resolve'
      * @param resolved the resolved object from the previous call to 'Resolve'
      * @param matches [output]
      */
@@ -130,7 +130,7 @@ public:
     const wxString& GetFilter() const { return m_filter; }
 
     /**
-     * @brief get the lookup flags to pass to the lookup table for feteching members
+     * @brief get the lookup flags to pass to the lookup table for fetching members
      */
     size_t GetLookupFlags() const;
 };

--- a/CodeLite/PHP/PHPLookupTable.cpp
+++ b/CodeLite/PHP/PHPLookupTable.cpp
@@ -1151,7 +1151,7 @@ PHPEntityBase::List_t PHPLookupTable::FindNamespaces(const wxString& fullnameSta
 void PHPLookupTable::ResetDatabase()
 {
     wxFileName curfile = m_filename;
-    Close(); // Close the databse releasing any file capture we have
+    Close(); // Close the database releasing any file capture we have
     // Delete the file
     if(curfile.IsOk() && curfile.Exists()) {
         // Delete it from the file system

--- a/CodeLite/PHP/PHPLookupTable.h
+++ b/CodeLite/PHP/PHPLookupTable.h
@@ -179,7 +179,7 @@ public:
     void SetSizeLimit(size_t sizeLimit) { this->m_sizeLimit = sizeLimit; }
 
     /**
-     * @brief return list of functiosn from a given file
+     * @brief return list of functions from a given file
      */
     size_t FindFunctionsByFile(const wxFileName& filename, PHPEntityBase::List_t& functions);
 

--- a/CodeLite/PHP/PHPSourceFile.cpp
+++ b/CodeLite/PHP/PHPSourceFile.cpp
@@ -269,7 +269,7 @@ void PHPSourceFile::OnUse()
                 // use Zend\Mvc\Controll\Action;
                 // is equal for writing:
                 // use \Zend\Mvc\Controll\Action;
-                // For simplicitiy, we change it to fully qualified path
+                // For simplicity, we change it to fully qualified path
                 // so parsing is easier
                 if(!fullname.StartsWith("\\")) {
                     fullname.Prepend("\\");
@@ -1070,7 +1070,7 @@ void PHPSourceFile::OnDefine(const phpLexerToken& tok)
         var->SetLine(tok.lineNumber);
 
         // We keep the defines in a special list
-        // this is because 'define' does not obay to the current scope
+        // this is because 'define' does not obey to the current scope
         m_defines.push_back(var);
     }
     // Always consume the 'define' statement
@@ -1299,7 +1299,7 @@ void PHPSourceFile::ParseUseTraitsBody()
                 // use Zend\Mvc\Controll\Action;
                 // is equal for writing:
                 // use \Zend\Mvc\Controll\Action;
-                // For simplicitiy, we change it to fully qualified path
+                // For simplicity, we change it to fully qualified path
                 // so parsing is easier
                 if(!fullname.StartsWith("\\")) {
                     fullname.Prepend("\\");
@@ -1328,7 +1328,7 @@ void PHPSourceFile::ParseUseTraitsBody()
         } break;
         case kPHP_T_INSTEADOF: {
             // For now, we are not interested in
-            // A insteadof b; statements, so just clear the collected data so far
+            // A instead of b; statements, so just clear the collected data so far
             fullname.clear();
             temp.clear();
             alias.clear();
@@ -1562,7 +1562,7 @@ wxString PHPSourceFile::DoMakeIdentifierAbsolute(const wxString& type, bool exac
     }
 
     if(exactMatch && m_lookup && !typeWithNS.Contains("\\") && !m_lookup->ClassExists(ns + typeWithNS)) {
-        // Only when "exactMatch" apply this logic, otherwise, we might be getting a partialy typed string
+        // Only when "exactMatch" apply this logic, otherwise, we might be getting a partially typed string
         // which we will not find by calling FindChild()
         typeWithNS.Prepend("\\"); // Use the global NS
     } else {

--- a/CodeLite/Platform/PlatformCommon.hpp
+++ b/CodeLite/Platform/PlatformCommon.hpp
@@ -29,7 +29,7 @@ public:
     bool WhichWithVersion(const wxString& command, const std::vector<int>& versions, wxString* command_fullpath);
 
     /**
-     * @brief locaate rustup bin folder (on platforms that this is available)
+     * @brief locate rustup bin folder (on platforms that this is available)
      */
     bool FindRustupToolchainBinDir(wxString* rustup_bin_dir);
 

--- a/CodeLite/SocketAPI/clConnectionString.cpp
+++ b/CodeLite/SocketAPI/clConnectionString.cpp
@@ -20,7 +20,7 @@ void clConnectionString::DoParse(const wxString& connectionString)
         m_protocol = kTcp;
     } else if(protocol == "unix") {
 #ifdef __WXMSW__
-        clWARNING() << "unix protocol is not suppported on Windows" << clEndl;
+        clWARNING() << "unix protocol is not supported on Windows" << clEndl;
         return;
 #else
         m_protocol = kUnixLocalSocket;

--- a/CodeLite/StringUtils.h
+++ b/CodeLite/StringUtils.h
@@ -119,7 +119,7 @@ public:
     /// If string contains space, wrap it with double quotes
     static wxString WrapWithDoubleQuotes(const wxString& str);
 
-    /// If a string is wrapped with double quoutes -> strip them
+    /// If a string is wrapped with double quotes -> strip them
     static wxString StripDoubleQuotes(const wxString& str);
 
     /// Append `str` to `arr`. If the array size exceed the truncation size, shrink it to fit

--- a/CodeLite/clFileName.cpp
+++ b/CodeLite/clFileName.cpp
@@ -12,7 +12,7 @@ namespace
 {
 
 std::once_flag cygpath_once;
-wxString cygpath; // contains path to cygpth or empty string if not found
+wxString cygpath; // contains path to cygpath or empty string if not found
 
 #ifdef __WXMSW__
 /// helper method:

--- a/CodeLite/clTempFile.hpp
+++ b/CodeLite/clTempFile.hpp
@@ -21,7 +21,7 @@ public:
 
     ~clTempFile();
     /**
-     * @brief wite content to the temp file
+     * @brief write content to the temp file
      */
     bool Write(const wxString& content, wxMBConv& conv = wxConvUTF8);
     /**

--- a/CodeLite/cl_command_event.h
+++ b/CodeLite/cl_command_event.h
@@ -471,7 +471,7 @@ public:
     // Special features not available by all the debuggers
     enum eFeatures {
         kStepInst = (1 << 0),         // single step instruction
-        kInterrupt = (1 << 1),        // interrup the running process
+        kInterrupt = (1 << 1),        // interrupt the running process
         kShowCursor = (1 << 2),       // show the current active line
         kJumpToCursor = (1 << 3),     // Jump to the caret line, without executing the code in between
         kRunToCursor = (1 << 4),      // execute all the code until reaching the caret
@@ -625,7 +625,7 @@ typedef void (wxEvtHandler::*clGotoEventFunction)(clGotoEvent&);
 #define clGotoEventHandler(func) wxEVENT_HANDLER_CAST(clGotoEventFunction, func)
 
 // --------------------------------------------------------------
-// Processs event
+// Process event
 // --------------------------------------------------------------
 class IProcess;
 class WXDLLIMPEXP_CL clProcessEvent : public clCommandEvent

--- a/CodeLite/cl_standard_paths.h
+++ b/CodeLite/cl_standard_paths.h
@@ -101,7 +101,7 @@ public:
     wxString GetBinaryFullPath(const wxString& toolname, bool unixStylePath = false) const;
 
     /**
-     * @brief get CodeLite executale path
+     * @brief get CodeLite executable path
      */
     wxString GetExecutablePath() const;
 
@@ -116,7 +116,7 @@ public:
     wxString GetLexersDir() const;
 
     /**
-     * @brief return the project templates dircectory
+     * @brief return the project templates directory
      */
     wxString GetProjectTemplatesDir() const;
 

--- a/CodeLite/codelite_events.h
+++ b/CodeLite/codelite_events.h
@@ -245,7 +245,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_GET_IS_PLUGIN_BUILD, clBuildEvent
 // to the compilation/link line of the default build system
 // By using the event.SetCommand()/event.GetCommand()
 // Note, that the since all multiple plugins
-// might be interesting with this feature, it is recommened
+// might be interesting with this feature, it is recommended
 // to use it like this:
 // wxString content = event.GetCommand();
 // content << wxT(" -DMYMACRO ");
@@ -254,7 +254,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_GET_IS_PLUGIN_BUILD, clBuildEvent
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_GET_ADDITIONAL_COMPILEFLAGS, clBuildEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_GET_ADDITIONAL_LINKFLAGS, clBuildEvent);
 
-// Evnet type: clBuildEvent
+// Event type: clBuildEvent
 // Sent to the plugins to request to export the makefile
 // for the project + configuration
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_PLUGIN_EXPORT_MAKEFILE, clBuildEvent);
@@ -383,7 +383,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_CC_CODE_COMPLETE, clCodeCompletio
 // User asked for "word completion" Ctrl-SPACE
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_CC_WORD_COMPLETE, clCodeCompletionEvent);
 
-// A function calltip is requesed
+// A function calltip is requested
 // clientData is set to the client data set by the user
 // the plugin returns the tooltip to the IDE using the:
 // evt.SetTooltip(..) method
@@ -458,7 +458,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_CMD_CLOSE_WORKSPACE, clCommandEve
 
 // Event type: clCommandEvent
 // This event is sent by codelite to the plugins to query whether a
-// a custom workspace is opened (i.e. a worksapce which is completely managed
+// a custom workspace is opened (i.e. a workspace which is completely managed
 // by the plugin) this allows codelite to enable menu items which otherwise
 // will be left disabled
 // to return a true or false reply to codelite, use
@@ -535,7 +535,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_FINDBAR_ABOUT_TO_SHOW, clFindEven
 // This event should be used with  'wxEVT_FINDBAR_ABOUT_TO_SHOW'. If this event is not sent when the window
 // is destroyed - it might result in a crash
 // The window pointer is passed using event.SetCtrl()
-// If the editor managed by the find-bar is the same as event.GetCtrl() -> the find-bar will un-refernce it
+// If the editor managed by the find-bar is the same as event.GetCtrl() -> the find-bar will un-reference it
 // but *IT DOES NOT FREE ITS MEMORY*
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_FINDBAR_RELEASE_EDITOR, clFindEvent);
 
@@ -600,12 +600,12 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_CMD_RELOAD_WORKSPACE, clCommandEv
 
 // Event type: clColourEvent
 // Sent by codelite whenever it needs to colour a single tab
-// avoid calling event.Skip() to notify codelite that the plugin wants to place a sepcial
+// avoid calling event.Skip() to notify codelite that the plugin wants to place a special
 // colour. The colours (*plural*) should be passed using the 'event.SetFgColour()' and 'event.SetBgColour()'
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_COLOUR_TAB, clColourEvent);
 
 // Event type: clCommandEvent
-// Sent by codelite before it starts building the "Workspsace View" tree view.
+// Sent by codelite before it starts building the "Workspace View" tree view.
 // User may provide a different image list by placing it inside the event
 // event.SetClientData() member and by calling event.Skip(false)
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_WORKSPACE_VIEW_BUILD_STARTING, clCommandEvent);
@@ -639,7 +639,7 @@ wxDECLARE_EXPORTED_EVENT(
     WXDLLIMPEXP_CL,
     wxEVT_DBG_UI_START,
     clDebugEvent); // Start. This event is fired when a debug session is starting. The plugin should also set the
-                   // "feaures" field to indicate which features are available by the debugger
+                   // "features" field to indicate which features are available by the debugger
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_DBG_UI_CONTINUE, clDebugEvent);  // Continue
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_DBG_UI_STOP, clDebugEvent);      // Stop the debugger
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_DBG_UI_STEP_IN, clDebugEvent);   // Step into function
@@ -675,7 +675,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_DBG_EXPR_TOOLTIP, clDebugEvent);
 // This event is sent by codelite to all plugins to determine whether a plugin is actually a debugger.
 // A plugin should *always* call event.Skip() when handling this event. If the plugin is actually a debugger
 // plugin, it should add itself like this: event.GetStrings().Add("<the-debugger-name")
-// This string is later will be availe for codelite to display it in various dialogs (e.g. Quick Debug, project settings
+// This string is later will be available for codelite to display it in various dialogs (e.g. Quick Debug, project settings
 // etc)
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_DBG_IS_PLUGIN_DEBUGGER, clDebugEvent);
 
@@ -706,7 +706,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_NEW_PROJECT_WIZARD_SHOWING, clNew
 // event type: clNewProjectEvent
 // User clicked on the 'Finish' button of the new project wizard dialog
 // call event.Skip( false ) if the plugin wants to handle the new project, otherwise
-// call event.Skip( true ) for codelite to run the default behvior
+// call event.Skip( true ) for codelite to run the default behavior
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_NEW_PROJECT_WIZARD_FINISHED, clNewProjectEvent);
 
 // --------------------------------------------------------------
@@ -790,11 +790,11 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_CONTEXT_MENU_TAB_LABEL, clContext
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_CMD_COLOURS_FONTS_UPDATED, clCommandEvent);
 
 // File has been loaded into the IDE
-// User: clCommandEvnet::GetFileName() to get the file name
+// User: clCommandEvent::GetFileName() to get the file name
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_FILE_LOADED, clCommandEvent);
 
 // File has been closed
-// User: clCommandEvnet::GetFileName() to get the file name
+// User: clCommandEvent::GetFileName() to get the file name
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_FILE_CLOSED, clCommandEvent);
 
 // Sent when codelite is about to set the main frame's title.
@@ -873,13 +873,13 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_FORCE_RESTART_CODELITE, clCommand
 
 // Event: clCommandEvent
 // Toggle workspace view tab. Use event.IsSelected() to test whether we should hide/show the tab
-// In anycase, you should not destroy the window, just hide it
+// In any case, you should not destroy the window, just hide it
 // The tab name is set in the event.GetString()
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_SHOW_WORKSPACE_TAB, clCommandEvent);
 
 // Event: clCommandEvent
 // Toggle output view tab. Use event.IsSelected() to test whether we should hide/show the tab
-// In anycase, you should not destroy the window, just hide it
+// In any case, you should not destroy the window, just hide it
 // The tab name is set in the event.GetString()
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CL, wxEVT_SHOW_OUTPUT_TAB, clCommandEvent);
 

--- a/CodeLite/ctags_manager.cpp
+++ b/CodeLite/ctags_manager.cpp
@@ -275,7 +275,7 @@ bool TagsManager::GetDerivationListInternal(const wxString& path, TagEntryPtr de
                 // dont attempt to fix it
                 if(inherits.Contains(wxT("::")) == false) {
 
-                    // Correc the type/scope
+                    // Correct the type/scope
                     bool testForTemplate = !IsTypeAndScopeExists(inherits, possibleScope);
 
                     // If the type does not exists, check for templates
@@ -293,7 +293,7 @@ bool TagsManager::GetDerivationListInternal(const wxString& path, TagEntryPtr de
                         // this is done to make sure that the new type is not a macro...
                         if(!newType.IsEmpty() && newType != inherits) {
 
-                            // check the user defined types for a replcement token
+                            // check the user defined types for a replacement token
                             wxString replacement = DoReplaceMacros(newType);
                             if(replacement == newType) {
                                 // No match was found in the user defined replacements
@@ -529,7 +529,7 @@ void TagsManager::FilterNonNeededFilesForRetaging(wxArrayString& strFiles, ITags
         // does the file exist in both lists?
         std::unordered_set<wxString>::iterator iter = files_set.find(fe->GetFile());
         if(iter != files_set.end()) {
-            // get the actual modifiaction time of the file from the disk
+            // get the actual modification time of the file from the disk
             struct stat buff;
             int modified(0);
 

--- a/CodeLite/ctags_manager.h
+++ b/CodeLite/ctags_manager.h
@@ -134,7 +134,7 @@ public:
     void ClearCachedFile(const wxString& fileName);
 
     /**
-     * @brief load fileName into cache, note that this call will clear perivous
+     * @brief load fileName into cache, note that this call will clear previous
      * cache
      */
     void CacheFile(const wxString& fileName);
@@ -256,7 +256,7 @@ public:
      * file name
      * @param fileName file to search for
      * @param lineno the line number
-     * @return pointer to the tage which matches the line number & files
+     * @return pointer to the tag which matches the line number & files
      */
     TagEntryPtr FunctionFromFileLine(const wxFileName& fileName, int lineno);
 
@@ -306,7 +306,7 @@ public:
                                   std::vector<std::pair<int, int>>* paramLen = NULL);
 
     /**
-     * @brief fileter a recently tagged files from the strFiles array
+     * @brief filter a recently tagged files from the strFiles array
      * @param strFiles
      * @param db
      */
@@ -314,7 +314,7 @@ public:
 
     /**
      * @brief insert functionBody into clsname. This function will search for best location
-     * to place the function body. set visibility to 0 for 'pubilc' function, 1 for 'protected' and 2 for private
+     * to place the function body. set visibility to 0 for 'public' function, 1 for 'protected' and 2 for private
      * return true if this function succeeded, false otherwise
      */
     bool InsertFunctionDecl(const wxString& clsname, const wxString& functionDecl, wxString& sourceContent,

--- a/CodeLite/database/entry.cpp
+++ b/CodeLite/database/entry.cpp
@@ -128,7 +128,7 @@ void TagEntry::Create(const wxString& fileName, const wxString& name, int lineNu
             if(!tmpname.StartsWith("__anon")) {
                 UpdatePath(path);
             } else {
-                // anonymouse union, remove the anonymous part from its name
+                // anonymous union, remove the anonymous part from its name
                 path = path.BeforeLast(':');
                 path = path.BeforeLast(':');
                 UpdatePath(path);
@@ -269,7 +269,7 @@ wxString TagEntry::GetPattern() const
 void TagEntry::FromLine(const wxString& line)
 {
     // label	C:\src\wxCustomControls\clTreeCtrl\clChoice.cpp	/^        const wxString& label = m_choices[i];$/;"
-    // local line:116	type:constwxString
+    // local line:116	type:const wxString
     wxString pattern, kind;
     wxString strLine = line;
     long lineNumber = wxNOT_FOUND;

--- a/CodeLite/database/entry.h
+++ b/CodeLite/database/entry.h
@@ -251,7 +251,7 @@ public:
      * \param lineNumber Tag line number
      * \param pattern Pattern
      * \param kind Tag kind (class, struct, etc)
-     * \param extFields Map of extenstion fields (key:value)
+     * \param extFields Map of extention fields (key:value)
      * \param project Project name
      */
     void Create(const wxString& fileName, const wxString& name, int lineNumber, const wxString& pattern,
@@ -387,7 +387,7 @@ public:
     wxString GetFullDisplayName() const;
 
     //------------------------------------------
-    // Extenstion fields
+    // Extention fields
     //------------------------------------------
     const wxString& GetExtField(const wxString& extField) const;
 

--- a/CodeLite/database/istorage.h
+++ b/CodeLite/database/istorage.h
@@ -144,7 +144,7 @@ public:
                                         std::vector<TagEntryPtr>& tags) = 0;
 
     /**
-     * @brief reutnr array of tags by kind and path
+     * @brief return array of tags by kind and path
      * @param kinds array of kind
      * @param path
      * @param tags  [output]
@@ -265,7 +265,7 @@ public:
      * Store tree of tags into db.
      * @param tree Tags tree to store
      * @param path Database file name
-     * @param autoCommit handle the Store operation inside a transaction or let the user hadle it
+     * @param autoCommit handle the Store operation inside a transaction or let the user handle it
      */
     virtual void Store(const std::vector<TagEntryPtr>& tags, bool auto_commit = true) = 0;
 
@@ -300,7 +300,7 @@ public:
      * Delete all entries from database that are related to filename.
      * @param path Database name
      * @param fileName File name
-     * @param autoCommit handle the Delete operation inside a transaction or let the user hadle it
+     * @param autoCommit handle the Delete operation inside a transaction or let the user handle it
      */
     virtual void DeleteByFileName(const wxFileName& path, const wxString& fileName, bool autoCommit = true) = 0;
 

--- a/CodeLite/database/tags_storage_sqlite3.h
+++ b/CodeLite/database/tags_storage_sqlite3.h
@@ -38,7 +38,7 @@
 
 /**
  * TagsDatabase is a wrapper around wxSQLite3 database with tags specific functions.
- * It allows caller to query and populate the SQLite database for tags with a set of convinient functions.
+ * It allows caller to query and populate the SQLite database for tags with a set of convenient functions.
  * this class is responsible for creating the schema for the CodeLite library.
  *
  * The tables are automatically created once a database is created
@@ -59,7 +59,7 @@
  * |Pattern       | String | pattern that can be used to located this tag in the file
  * |Parent        | String | tag direct parent, can be its class parent (for members or functions), namespace or the
  * literal "<global>"
- * |Inherits      | String | If this class/struct inherits from other class, it will cotain the name of the base class
+ * |Inherits      | String | If this class/struct inherits from other class, it will contain the name of the base class
  * |Path          | String | full name including path, (e.g. Project::ClassName::FunctionName
  * |Typeref       | String | Special type of tag, that points to other Tag (i.e. typedef)
  *
@@ -205,7 +205,7 @@ public:
 
     /**
      * store list of tags to store. The list is considered complete and all files
-     * afftected will be erased from the db first
+     * affected will be erased from the db first
      */
     void Store(const std::vector<TagEntryPtr>& tags, bool auto_commit = true);
 
@@ -222,7 +222,7 @@ public:
      * Delete all entries from database that are related to filename.
      * @param path Database name
      * @param fileName File name
-     * @param autoCommit handle the Delete operation inside a transaction or let the user hadle it
+     * @param autoCommit handle the Delete operation inside a transaction or let the user handle it
      */
     void DeleteByFileName(const wxFileName& path, const wxString& fileName, bool autoCommit = true);
 
@@ -281,7 +281,7 @@ public:
     const bool IsOpen() const;
 
     /**
-     * Return SQLite3 preapre statement object
+     * Return SQLite3 prepare statement object
      * @param sql sql
      * @return wxSQLite3ResultSet object
      */
@@ -384,7 +384,7 @@ public:
     virtual void GetTagsByNameAndParent(const wxString& name, const wxString& parent, std::vector<TagEntryPtr>& tags);
 
     /**
-     * @brief reutnr array of tags by kind and path
+     * @brief return array of tags by kind and path
      * @param kinds array of kind
      * @param path
      * @param tags  [output]

--- a/CodeLite/language.cpp
+++ b/CodeLite/language.cpp
@@ -247,7 +247,7 @@ wxArrayString Language::DoExtractTemplateDeclarationArgs(TagEntryPtr tag)
     wxString pattern = tag->GetPattern();
     wxString templateString;
 
-    // extract the template declartion list
+    // extract the template declaration list
     CppScanner declScanner;
     declScanner.ReturnWhite(1);
     declScanner.SetText(_C(pattern));

--- a/CodeLite/language.h
+++ b/CodeLite/language.h
@@ -133,7 +133,7 @@ public:
 
     /**
      * @brief insert functionBody into clsname. This function will search for best location
-     * to place the function body. set visibility to 0 for 'pubilc' function, 1 for 'protected' and 2 for private
+     * to place the function body. set visibility to 0 for 'public' function, 1 for 'protected' and 2 for private
      * return true if this function succeeded, false otherwise
      */
     bool InsertFunctionDecl(const wxString& clsname, const wxString& functionDecl, wxString& sourceContent,

--- a/CodeLite/procutils.cpp
+++ b/CodeLite/procutils.cpp
@@ -208,7 +208,7 @@ wxString ProcUtils::GetProcessNameByPid(long pid)
 {
 #ifdef __WXMSW__
     // go over the process modules and get the full path of
-    // the executeable
+    // the executable
     HANDLE hModuleSnap = INVALID_HANDLE_VALUE;
     MODULEENTRY32 me32;
 
@@ -383,7 +383,7 @@ std::vector<ProcessEntry> ProcUtils::GetProcessList()
         entry.name = line.AfterFirst(wxT(' '));
 
         if (entry.pid == 0 && i > 0) {
-            // probably this line belongs to the provious one
+            // probably this line belongs to the previous one
             ProcessEntry e = proclist.back();
             proclist.pop_back();
             e.name << entry.name;
@@ -654,7 +654,7 @@ wxString& ProcUtils::WrapInShell(wxString& cmd)
     }
 #else
     command << "/bin/sh -c '";
-    // escape any single quoutes
+    // escape any single quotes
     cmd.Replace("'", "\\'");
     command << cmd << "'";
 #endif

--- a/CodeLite/procutils.h
+++ b/CodeLite/procutils.h
@@ -104,7 +104,7 @@ public:
 
     /**
      * \brief a safe function that executes 'command' and returns its output. This function
-     * is safed to be called from secondary thread (hence, SafeExecuteCommand)
+     * is safe to be called from secondary thread (hence, SafeExecuteCommand)
      * \param command
      * \param output
      */

--- a/CodeLite/search_thread.cpp
+++ b/CodeLite/search_thread.cpp
@@ -437,7 +437,7 @@ void SearchThread::DoSearchLine(const wxString& line,
                 }
             }
 
-            // Pipe filtes OK?
+            // Pipe filters OK?
             if (!allFiltersOK)
                 return;
 
@@ -521,7 +521,7 @@ void SearchThread::SendEvent(wxEventType type, wxEvtHandler* owner)
         SEND_ST_EVENT();
 
     } else if ((type == wxEVT_SEARCH_THREAD_SEARCHEND) || (type == wxEVT_SEARCH_THREAD_SEARCHCANCELED)) {
-        // search eneded, if we got any matches "buffered" send them before the
+        // search ended, if we got any matches "buffered" send them before the
         // the summary event
         if (m_results.empty() == false) {
             wxCommandEvent evt(wxEVT_SEARCH_THREAD_MATCHFOUND, GetId());

--- a/CodeLite/search_thread.h
+++ b/CodeLite/search_thread.h
@@ -249,7 +249,7 @@ public:
         }
     }
 
-    // return a foramtted message
+    // return a formatted message
     wxString GetMessage() const
     {
         wxString msg;
@@ -395,7 +395,7 @@ private:
 
     /**
      * Do the actual search operation
-     * \param data inpunt contains information about the search
+     * \param data input contains information about the search
      */
     void DoSearchFiles(ThreadRequest* data);
 

--- a/CodeLite/ssh/clSSHChannel.hpp
+++ b/CodeLite/ssh/clSSHChannel.hpp
@@ -122,7 +122,7 @@ public:
     void Cleanup() override { Close(); }
 
     // Terminate the process. It is recommended to use this method
-    // so it will invoke the 'Cleaup' procedure and the process
+    // so it will invoke the 'Cleanup' procedure and the process
     // termination event will be sent out
     void Terminate() override { Close(); }
 

--- a/CodeLite/ssh/clSSHInteractiveChannel.cpp
+++ b/CodeLite/ssh/clSSHInteractiveChannel.cpp
@@ -187,7 +187,7 @@ clSSHInteractiveChannel::Ptr_t clSSHInteractiveChannel::Create(wxEvtHandler* par
 
     // remote servers might often return some prompt messages
     // in order to filter these messages out, we send a echo
-    // command and wait for the reponse
+    // command and wait for the response
     std::string message;
     message.append("echo ").append(START_MARKER).append("\n");
     process->Write(message);

--- a/CodeLite/ssh/clSSHInteractiveChannel.hpp
+++ b/CodeLite/ssh/clSSHInteractiveChannel.hpp
@@ -84,7 +84,7 @@ public:
     virtual void Cleanup();
 
     /// Terminate the process. It is recommended to use this method
-    /// so it will invoke the 'Cleaup' procedure and the process
+    /// so it will invoke the 'Cleanup' procedure and the process
     /// termination event will be sent out
     virtual void Terminate();
 

--- a/CodeLite/ssh/cl_sftp.h
+++ b/CodeLite/ssh/cl_sftp.h
@@ -156,7 +156,7 @@ public:
     void Mkpath(const wxString& remoteDirFullpath);
 
     /**
-     * @brief Remove a directoy.
+     * @brief Remove a directory.
      * @param dirname
      */
     void RemoveDir(const wxString& dirname);

--- a/CodeLite/tokenizer.h
+++ b/CodeLite/tokenizer.h
@@ -50,14 +50,14 @@
  * StringTokenizer also allows you to break string with number of delimiters:
  *
  * \code
- * wxArrayString dlimArr;
+ * wxArrayString delimArr;
  * delimArr.Add("_T(" "));
  * delimArr.Add("_T("-"));
  * delimArr.Add("_T(":"));
  * StringTokenizer tok(_T("first-second:third"), delimArr);
  * \endcode 
  * 
- * The above exmple will result with: first, second and third.
+ * The above example will result with: first, second and third.
  *
  * \ingroup CodeLite
  * \version 1.0
@@ -112,7 +112,7 @@ public:
 	 */
 	const int Count() const;
 	/**
-	 * Random acess operator, statring from zero
+	 * Random access operator, starting from zero
 	 * \param nIndex token index
 	 * \return token at nIndex (copy of it)
 	 */

--- a/CodeLite/tree.h
+++ b/CodeLite/tree.h
@@ -87,8 +87,8 @@ public:
 	 * Compare this tree against another tree.
 	 * \param targetTree Target tree to compare with
 	 * \param deletedItems Array of pairs of items which exist in this tree and not in target tree
-	 * \param modifiedItems Array of pairs of items which have the same key but differnt data
-	 * \param newItems Aarray of pairs of items which exist in the target tree but not in this tree
+	 * \param modifiedItems Array of pairs of items which have the same key but different data
+	 * \param newItems Array of pairs of items which exist in the target tree but not in this tree
 	 * \param fromNode If its set to null, comparison will start from this tree root node, if not null,
 	 * comparison will compare sub-tree which root of its fromNode
 	 */

--- a/CxxParser/cpp_scope_grammar.y
+++ b/CxxParser/cpp_scope_grammar.y
@@ -40,7 +40,7 @@ extern bool setLexerInput(const std::string &in, const std::map<std::string, std
 extern int cl_scope_lineno;
 extern std::vector<std::string> currentScope;
 extern void printScopeName();	//print the current scope name
-extern void increaseScope();	//increase scope with anonymouse value
+extern void increaseScope();	//increase scope with anonymous value
 extern std::string getCurrentScope();
 extern void cl_scope_lex_clean();
 extern void cl_scope_less(int count);
@@ -234,7 +234,7 @@ namespace_decl	:	stmnt_starter LE_NAMESPACE nested_scope_specifier LE_IDENTIFIER
                         }
                     |	stmnt_starter LE_NAMESPACE '{'
                         {
-                            //anonymouse namespace
+                            //anonymous namespace
                             increaseScope();
                             
                         }

--- a/DatabaseExplorer/databaseexplorer.cpp
+++ b/DatabaseExplorer/databaseexplorer.cpp
@@ -118,7 +118,7 @@ DatabaseExplorer::DatabaseExplorer(IManager* manager)
     m_mgr->BookAddPage(PaneId::SIDE_BAR, m_dbViewerPanel, _("DbExplorer"), "dbexplorer-button");
     m_mgr->AddWorkspaceTab(_("DbExplorer"));
 
-    // configure autolayout algorithns
+    // configure autolayout algorithms
     wxSFAutoLayout layout;
 
     wxSFLayoutHorizontalTree* pHTreeAlg =
@@ -207,7 +207,7 @@ void DatabaseExplorer::OnOpenWithDBE(clCommandEvent& e)
     e.Skip();
     if (FileExtManager::IsFileType(e.GetFileName(), FileExtManager::TypeDatabase)) {
         e.Skip(false);
-        // Open the databse file
+        // Open the database file
         DoOpenFile(e.GetFileName());
     }
 }

--- a/Debugger/debuggergdb.cpp
+++ b/Debugger/debuggergdb.cpp
@@ -405,7 +405,7 @@ void DbgGdb::DoCleanup()
     m_bpList.clear();
     m_debuggeeProjectName.Clear();
 
-    // Clear any bufferd output
+    // Clear any buffer output
     m_gdbOutputIncompleteLine.Clear();
 
     // Free allocated console for this session
@@ -465,7 +465,7 @@ void DbgGdb::SetBreakpoints()
 {
     for(size_t i = 0; i < m_bpList.size(); i++) {
         // Without the 'unnecessary' cast in the next line, bpinfo.bp_type is seen as (e.g.) 4 instead of
-        // BP_type_tempbreak, ruining switch statments :/
+        // BP_type_tempbreak, ruining switch statements :/
         clDebuggerBreakpoint bpinfo = (clDebuggerBreakpoint)m_bpList.at(i);
         Break(bpinfo);
     }
@@ -496,7 +496,7 @@ bool DbgGdb::Break(const clDebuggerBreakpoint& bp)
         command = "-break-watch ";
         switch(bp.watchpoint_type) {
         case WP_watch:
-            // nothing to add, simple watchpoint - trigrred when BP is write
+            // nothing to add, simple watchpoint - triggered when BP is write
             break;
         case WP_rwatch:
             // read watchpoint
@@ -620,7 +620,7 @@ bool DbgGdb::SetCommands(const clDebuggerBreakpoint& bp)
     if(bp.debugger_id == -1) { // Sanity check
         return false;
     }
-    // There isn't (currentl) a MI command-list command, so use the CLI one
+    // There isn't (currently) a MI command-list command, so use the CLI one
     // This doesn't actually work either, but at least the commands are visible in -break-list
     wxString command("commands ");
     command << bp.debugger_id << '\n' << bp.commandlist << "\nend";
@@ -1535,7 +1535,7 @@ void DbgGdb::OnKillGDB(wxCommandEvent& e)
 
 bool DbgGdb::Disassemble(const wxString& filename, int lineNumber)
 {
-    // Trigger a "disasseble" call
+    // Trigger a "disassemble" call
     if(/*filename.IsEmpty() || lineNumber == wxNOT_FOUND*/ true) {
         // Use the $pc
         if(!WriteCommand("-data-disassemble -s \"$pc -100\" -e \"$pc + 100\" -- 0",

--- a/Debugger/debuggergdb.h
+++ b/Debugger/debuggergdb.h
@@ -86,7 +86,7 @@ protected:
     bool DoGetNextLine(wxString& line);
     void DoCleanup();
 
-    // wrapper for convinience
+    // wrapper for convenience
     void DoProcessAsyncCommand(wxString& line, wxString& id);
 
 protected:

--- a/Docker/clDockerWorkspace.h
+++ b/Docker/clDockerWorkspace.h
@@ -83,7 +83,7 @@ public:
     void Close();
 
     /**
-     * @brief do we have worksapce opened?
+     * @brief do we have workspace opened?
      */
     bool IsOpen() const;
 

--- a/Interfaces/IWorkspace.h
+++ b/Interfaces/IWorkspace.h
@@ -111,7 +111,7 @@ public:
      */
     virtual void GetWorkspaceFiles(wxArrayString& files) const = 0;
     /**
-     * @brief return list of files belonged to the prokect. If the workspace does not support
+     * @brief return list of files belonged to the project. If the workspace does not support
      * projects, do not modify 'files'
      * @param projectName the project name
      * @param files [output] list of files in absolute path
@@ -140,7 +140,7 @@ public:
     virtual wxArrayString GetWorkspaceProjects() const = 0;
 
     /**
-     * @brief returm true if this workspace is a remote one
+     * @brief return true if this workspace is a remote one
      */
     virtual bool IsRemote() const { return false; }
     /**

--- a/Interfaces/debugger.h
+++ b/Interfaces/debugger.h
@@ -393,7 +393,7 @@ public:
     /**
      * \brief Run the program under the debugger. This method must be called *after* Start() has been called
      * \param args arguments to pass to the debuggee process
-     * \param comm the preferemd communication string, if this string is not empty, the debugger assumes remote
+     * \param comm the preferred communication string, if this string is not empty, the debugger assumes remote
      * debugging is on
      * and will execute a different set of commands for connecting to the debuggee.
      * comm is in the format of HOST:PORT or tty for serial debugging - this feature is currently enabled in GDB only
@@ -474,7 +474,7 @@ public:
      */
     virtual bool Break(const clDebuggerBreakpoint& bp) = 0;
     /**
-     * @brief restart the debuggin session. (similar to 'run' command on GDB)
+     * @brief restart the debugging session. (similar to 'run' command on GDB)
      * @return true on success false otherwise
      */
     virtual bool Restart() = 0;
@@ -578,7 +578,7 @@ public:
      */
     virtual bool ResolveType(const wxString& expression, int userReason) = 0;
 
-    // We provide two ways of evulating an expressions:
+    // We provide two ways of evaluating an expression:
     // The short one, which returns a string, and long one
     // which returns a tree of the result
     virtual bool EvaluateExpressionToString(const wxString& expression, const wxString& format) = 0;
@@ -613,7 +613,7 @@ public:
     // ----------------------------------------------------------------------------------------
     // Variable object manipulation (GDB only)
     // If you wish to implement a debugger other than
-    // GDB, implement all the 'Variable Object' releated method
+    // GDB, implement all the 'Variable Object' related method
     // with an empty implementation
     // ----------------------------------------------------------------------------------------
     /**
@@ -625,7 +625,7 @@ public:
     /**
      * @brief create variable object from a given expression
      * @param expression the expression to create a variable object for
-     * @param persistent make a presistent watch, else create a floating watch which is not bound to the creation frame
+     * @param persistent make a persistent watch, else create a floating watch which is not bound to the creation frame
      */
     virtual bool CreateVariableObject(const wxString& expression, bool persistent, int userReason) = 0;
 

--- a/Interfaces/debuggerobserver.h
+++ b/Interfaces/debuggerobserver.h
@@ -57,7 +57,7 @@ enum DebuggerReasons {
 enum DebuggerUpdateReason {
     DBG_UR_INVALID = -1,            // Invalid
     DBG_UR_GOT_CONTROL,             // Application gains the control back from the debugger
-    DBG_UR_LOST_CONTROL,            // Appliecation lost control to the debugge, and it can not interact (atm) with it
+    DBG_UR_LOST_CONTROL,            // Application lost control to the debugger, and it can not interact (atm) with it
     DBG_UR_ADD_LINE,                // Log line
     DBG_UR_BP_ADDED,                // Breakpoint was added
     DBG_UR_STOPPED,                 // Debugger stopped
@@ -137,7 +137,7 @@ public:
     virtual void DebuggerUpdate(const DebuggerEventData& event) = 0;
 
 public:
-    // For convinience
+    // For convenience
     /**
      * @brief this function is called when the debugger plugin got the control back from the debugger
      * @param reason the reason why the debugger gave the control to the plugin.
@@ -225,7 +225,7 @@ public:
     }
 
     /**
-     * @brief an expression has been evaludated
+     * @brief an expression has been evaluated
      * @param expression the expression that the debugger was requested to evaluate
      * @param evaluated evaluated expression as string
      */
@@ -239,7 +239,7 @@ public:
     }
 
     /**
-     * @brief debugger connected to the remote target sucessfully
+     * @brief debugger connected to the remote target successfully
      * @param line debugger output
      */
     void UpdateRemoteTargetConnected(const wxString& line)

--- a/Interfaces/iconfigtool.h
+++ b/Interfaces/iconfigtool.h
@@ -51,7 +51,7 @@ public:
     /**
      * @brief read an object from the configuration file and place it into obj
      * @param name the name of the object that is stored in the configuration file
-     * @param obj a pointer previsouly allocated SerializedObject
+     * @param obj a pointer previously allocated SerializedObject
      * @return true if the object exist and was read successfully from the configuration file
      */
     virtual bool ReadObject(const wxString& name, SerializedObject* obj) = 0;

--- a/Interfaces/imanager.h
+++ b/Interfaces/imanager.h
@@ -70,7 +70,7 @@ using MainNotebook = clGenericNotebook;
 #endif
 
 //--------------------------
-// Auxulary class
+// Auxilary class
 //--------------------------
 
 class TreeItemInfo
@@ -152,7 +152,7 @@ public:
     /// Return the plugins' toolbar managed by CodeLite
     virtual clToolBarGeneric* GetToolBar() = 0;
 
-    /// Return applicaion menu bar
+    /// Return application menu bar
     virtual wxMenuBar* GetMenuBar() = 0;
 
     /**
@@ -408,7 +408,7 @@ public:
     virtual int GetToolbarIconSize() = 0;
 
     /**
-     * @brief return true if toobars are allowed for plugins. This is useful for the Mac port of
+     * @brief return true if toolbars are allowed for plugins. This is useful for the Mac port of
      * codelite. On Mac, only single toolbar is allowed in the application (otherwise, the application
      * does not feet into the environment)
      * @return true if plugin can create a toolbar, false otherwise
@@ -515,7 +515,7 @@ public:
     virtual bool IsShutdownInProgress() const = 0;
 
     /**
-     * return true if the last buid ended successfully
+     * return true if the last build ended successfully
      */
     virtual bool IsBuildEndedSuccessfully() const = 0;
 
@@ -557,7 +557,7 @@ public:
     /**
      * @brief close 'editor' from the notebook
      * @param editor editor to close
-     * @param prompt if set to 'true' prompt if editor is modified, otherwise, close withotu prompting
+     * @param prompt if set to 'true' prompt if editor is modified, otherwise, close without prompting
      */
     virtual bool CloseEditor(IEditor* editor, bool prompt = true) = 0;
 
@@ -591,7 +591,7 @@ public:
     virtual wxString GetPageTitle(wxWindow* win) const = 0;
 
     /**
-     * @brief open new editor "untitiled"
+     * @brief open new editor "untitled"
      * @return pointer to the editor
      */
     virtual IEditor* NewEditor() = 0;

--- a/Interfaces/plugin_version.h
+++ b/Interfaces/plugin_version.h
@@ -26,7 +26,7 @@
 #ifndef PLUGIN_VERSION_H
 #define PLUGIN_VERSION_H
 
-// Interface version is calcualted as follows: MAJOR * 1000 + MINOR * 100, e.g. codelite 4.1 => 4100, codelite 5.0 =>
+// Interface version is calculated as follows: MAJOR * 1000 + MINOR * 100, e.g. codelite 4.1 => 4100, codelite 5.0 =>
 // 5000
 #define PLUGIN_INTERFACE_VERSION 16000 // CodeLite 16
 

--- a/LanguageServer/LanguageServerCluster.cpp
+++ b/LanguageServer/LanguageServerCluster.cpp
@@ -1169,7 +1169,7 @@ void LanguageServerCluster::UpdateNavigationBar()
     scopes.reserve(symbols.size());
 
     for (const LSP::SymbolInformation& symbol : symbols) {
-        // only collect methdos
+        // only collect methods
         if (symbol.GetKind() != LSP::kSK_Function && symbol.GetKind() != LSP::kSK_Method &&
             symbol.GetKind() != LSP::kSK_Constructor)
             continue;

--- a/LiteEditor/DebuggerDisassemblyTab.cpp
+++ b/LiteEditor/DebuggerDisassemblyTab.cpp
@@ -246,7 +246,7 @@ void DebuggerDisassemblyTab::OnRefreshView(clCommandEvent& e)
     e.Skip();
     IDebugger* debugger = DebuggerMgr::Get().GetActiveDebugger();
     if(debugger && debugger->IsRunning() && ManagerST::Get()->DbgCanInteract()) {
-        // Only update disass view if the view is visible
+        // Only update disassemble view if the view is visible
         if(ManagerST::Get()->IsDebuggerViewVisible(wxGetTranslation(DebuggerPane::DISASSEMBLY))) {
             debugger->ListRegisters();
             debugger->Disassemble("", -1);

--- a/LiteEditor/app.cpp
+++ b/LiteEditor/app.cpp
@@ -313,7 +313,7 @@ bool CodeLiteApp::OnInit()
     CodeLiteBlockSigChild();
 
 #ifdef __WXGTK__
-    // Insall signal handlers
+    // Install signal handlers
     signal(SIGSEGV, WaitForDebugger);
     signal(SIGABRT, WaitForDebugger);
 #endif
@@ -330,7 +330,7 @@ bool CodeLiteApp::OnInit()
     wxLog::SetActiveTarget(new wxLogStderr());
 
 #if wxUSE_ON_FATAL_EXCEPTION
-    // trun on fatal exceptions handler
+    // turn on fatal exceptions handler
     wxHandleFatalExceptions(true);
 #endif
 
@@ -630,7 +630,7 @@ bool CodeLiteApp::OnInit()
     wxString strVersion = CODELITE_VERSION_STRING;
     cfg->Init(strVersion, wxT("2.0.2"));
     if (!cfg->Load()) {
-        clERROR() << "Failed to load configuration file: config/codelite.xml. Workding directory:" << wxGetCwd()
+        clERROR() << "Failed to load configuration file: config/codelite.xml. Working directory:" << wxGetCwd()
                   << endl;
         return false;
     }
@@ -715,7 +715,7 @@ bool CodeLiteApp::OnInit()
             // However I couldn't find a way to do this
         }
     } else {
-        // For proper encoding handling by system libraries it's needed to inialize locale even if UI translation is
+        // For proper encoding handling by system libraries it's needed to initialize locale even if UI translation is
         // turned off
         m_locale.Init(wxLANGUAGE_ENGLISH, wxLOCALE_DONT_LOAD_DEFAULT);
     }
@@ -909,7 +909,7 @@ void CodeLiteApp::MSWReadRegistry()
         registry.Read(wxT("mingw"), strMingw);
         registry.Read(wxT("unittestpp"), strUnitTestPP);
 
-        // Supprot for wxWidgets
+        // Support for wxWidgets
         if (strWx.IsEmpty() == false) {
             // we have WX installed on this machine, set the path of WXWIN & WXCFG to point to it
             EnvMap envs = vars.GetVariables(wxT("Default"), false, wxEmptyString, wxEmptyString);

--- a/LiteEditor/manager.cpp
+++ b/LiteEditor/manager.cpp
@@ -3032,7 +3032,7 @@ void Manager::DoRestartCodeLite([[maybe_unused]] bool force)
 #endif
 
     restartCodeLiteCommand << clStandardPaths::Get().GetExecutablePath();
-    // Restore the original working dir and any paramters
+    // Restore the original working dir and any parameters
     for (int i = 1; i < wxTheApp->argc; ++i) {
         wxString cmdArg = wxTheApp->argv[i];
         ::WrapWithQuotes(cmdArg);

--- a/LiteEditor/manager.h
+++ b/LiteEditor/manager.h
@@ -175,7 +175,7 @@ public:
 
     /**
      * @brief close the currently opened workspace and reload it without saving any modifications made to it, if no
-     * workspace is opened, this functiond does anything
+     * workspace is opened, this function does anything
      */
     void ReloadWorkspace();
 
@@ -204,7 +204,7 @@ public:
 
     /**
      * @brief update the C++ parser search / exclude paths with the global paths
-     * and the workspace specifc ones
+     * and the workspace specific ones
      * @return true if the paths were modified, false otherwise
      */
     void UpdateParserPaths(bool notify);
@@ -315,7 +315,7 @@ public:
     void RetagFile(const wxString& filename);
 
     /**
-     * @brief Launch the ParseThread to update the preprocessor vizualisation
+     * @brief Launch the ParseThread to update the preprocessor visualization
      * @param filename
      */
     void UpdatePreprocessorFile(clEditor* editor);
@@ -436,7 +436,7 @@ public:
     void SetProjectGlobalSettings(const wxString& projectName, BuildConfigCommonPtr settings);
 
     /**
-     * @brief return the project excution command as it appears in the project settings
+     * @brief return the project execution command as it appears in the project settings
      * @param projectName
      * @param wd the working directory that the command should be running from
      * @param considerPauseWhenExecuting when set to true (default) CodeLite will take into consideration the value set
@@ -493,7 +493,7 @@ public:
     void ShowPane(const wxString& paneName, bool commit = true);
 
     /**
-     * Hide/Show all panes. This function saves the current prespective and
+     * Hide/Show all panes. This function saves the current perspective and
      * then hides all panes, when called again, all panes are restored
      */
     void TogglePanes();
@@ -569,7 +569,7 @@ public:
     DbgStackInfo DbgGetCurrentFrameInfo() { return m_dbgCurrentFrameInfo; }
 
     //---------------------------------------------------
-    // Internal implementaion for various debugger events
+    // Internal implementation for various debugger events
     //---------------------------------------------------
 
     void UpdateAddLine(const wxString& line, const bool OnlyIfLoggingOn = false);
@@ -624,7 +624,7 @@ public:
     void CleanWorkspace();
 
     /**
-     * @brief clean, followed by buid of the entire workspace. This operation is equal to
+     * @brief clean, followed by build of the entire workspace. This operation is equal to
      * manually right clicking on each project in the workspace and selecting
      * 'clean'
      */
@@ -643,7 +643,7 @@ public:
     void CompileFile(const wxString& project, const wxString& fileName, bool preprocessOnly = false);
 
     /**
-     * return true if the last buid ended successfully
+     * return true if the last build ended successfully
      */
     bool IsBuildEndedSuccessfully() const;
 
@@ -655,7 +655,7 @@ public:
     void GetActiveProjectAndConf(wxString& project, wxString& conf);
     /**
      * @brief return true if debugger view is visible
-     * This can be true incase the view is the selected tab in the debuggger pane notebook
+     * This can be true incase the view is the selected tab in the debugger pane notebook
      * or incase it is detached and visible
      */
     bool IsDebuggerViewVisible(const wxString& name);

--- a/Plugin/CodeLiteRemoteHelper.hpp
+++ b/Plugin/CodeLiteRemoteHelper.hpp
@@ -37,7 +37,7 @@ public:
     JSON* GetPluginConfig(const wxString& plugin_name) const;
 
     /**
-     * @brief return true if a remote workspce is loaded
+     * @brief return true if a remote workspace is loaded
      */
     bool IsRemoteWorkspaceOpened() const;
 

--- a/Plugin/CompilerLocator/CompilerLocatorMSYS2.cpp
+++ b/Plugin/CompilerLocator/CompilerLocatorMSYS2.cpp
@@ -59,7 +59,7 @@ bool CompilerLocatorMSYS2Env::Locate()
 
     wxArrayString paths_to_try = ::wxStringTokenize(path_env, ";", wxTOKEN_STRTOK);
     for (const auto& path : paths_to_try) {
-        clDEBUG() << "Tyring to locate compiler at:" << path << endl;
+        clDEBUG() << "Trying to locate compiler at:" << path << endl;
         auto cmp = CompilerLocatorMSYS2::Locate(path);
         if (cmp) {
             clDEBUG() << "Found compiler:" << cmp->GetName() << endl;

--- a/Plugin/Debugger/debuggermanager.h
+++ b/Plugin/Debugger/debuggermanager.h
@@ -42,7 +42,7 @@ class EnvironmentConfig;
 // sent when a "QueryLocals" command is completed (only for locals - not for function arguments)
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_SDK, wxEVT_DEBUGGER_QUERY_LOCALS, clCommandEvent);
 
-// sent when a variable object createion is completed
+// sent when a variable object creation is completed
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_SDK, wxEVT_DEBUGGER_VAROBJECT_CREATED, clCommandEvent);
 
 // sent by codelite when a pane is needed to refresh its content
@@ -51,13 +51,13 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_SDK, wxEVT_DEBUGGER_UPDATE_VIEWS, clCommand
 // sent by the debugger when a "ListChildren" command is completed
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_SDK, wxEVT_DEBUGGER_LIST_CHILDREN, clCommandEvent);
 
-// sent by the debugger after a successfull evaluation of variable object
+// sent by the debugger after a successful evaluation of variable object
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_SDK, wxEVT_DEBUGGER_VAROBJ_EVALUATED, clCommandEvent);
 
-// sent by the debugger when a "disasseble" command returned
+// sent by the debugger when a "disassemble" command returned
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_SDK, wxEVT_DEBUGGER_DISASSEBLE_OUTPUT, clCommandEvent);
 
-// sent by the debugger when a "disasseble" current line command returns
+// sent by the debugger when a "disassemble" current line command returns
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_SDK, wxEVT_DEBUGGER_DISASSEBLE_CURLINE, clCommandEvent);
 
 // sent by the debugger when a "QueryFileLine" command has completed
@@ -103,7 +103,7 @@ public:
     const wxString& GetActiveDebuggerName() const { return m_activeDebuggerName; }
     /**
      * Load all available debuggers. This functions searches for dll/so/sl
-     * which are located udner $(HOME)/.liteeditor/debuggers/ on Linux, and on Windows
+     * which are located under $(HOME)/.liteeditor/debuggers/ on Linux, and on Windows
      * under C:\Program Files\LiteEditor\debuggers\
      */
     bool LoadDebuggers(IDebuggerObserver* observer);

--- a/Plugin/clCodeLiteRemoteProcess.cpp
+++ b/Plugin/clCodeLiteRemoteProcess.cpp
@@ -110,7 +110,7 @@ public:
     void Cleanup() override {}
 
     // Terminate the process. It is recommended to use this method
-    // so it will invoke the 'Cleaup' procedure and the process
+    // so it will invoke the 'Cleanup' procedure and the process
     // termination event will be sent out
     void Terminate() override {}
 

--- a/Plugin/clCodeLiteRemoteProcess.hpp
+++ b/Plugin/clCodeLiteRemoteProcess.hpp
@@ -186,7 +186,7 @@ public:
                               const wxString& working_directory,
                               const clEnvList_t& env);
     /**
-     * @brief call 'exec' and return an instance of IProcess. This method is for compatability with the
+     * @brief call 'exec' and return an instance of IProcess. This method is for compatibility with the
      * CreateAsyncProcess family of functions
      * @note it is up to the caller to delete the return process object
      */

--- a/Plugin/clControlWithItems.cpp
+++ b/Plugin/clControlWithItems.cpp
@@ -96,7 +96,7 @@ public:
         e.SetEventObject(GetParent());
         m_searchedCtrl->GetEventHandler()->AddPendingEvent(e);
 
-        // remove ourself from the paren't sizer
+        // remove ourself from the parent's sizer
         GetParent()->GetSizer()->Detach(this);
         GetParent()->GetSizer()->Layout();
 
@@ -532,7 +532,7 @@ clHeaderBar* clControlWithItems::GetHeader() const { return m_viewHeader; }
 void clControlWithItems::DoPositionVScrollbar()
 {
     if (IsHeaderVisible()) {
-        // When the heaer is visible place the vertical scrollbar under it
+        // When the header is visible place the vertical scrollbar under it
         wxRect clientRect = GetClientRect();
         wxSize vsbSize = GetVScrollBar()->GetSize();
 

--- a/Plugin/clControlWithItems.h
+++ b/Plugin/clControlWithItems.h
@@ -180,7 +180,7 @@ public:
 
     /**
      * @brief sets a column width. If the width is less than 0, this function does nothing. If the column is out of
-     * bound this function does nothing. Two sepcial values are allowed here: wxCOL_WIDTH_DEFAULT and
+     * bound this function does nothing. Two special values are allowed here: wxCOL_WIDTH_DEFAULT and
      * wxCOL_WIDTH_AUTOSIZE
      * @param col the column index
      * @param width the width. Can contain one of the special values: wxCOL_WIDTH_DEFAULT and wxCOL_WIDTH_AUTOSIZE
@@ -192,13 +192,13 @@ public:
      */
     void SetShowHeader(bool b);
     /**
-     * @brief is the heaer bar visible?
+     * @brief is the header bar visible?
      */
     bool IsHeaderVisible() const;
 
     /**
      * @brief update the scrollbar with the current view status
-     * subclass should call this method whenver the view changes (re-sized, items are expanding, collapsing etc)
+     * subclass should call this method whenever the view changes (re-sized, items are expanding, collapsing etc)
      */
     virtual void UpdateScrollBar();
 
@@ -220,7 +220,7 @@ public:
     virtual bool IsEmpty() const = 0;
     /**
      * @brief return the total of numbers of items we can scroll
-     * If the view has collpased items, the range _excludes_ them
+     * If the view has collapsed items, the range _excludes_ them
      */
     virtual int GetRange() const = 0;
 

--- a/Plugin/clDataViewListCtrl.h
+++ b/Plugin/clDataViewListCtrl.h
@@ -92,7 +92,7 @@ public:
                             size_t searchFlags = wxDV_SEARCH_DEFAULT);
 
     /**
-     * @brief highlight matched string of an item. This call should be called after a successfull call to
+     * @brief highlight matched string of an item. This call should be called after a successful call to
      * FindNext or FindPrev
      */
     void HighlightText(const wxDataViewItem& item, bool b);
@@ -103,7 +103,7 @@ public:
     void ClearHighlight(const wxDataViewItem& item);
 
     ///===--------------------
-    /// wxDV compatilibty API
+    /// wxDV compatibility API
     ///===--------------------
 
     /**

--- a/Plugin/clScrolledPanel.h
+++ b/Plugin/clScrolledPanel.h
@@ -86,7 +86,7 @@ public:
 
     /**
      * @brief when enabled, the scrollbar will only be shown (if needed at all) when this window has the focus (or any
-     * of its decendants)
+     * of its descendants)
      */
     void SetShowScrollBarOnFocus(bool b) { m_showSBOnFocus = b; }
 
@@ -101,14 +101,14 @@ public:
     wxRect GetClientArea() const;
 
     /**
-     * @brief whenver the view changes (i.e. there is a new top line) call this method so the scrollbar
+     * @brief whenever the view changes (i.e. there is a new top line) call this method so the scrollbar
      * will adjust its position
      */
     void UpdateVScrollBar(int position, int thumbSize, int rangeSize, int pageSize);
     void UpdateHScrollBar(int position, int thumbSize, int rangeSize, int pageSize);
 
     //===----------------------------------------------------
-    // Overridables
+    // Overridable
     //===----------------------------------------------------
 
     /**
@@ -146,7 +146,7 @@ public:
     virtual void ScrollToColumn(int firstColumn) { wxUnusedVar(firstColumn); }
 
     /**
-     * @brief called by the scrolled window whenver a key is down
+     * @brief called by the scrolled window whenever a key is down
      * return true if the key was processed and we should stop the processing of this event
      */
     virtual bool DoKeyDown(const wxKeyEvent& event)

--- a/Plugin/clTabRenderer.h
+++ b/Plugin/clTabRenderer.h
@@ -67,10 +67,10 @@ enum NotebookStyle {
     /// Allow DnD between different book controls
     kNotebook_AllowForeignDnD = (1 << 10),
 
-    /// We keep this flag for backward compatability
+    /// We keep this flag for backward compatibility
     kNotebook_RightTabs = 0,
 
-    /// We keep this flag for backward compatability
+    /// We keep this flag for backward compatibility
     kNotebook_LeftTabs = 0,
 
     /// Fixed width tabs
@@ -245,7 +245,7 @@ public:
     virtual void FinaliseBackground(wxWindow* parent, wxDC& dc, const wxRect& clientRect, const wxRect& activeTabRect,
                                     const clTabColours& colours, size_t style);
     /**
-     * @brief reutrn font suitable for drawing the tab label
+     * @brief return font suitable for drawing the tab label
      */
     static wxFont GetTabFont(bool bold);
 
@@ -256,7 +256,7 @@ public:
                            eButtonState state);
 
     /**
-     * @brief draw cheveron button
+     * @brief draw chevron button
      */
     static void DrawChevron(wxWindow* win, wxDC& dc, const wxRect& rect, const clTabColours& colours);
 
@@ -274,7 +274,7 @@ public:
      */
     static clTabRenderer::Ptr_t CreateRenderer(const wxWindow* win, size_t tabStyle);
     /**
-     * @brief return list of availale renderers
+     * @brief return list of available renderers
      */
     static wxArrayString GetRenderers();
 

--- a/Plugin/clTreeCtrl.h
+++ b/Plugin/clTreeCtrl.h
@@ -127,7 +127,7 @@ public:
                           size_t searchFlags = wxTR_SEARCH_DEFAULT);
 
     /**
-     * @brief highlight matched string of an item. This call should be called after a successfull call to
+     * @brief highlight matched string of an item. This call should be called after a successful call to
      * FindNext or FindPrev
      */
     void HighlightText(const wxTreeItemId& item, bool b);
@@ -219,7 +219,7 @@ public:
     wxTreeItemId HitTest(const wxPoint& point, int& flags, int& column) const;
 
     /**
-     * @brief ppends an item to the end of the branch identified by parent, return a new item id.
+     * @brief Appends an item to the end of the branch identified by parent, return a new item id.
      */
     wxTreeItemId AppendItem(const wxTreeItemId& parent, const wxString& text, int image = -1, int selImage = -1,
                             wxTreeItemData* data = NULL);

--- a/Plugin/clTreeCtrlModel.h
+++ b/Plugin/clTreeCtrlModel.h
@@ -89,7 +89,7 @@ public:
     void AddSelection(const wxTreeItemId& item);
 
     /**
-     * @brief clear all selections, return true on sucess, this function fires the changing event
+     * @brief clear all selections, return true on success, this function fires the changing event
      */
     bool ClearSelections(bool notify);
 
@@ -99,7 +99,7 @@ public:
     bool IsVisible(const wxTreeItemId& item) const;
 
     /**
-     * @brief select the children of 'item' this functin fires the changing and changed events
+     * @brief select the children of 'item' this function fires the changing and changed events
      */
     void SelectChildren(const wxTreeItemId& item);
 

--- a/Plugin/editor_config.h
+++ b/Plugin/editor_config.h
@@ -208,14 +208,14 @@ public:
     void SetInstallDir(const wxString& instlDir);
 
     /**
-     * \brief convinience methods to store a single long value
+     * \brief convenience methods to store a single long value
      * \param name variable name
      * \param value value to store
      */
     void SetInteger(const wxString& name, long value);
 
     /**
-     * \brief convinience methods to retrieve a single long value stored using
+     * \brief convenience methods to retrieve a single long value stored using
      * the 'SaveLongValue()' method
      * \param name variable name
      * \param value value
@@ -225,7 +225,7 @@ public:
 
     /**
      * \brief get string from the configuration identified by key
-     * \param key key identifiying the string
+     * \param key key identifying the string
      * \return wxEmptyString or the value
      */
     wxString GetString(const wxString& key, const wxString& defaultValue = "");

--- a/Plugin/globals.cpp
+++ b/Plugin/globals.cpp
@@ -710,7 +710,7 @@ void WrapInShell(wxString& cmd)
     cmd = command;
 #else
     command << "/bin/sh -c '";
-    // escape any single quoutes
+    // escape any single quotes
     cmd.Replace("'", "\\'");
     command << cmd << "'";
     cmd = command;

--- a/Plugin/globals.h
+++ b/Plugin/globals.h
@@ -161,7 +161,7 @@ WXDLLIMPEXP_SDK wxString ExpandVariables(const wxString& expression, ProjectPtr 
 
 /**
  * * [DEPRECATED] DONT USE THIS METHOD ANYMORE - USE IMacroManager
- * \brief accepts expression string and expand all known marcos (e.g. $(ProjectName))
+ * \brief accepts expression string and expand all known macros (e.g. $(ProjectName))
  * \param expression expression
  * \param projectName project name (to be used for $(ProjectName) macro)
  * \param fileName file name, to help expand the $(CurrentFile) macro family
@@ -172,7 +172,7 @@ WXDLLIMPEXP_SDK wxString ExpandAllVariables(const wxString& expression, clCxxWor
                                             const wxString& fileName);
 
 /**
- * \brief copy entire directory content (recursievly) from source to target
+ * \brief copy entire directory content (recursively) from source to target
  * \param src source path
  * \param target target path
  * \return true on success, false otherwise
@@ -186,7 +186,7 @@ WXDLLIMPEXP_SDK bool CopyDir(const wxString& src, const wxString& target);
 WXDLLIMPEXP_SDK void Mkdir(const wxString& path);
 
 /**
- * \brief write file content with optinal backup
+ * \brief write file content with optional backup
  * \param file_name
  * \param content
  * \param backup
@@ -257,7 +257,7 @@ WXDLLIMPEXP_SDK void MSWSetNativeTheme(wxWindow* win, const wxString& theme = "E
 
 /**
  * @brief under Windows 10 and later, enable dark mode controls (where it is implemented)
- * based on the selected editor theme. This is dont recursievly on win
+ * based on the selected editor theme. This is dont recursively on win
  */
 WXDLLIMPEXP_SDK void MSWSetWindowDarkTheme(wxWindow* win);
 
@@ -368,7 +368,7 @@ WXDLLIMPEXP_SDK wxVariant MakeBitmapIndexText(const wxString& text, int imgIndex
 WXDLLIMPEXP_SDK wxVariant MakeCheckboxVariant(const wxString& label, bool checked, int imgIndex);
 
 /**
- * @brief split lines (using CR|LF as the separator), taking into considertaion line continuation
+ * @brief split lines (using CR|LF as the separator), taking into consideration line continuation
  * @param trim trim the lines with set to true
  */
 WXDLLIMPEXP_SDK wxArrayString SplitString(const wxString& inString, bool trim = true);
@@ -472,7 +472,7 @@ WXDLLIMPEXP_SDK std::pair<wxString, wxString> clRemoteFileSelector(const wxStrin
                                                                    const wxString& filter = wxEmptyString,
                                                                    wxWindow* parent = NULL);
 /**
- * @brief return the instance to the plugin manager. A convinience method
+ * @brief return the instance to the plugin manager. A convenience method
  */
 WXDLLIMPEXP_SDK IManager* clGetManager();
 /**
@@ -507,7 +507,7 @@ WXDLLIMPEXP_SDK int clGetScaledSize(int size);
 WXDLLIMPEXP_SDK int clGetSize(int size, const wxWindow* win);
 
 /**
- * @param signo singal number
+ * @param signo signal number
  * @brief send signo to the
  * @param processID the process ID to kill
  * @param kill_whole_group kill the process group
@@ -552,7 +552,7 @@ WXDLLIMPEXP_SDK void clFitColumnWidth(wxDataViewCtrl* ctrl);
 WXDLLIMPEXP_SDK wxSize clGetDisplaySize();
 
 /**
- * @brief returna top level window best size using its parent's size as reference
+ * @brief return a top level window best size using its parent's size as reference
  */
 WXDLLIMPEXP_SDK void clSetTLWindowBestSizeAndPosition(wxWindow* win);
 

--- a/Plugin/project.h
+++ b/Plugin/project.h
@@ -186,7 +186,7 @@ public:
     void SetFlags(size_t flags) { this->m_flags = flags; }
     size_t GetFlags() const { return m_flags; }
     /**
-     * @brief return true if this file should be execluded from the build of a specific configuration
+     * @brief return true if this file should be excluded from the build of a specific configuration
      */
     bool IsExcludeFromConfiguration(const wxString& config) const { return m_excludeConfigs.count(config); }
     void Rename(Project* project, const wxString& newName);
@@ -259,7 +259,7 @@ public:
     bool IsFolderExists(Project* project, const wxString& name) const;
 
     /**
-     * @brief reutrn child folder. Can be nullptr
+     * @brief return child folder. Can be nullptr
      */
     clProjectFolder::Ptr_t GetChild(Project* project, const wxString& name) const;
 
@@ -392,18 +392,18 @@ public:
     void ClearIncludePathCache();
 
     /**
-     * @brief a project was renamed - update our dependeices if needed
+     * @brief a project was renamed - update our dependencies if needed
      */
     void ProjectRenamed(const wxString& oldname, const wxString& newname);
     void SetIconPath(const wxString& iconPath) { this->m_iconPath = iconPath; }
     const wxString& GetIconPath() const { return m_iconPath; }
     /**
-     * @brief return set of compilers used by this project for the active build configuraion
+     * @brief return set of compilers used by this project for the active build configuration
      */
     void GetCompilers(wxStringSet_t& compilers);
 
     /**
-     * @brief replace compilers by name. compilers contains a map of the "olbd" compiler
+     * @brief replace compilers by name. compilers contains a map of the "old" compiler
      * name and the new compiler name
      */
     void ReplaceCompilers(const wxStringMap_t& compilers);
@@ -811,7 +811,7 @@ class WXDLLIMPEXP_SDK ProjectData
 {
 public:
     wxString m_name;           //< project name
-    wxString m_path;           //< project directoy
+    wxString m_path;           //< project directory
     ProjectPtr m_srcProject;   //< source project
     wxString m_cmpType;        //< Project compiler type
     wxString m_debuggerType;   //< Selected debugger

--- a/Plugin/workspace.h
+++ b/Plugin/workspace.h
@@ -220,7 +220,7 @@ public:
      * Open an existing workspace
      *
      * \param fileName
-     * Workspace file name (including extesion)
+     * Workspace file name (including extension)
      *
      * \returns
      * true on success false otherwise
@@ -259,12 +259,12 @@ public:
     /**
      * @brief rename a project
      * @param oldname current name
-     * @param newname new name for the proejct
+     * @param newname new name for the project
      */
     void RenameProject(const wxString& oldname, const wxString& newname);
 
     /**
-     * \brief get a string property from the worksapce file
+     * \brief get a string property from the workspace file
      * \returns property value or wxEmptyString
      */
     wxString GetStringProperty(const wxString& propName, wxString& errMsg);
@@ -314,7 +314,7 @@ public:
     void SetActiveProject(const wxString& name);
 
     /**
-     * Add new virtual directoy to workspace
+     * Add new virtual directory to workspace
      * \param vdFullPath virtual directory full path
      * \param errMsg [output] incase an error, report the error to the caller
      * \return true on success false otherwise
@@ -327,7 +327,7 @@ public:
     bool IsVirtualDirectoryExists(const wxString& vdFullPath);
 
     /**
-     * Remove virtual directoy to workspace
+     * Remove virtual directory to workspace
      * \param vdFullPath virtual directory full path
      * \param errMsg [output] incase an error, report the error to the caller
      * \return true on success false otherwise
@@ -336,7 +336,7 @@ public:
 
     /**
      * Add new file to project. The project name is taken from the virtual directory full path
-     * \param vdFullPath vritual directory full path including project
+     * \param vdFullPath virtual directory full path including project
      * \param fileName file name to add
      * \param errMsg output
      * \return true on success, false otherwise
@@ -345,7 +345,7 @@ public:
 
     /**
      * Remove file from a project. The project name is taken from the virtual directory full path
-     * \param vdFullPath vritual directory full path including project
+     * \param vdFullPath virtual directory full path including project
      * \param fileName file name to remove
      * \param errMsg output
      * \return true on success, false otherwise
@@ -474,12 +474,12 @@ public:
     wxArrayString GetWorkspaceProjects() const override;
 
     /**
-     * @brief return list of files that are exluded for a given workspace configuration
+     * @brief return list of files that are excluded for a given workspace configuration
      */
     size_t GetExcludeFilesForConfig(std::vector<wxString>& files, const wxString& workspaceConfigName = "");
 
     /**
-     * @brief return the workspce environment
+     * @brief return the workspace environment
      */
     clEnvList_t GetEnvironment() const override;
 

--- a/Plugin/wxCustomStatusBar.cpp
+++ b/Plugin/wxCustomStatusBar.cpp
@@ -417,7 +417,7 @@ void wxCustomStatusBar::Finalize()
 void wxCustomStatusBar::SetText(const wxString& message, int secondsToLive)
 {
     if(message.empty()) {
-        // passing an empty string suggets that we want to clear the text field completely
+        // passing an empty string suggests that we want to clear the text field completely
         ClearText();
         return;
     }

--- a/WebTools/XMLCodeCompletion.h
+++ b/WebTools/XMLCodeCompletion.h
@@ -69,7 +69,7 @@ protected:
     void PrepareHtmlCompletions();
     wxString GetCompletePattern(const wxString& tag) const;
     /**
-     * @brief Does 'tag' has a sepcial insert pattern?
+     * @brief Does 'tag' has a special insert pattern?
      * an example is the <a>: "<a href=""></a>"
      */
     bool HasSpecialInsertPattern(const wxString& tag) const;

--- a/WordCompletion/WordCompletionDictionary.cpp
+++ b/WordCompletion/WordCompletionDictionary.cpp
@@ -99,7 +99,7 @@ void WordCompletionDictionary::DoCacheActiveEditor(bool overwrite)
     // Queue this file
     wxStyledTextCtrl* stc = activeEditor->GetCtrl();
     
-    // Invoke the thread to parse and suggets words for this file
+    // Invoke the thread to parse and suggest words for this file
     WordCompletionThreadRequest* req = new WordCompletionThreadRequest;
     req->buffer = stc->GetText();
     req->filename = activeEditor->GetFileName();

--- a/WordCompletion/wordcompletion.cpp
+++ b/WordCompletion/wordcompletion.cpp
@@ -91,7 +91,7 @@ void WordCompletionPlugin::OnWordComplete(clCodeCompletionEvent& event)
         return;
     }
 
-    // Build the suggetsion list
+    // Build the suggestion list
     static wxBitmap sBmp = wxNullBitmap;
     if(!sBmp.IsOk()) {
         sBmp = m_mgr->GetStdIcons()->LoadBitmap("word");
@@ -106,7 +106,7 @@ void WordCompletionPlugin::OnWordComplete(clCodeCompletionEvent& event)
     wxString filter = event.GetWord().Lower(); // stc->GetTextRange(start, curPos);
 
     wxStringSet_t words = m_dictionary->GetWords();
-    // Parse the current bufer (if modified), to include non saved words
+    // Parse the current buffer (if modified), to include non saved words
     if(activeEditor->IsEditorModified()) {
         // For performance (this parsing is done in the main thread)
         // only parse the visible area of the document

--- a/codelite_echo/main.c
+++ b/codelite_echo/main.c
@@ -15,7 +15,7 @@ int main(int argc, char** argv)
     int i = 1;
     for(; i < argc; ++i) {
         if(strstr(argv[i], " ") || strstr(argv[i], "\t")) {
-            // escape with double quoutes
+            // escape with double quotes
             fprintf(stdout, "\"%s\" ", argv[i]);
         } else {
             // print it as it is

--- a/codelitephp/PHPParser/php_code_completion.cpp
+++ b/codelitephp/PHPParser/php_code_completion.cpp
@@ -269,14 +269,14 @@ void PHPCodeCompletion::OnCodeComplete(clCodeCompletionEvent& e)
                 bool isExprStartsWithOpenTag = expr->IsExprStartsWithOpenTag();
                 PHPEntityBase::Ptr_t entity = expr->Resolve(m_lookupTable, editor->GetFileName().GetFullPath());
                 if(entity) {
-                    // Suggets members for the resolved entity
+                    // Suggest members for the resolved entity
                     PHPEntityBase::List_t matches;
                     expr->Suggest(entity, m_lookupTable, matches);
                     if(!expr->GetFilter().IsEmpty() && (expr->GetCount() == 0)) {
                         // Word completion
                         PHPEntityBase::List_t keywords = PhpKeywords(expr->GetFilter());
 
-                        // Preprend the keywords
+                        // Prepend the keywords
                         matches.insert(matches.end(), keywords.begin(), keywords.end());
 
                         // Did user typed "<?ph" or "<?php" ??
@@ -768,7 +768,7 @@ int PHPCodeCompletion::GetLocationForSettersGetters(const wxString& filecontent,
     int depth = 0;
     int line = wxNOT_FOUND;
 
-    // searc for the open brace
+    // search for the open brace
     while(::phpLexerNext(scanner, token)) {
         if(token.type == '{') {
             ++depth;
@@ -909,7 +909,7 @@ void PHPCodeCompletion::OnActiveEditorChanged(wxCommandEvent& e)
             continue;
         }
 
-        // preapre a display string, exclude the function signature (it takes too much space)
+        // prepare a display string, exclude the function signature (it takes too much space)
         clEditorBar::ScopeEntry scope_entry;
         scope_entry.line_number = entity->GetLine();
         scope_entry.display_string = entity->GetFullName();

--- a/codelitephp/PHPParserUnitTests/main.cpp
+++ b/codelitephp/PHPParserUnitTests/main.cpp
@@ -706,7 +706,7 @@ TEST_FUNC(test_constants)
     sourceFile.Parse();
     lookup.UpdateSourceFile(sourceFile);
 
-    // Use this epxression and check
+    // Use this expression and check
     PHPExpression expr(sourceFile.GetText());
     PHPEntityBase::Ptr_t resolved = expr.Resolve(lookup, sourceFile.GetFilename().GetFullPath());
     CHECK_BOOL(resolved);
@@ -728,7 +728,7 @@ TEST_FUNC(test_phpdoc_var_in_class)
     sourceFile.Parse();
     lookup.UpdateSourceFile(sourceFile);
 
-    // Use this epxression and check
+    // Use this expression and check
     PHPExpression expr(sourceFile.GetText());
     PHPEntityBase::Ptr_t resolved = expr.Resolve(lookup, sourceFile.GetFilename().GetFullPath());
     CHECK_BOOL(resolved);
@@ -750,7 +750,7 @@ TEST_FUNC(test_phpdoc_property)
     sourceFile.Parse();
     lookup.UpdateSourceFile(sourceFile);
 
-    // Use this epxression and check
+    // Use this expression and check
     PHPExpression expr(sourceFile.GetText());
     PHPEntityBase::Ptr_t resolved = expr.Resolve(lookup, sourceFile.GetFilename().GetFullPath());
     CHECK_BOOL(resolved);
@@ -771,7 +771,7 @@ TEST_FUNC(test_phpdoc_method)
     sourceFile.Parse();
     lookup.UpdateSourceFile(sourceFile);
 
-    // Use this epxression and check
+    // Use this expression and check
     PHPExpression expr(sourceFile.GetText());
     PHPEntityBase::Ptr_t resolved = expr.Resolve(lookup, sourceFile.GetFilename().GetFullPath());
     CHECK_BOOL(resolved);
@@ -792,7 +792,7 @@ TEST_FUNC(test_function_phpdoc)
     sourceFile.Parse();
     lookup.UpdateSourceFile(sourceFile);
 
-    // Use this epxression and check
+    // Use this expression and check
     PHPExpression expr(sourceFile.GetText());
     PHPEntityBase::Ptr_t resolved = expr.Resolve(lookup, sourceFile.GetFilename().GetFullPath());
     CHECK_BOOL(resolved);

--- a/docs/docs/plugins/snipwiz.md
+++ b/docs/docs/plugins/snipwiz.md
@@ -38,10 +38,10 @@ You might change the menu entry from: `wxT("` to `wxT("$")` and the code from: `
 Now if you highlight the word `foo` in the editor, and select `wxT("$")` from the context menu, you should now see `wxT("foo")`
 
 If you press the ++ctrl++ key while clicking on the snippet menu, the snippet is not inserted at the current caret position, 
-but instead is copied to the clipboard and also to an internal buffer. You can do the insertion elsewhere, perhaps repeatdly, by pasting in the usual way (e.g. ++ctrl+v++), 
+but instead is copied to the clipboard and also to an internal buffer. You can do the insertion elsewhere, perhaps repeatedly, by pasting in the usual way (e.g. ++ctrl+v++),
 or from that buffer (via the context menu). Note however that the original text selection is retained: selecting `wxT("$")` from the 
 context menu while ++ctrl++ is being pressed and foo selected will copy `wxT("foo")` to the clipboard; 
-and so multiple pastes will insert multiple `wxT("foo")`s, irrespective of what is subsequently hightlit. 
+and so multiple pastes will insert multiple `wxT("foo")`s, irrespective of what is subsequently highlight.
 
 !!! TIP
     If you have a multi-line snippet, you should paste from the internal buffer, since this will retain the correct indentation. 
@@ -101,7 +101,7 @@ You should now have a dialog with the following content:
 - Switch to the `Generate` tab
 - Under the `Class` section select the template (in our case `MyDialog`)
 - Give a name to your class (this will replace the `%CLASS%` place holder)
-- Under the Files section, set the file name (header and implementation), path and (optinally) a project tree folder
+- Under the Files section, set the file name (header and implementation), path and (optionally) a project tree folder
 - Click `Generate`
 
 You should now have 2 new files generated: header and implementation files with the class definition

--- a/formbuilder/comment_panel.fbp
+++ b/formbuilder/comment_panel.fbp
@@ -886,7 +886,7 @@
                         <property name="font" />
                         <property name="hidden">0</property>
                         <property name="id">wxID_ANY</property>
-                        <property name="label">The following macros are available:&#x0A;$(CurrentFileName), $(CurrentFilePath), $(User), $(Date), $(Name)&#x0A;$(CurrentFileFullPath), $(CurrentFileExt), $(ProjectName), $(WorksapceName)</property>
+                        <property name="label">The following macros are available:&#x0A;$(CurrentFileName), $(CurrentFilePath), $(User), $(Date), $(Name)&#x0A;$(CurrentFileFullPath), $(CurrentFileExt), $(ProjectName), $(WorkspaceName)</property>
                         <property name="maximum_size" />
                         <property name="minimum_size" />
                         <property name="name">m_staticText12</property>

--- a/git/git.cpp
+++ b/git/git.cpp
@@ -146,7 +146,7 @@ public:
     void Cleanup() override {}
 
     // Terminate the process. It is recommended to use this method
-    // so it will invoke the 'Cleaup' procedure and the process
+    // so it will invoke the 'Cleanup' procedure and the process
     // termination event will be sent out
     void Terminate() override {}
 

--- a/sdk/databaselayer/CMakeLists.txt
+++ b/sdk/databaselayer/CMakeLists.txt
@@ -65,7 +65,7 @@ if(WITH_MYSQL)
     endif(UNIX AND NOT APPLE)
 
 else()
-    message(STATUS "MySQL is execluded from build")
+    message(STATUS "MySQL is excluded from build")
 endif()
 
 # Define the output

--- a/wxcrafter/controls/wizard_page_wrapper.cpp
+++ b/wxcrafter/controls/wizard_page_wrapper.cpp
@@ -39,7 +39,7 @@ wxString WizardPageWrapper::CppCtorCode() const
     if(!wizard) { return code; }
 
     // If this is the last page, perform the 'Chain' call
-    // We use |@@| as a sepcial delimiter here (to avoid indenting this code)
+    // We use |@@| as a special delimiter here (to avoid indenting this code)
     // it will be replaced later by the TopLevelWindowWrapper to an empty string
     const wxcWidget::List_t& siblings = wizard->GetChildren();
     const wxcWidget* lastChild = siblings.back();

--- a/wxcrafter/src/winid_property.cpp
+++ b/wxcrafter/src/winid_property.cpp
@@ -143,7 +143,7 @@ JSONElement WinIdProperty::Serialize() const
 void WinIdProperty::UnSerialize(const JSONElement& json)
 {
     DoBaseUnSerialize(json);
-    // Backward compatability
+    // Backward compatibility
     if(json.hasNamedObject(wxT("m_winid")))
         m_winid = json.namedObject(wxT("m_winid")).toString();
     else


### PR DESCRIPTION
I split previous PR (https://github.com/eranif/codelite/pull/3579) which mixes English typo which just change comment/variable name (moved here) and the one which impacts build