### PR TITLE
[CI] Use `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to bypass compatibility error

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         mkdir wx-config-msys2/build-release
         cd wx-config-msys2/build-release
-        cmake .. -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$HOME/root"
+        cmake .. -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$HOME/root" -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         mingw32-make -j$(nproc) install
         #add $HOME/root/bin to PATH
 
@@ -87,7 +87,7 @@ jobs:
       run: |
         mkdir build-release
         cd build-release
-        MSYS2_BASE=/d/a/_temp/msys64 PATH="$HOME/root/bin:$PATH" cmake .. -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DWXWIN="$HOME/root" -Wno-dev -DBUILD_TESTING=0
+        MSYS2_BASE=/d/a/_temp/msys64 PATH="$HOME/root/bin:$PATH" cmake .. -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DWXWIN="$HOME/root" -Wno-dev -DBUILD_TESTING=0 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         PATH="$HOME/root/bin:$PATH" mingw32-make -j$(nproc) install
         PATH="$HOME/root/bin:$PATH" mingw32-make -j$(nproc) setup
     #    ctest --output-on-failure # Missing dll near test executables

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         mkdir build-release
         cd build-release
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DWITH_MYSQL=1 -DWITH_POSTGRES=1 -DWITH_CHATAI=1 -DCOPY_WX_LIBS=1 -DBUILD_TESTING=1
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DWITH_MYSQL=1 -DWITH_POSTGRES=1 -DWITH_CHATAI=1 -DCOPY_WX_LIBS=1 -DBUILD_TESTING=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         make -j$(nproc)
         sudo make install
         ctest --output-on-failure


### PR DESCRIPTION
Workaround for CMake 4.0+