### PR TITLE
[cleanup] Fix clang warning: missing `override`

### DIFF
--- a/AutoSave/autosave.h
+++ b/AutoSave/autosave.h
@@ -42,21 +42,21 @@ protected:
     
 public:
     AutoSave(IManager* manager);
-    ~AutoSave();
+    ~AutoSave() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
 };
 
 #endif // AutoSave

--- a/CMakePlugin/CMakePlugin.h
+++ b/CMakePlugin/CMakePlugin.h
@@ -120,7 +120,7 @@ public:
     /**
      * @brief Destructor.
      */
-    virtual ~CMakePlugin();
+    ~CMakePlugin() override;
 
     // Public Accessors
 public:
@@ -171,19 +171,19 @@ public:
      *
      * @return Codelite tool bar or NULL.
      */
-    void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
 
     /**
      * @brief Creates a menu for plugin.
      *
      * @param pluginsMenu
      */
-    void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug plugin.
      */
-    void UnPlug();
+    void UnPlug() override;
 
     // Public Events
 public:

--- a/CallGraph/callgraph.h
+++ b/CallGraph/callgraph.h
@@ -61,7 +61,7 @@ public:
     /**
      * @brief Default destructor.
      */
-    ~CallGraph();
+    ~CallGraph() override;
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
@@ -70,19 +70,19 @@ public:
      * @param parent
      * @return
      */
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Function create plugin menu for Call graph used in menu Plugins of Codelite.
      * @param pluginsMenu
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Function unplug the plugin from CodeLite IDE.
      */
-    virtual void UnPlug();
+    void UnPlug() override;
 
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
 
     /**
      * @brief Return string with value path for external application gprof which is stored in configuration data.

--- a/ChatAI/ChatAI.hpp
+++ b/ChatAI/ChatAI.hpp
@@ -32,11 +32,11 @@ class ChatAI : public IPlugin
 {
 public:
     ChatAI(IManager* manager);
-    virtual ~ChatAI();
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    ~ChatAI() override;
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
     ChatAIConfig& GetConfig() { return m_cli.GetConfig(); }
     bool IsRunning() const { return m_cli.IsRunning(); }
 

--- a/CodeFormatter/codeformatter.h
+++ b/CodeFormatter/codeformatter.h
@@ -64,11 +64,11 @@ public:
     void OnContextMenu(clContextMenuEvent& event);
 
     CodeFormatter(IManager* manager);
-    virtual ~CodeFormatter();
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    ~CodeFormatter() override;
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 
     IManager* GetManager();
     // event handlers

--- a/CodeLiteDiff/codelitediff.h
+++ b/CodeLiteDiff/codelitediff.h
@@ -44,14 +44,14 @@ protected:
 
 public:
     CodeLiteDiff(IManager* manager);
-    ~CodeLiteDiff();
+    ~CodeLiteDiff() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void UnPlug() override;
 };
 
 #endif // CodeLiteDiff

--- a/ContinuousBuild/continuousbuild.h
+++ b/ContinuousBuild/continuousbuild.h
@@ -50,15 +50,15 @@ public:
 
 public:
     ContinuousBuild(IManager* manager);
-    ~ContinuousBuild();
+    ~ContinuousBuild() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 
     void StopAll();
 

--- a/Copyright/copyright.h
+++ b/Copyright/copyright.h
@@ -40,14 +40,14 @@ protected:
 
 public:
     Copyright(IManager* manager);
-    ~Copyright();
+    ~Copyright() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void UnPlug() override;
 
     // event handlers
     void OnOptions(wxCommandEvent& e);

--- a/DatabaseExplorer/databaseexplorer.h
+++ b/DatabaseExplorer/databaseexplorer.h
@@ -34,15 +34,15 @@ class DatabaseExplorer : public IPlugin
 {
 public:
     DatabaseExplorer(IManager* manager);
-    ~DatabaseExplorer();
+    ~DatabaseExplorer() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 
     static IManager* GetManager();
     static DbViewerPanel* GetViewerPanel() { return m_dbViewerPanel; }

--- a/DebugAdapterClient/DebugAdapterClient.hpp
+++ b/DebugAdapterClient/DebugAdapterClient.hpp
@@ -148,7 +148,7 @@ private:
 
 public:
     DebugAdapterClient(IManager* manager);
-    ~DebugAdapterClient();
+    ~DebugAdapterClient() override;
 
     IManager* GetManager() { return m_mgr; }
 

--- a/Docker/docker.h
+++ b/Docker/docker.h
@@ -14,21 +14,21 @@ class Docker : public IPlugin
 
 public:
     Docker(IManager* manager);
-    virtual ~Docker();
+    ~Docker() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
 
     DockerOutputPane* GetTerminal() { return m_outputView; }
     clDockerDriver::Ptr_t GetDriver() { return m_driver; }

--- a/EOSWiki/eoswiki.h
+++ b/EOSWiki/eoswiki.h
@@ -21,21 +21,21 @@ protected:
 
 public:
     EOSWiki(IManager* manager);
-    virtual ~EOSWiki();
+    ~EOSWiki() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
 };
 
 #endif // EOSWiki

--- a/EditorConfigPlugin/editorconfigplugin.h
+++ b/EditorConfigPlugin/editorconfigplugin.h
@@ -18,21 +18,21 @@ protected:
 
 public:
     EditorConfigPlugin(IManager* manager);
-    ~EditorConfigPlugin();
+    ~EditorConfigPlugin() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
 
     void OnEditorConfigLoading(clEditorConfigEvent& event);
     void OnActiveEditorChanged(wxCommandEvent& event);

--- a/ExternalTools/externaltools.h
+++ b/ExternalTools/externaltools.h
@@ -49,15 +49,15 @@ protected:
 
 public:
     ExternalToolsPlugin(IManager* manager);
-    ~ExternalToolsPlugin();
+    ~ExternalToolsPlugin() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 };
 
 #endif // ExternalTools

--- a/Gizmos/gizmos.h
+++ b/Gizmos/gizmos.h
@@ -43,15 +43,15 @@ protected:
 
 public:
     WizardsPlugin(IManager* manager);
-    ~WizardsPlugin();
+    ~WizardsPlugin() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 
     void DoCreateNewPlugin();
     void DoCreateNewClass();

--- a/HelpPlugin/helpplugin.h
+++ b/HelpPlugin/helpplugin.h
@@ -41,21 +41,21 @@ protected:
     
 public:
     HelpPlugin(IManager* manager);
-    ~HelpPlugin();
+    ~HelpPlugin() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
 };
 
 #endif // HelpPlugin

--- a/Interfaces/debugger.h
+++ b/Interfaces/debugger.h
@@ -178,7 +178,7 @@ public:
     DebuggerInformation() = default;
     ~DebuggerInformation() override = default;
 
-    void Serialize(Archive& arch)
+    void Serialize(Archive& arch) override
     {
         arch.Write("name", name);
         arch.Write("path", path);
@@ -206,7 +206,7 @@ public:
         arch.Write("cygwinPathCommand", cygwinPathCommand);
     }
 
-    void DeSerialize(Archive& arch)
+    void DeSerialize(Archive& arch) override
     {
         READ_CONFIG_PARAM("name", name);
         READ_CONFIG_PARAM("path", path);

--- a/LanguageServer/languageserver.h
+++ b/LanguageServer/languageserver.h
@@ -51,16 +51,16 @@ public:
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
 
     /**
      * @brief log message to the output tab

--- a/MacBundler/macbundler.h
+++ b/MacBundler/macbundler.h
@@ -38,7 +38,7 @@ class MacBundler : public IPlugin
 
 public:
     MacBundler(IManager* manager);
-    ~MacBundler();
+    ~MacBundler() override;
 
     void onBundleInvoked_active(wxCommandEvent& evt);
     void onBundleInvoked_selected(wxCommandEvent& evt);
@@ -46,10 +46,10 @@ public:
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 };
 
 #endif // MacBundler

--- a/MemCheck/memcheck.h
+++ b/MemCheck/memcheck.h
@@ -47,16 +47,16 @@ class MemCheckPlugin : public IPlugin
 {
 public:
     MemCheckPlugin(IManager* manager);
-    virtual ~MemCheckPlugin();
+    ~MemCheckPlugin() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
 
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 
     MemCheckSettings* const GetSettings() { return m_settings; };
 

--- a/Outline/outline.h
+++ b/Outline/outline.h
@@ -51,7 +51,7 @@ public:
     // Constructors/Destructors
     //--------------------------------------------
     SymbolViewPlugin(IManager* manager);
-    ~SymbolViewPlugin();
+    ~SymbolViewPlugin() override;
 
     //--------------------------------------------
     // Abstract methods

--- a/PHPLint/phplint.h
+++ b/PHPLint/phplint.h
@@ -56,21 +56,21 @@ protected:
 
 public:
     PHPLint(IManager* manager);
-    ~PHPLint();
+    ~PHPLint() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
 
     void OnCheck(wxCommandEvent& e);
     void OnLintingDone(const wxString& lintOutput);

--- a/PHPRefactoring/phprefactoring.h
+++ b/PHPRefactoring/phprefactoring.h
@@ -32,21 +32,22 @@ private:
 
 public:
     PHPRefactoring(IManager* manager);
-    ~PHPRefactoring();
+    ~PHPRefactoring() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
+
     void OnEditorContextMenu(clContextMenuEvent& event);
     void OnExtractMethod(wxCommandEvent& e);
     void OnRenameLocalVariable(wxCommandEvent& e);

--- a/QmakePlugin/qmakeplugin.h
+++ b/QmakePlugin/qmakeplugin.h
@@ -47,18 +47,17 @@ protected:
 
 public:
     QMakePlugin(IManager* manager);
-    ~QMakePlugin();
+    ~QMakePlugin() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void HookProjectSettingsTab(wxBookCtrlBase* book, const wxString& projectName, const wxString& configName);
-    virtual void UnHookProjectSettingsTab(wxBookCtrlBase* book, const wxString& projectName,
-                                          const wxString& configName);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void HookProjectSettingsTab(wxBookCtrlBase* book, const wxString& projectName, const wxString& configName) override;
+    void UnHookProjectSettingsTab(wxBookCtrlBase* book, const wxString& projectName, const wxString& configName) override;
+    void UnPlug() override;
 
     // event handlers
     void OnSaveConfig(clProjectSettingsEvent& event);

--- a/Remoty/RemotyPlugin.hpp
+++ b/Remoty/RemotyPlugin.hpp
@@ -39,7 +39,7 @@ class RemotyPlugin : public IPlugin
 
 public:
     RemotyPlugin(IManager* manager);
-    virtual ~RemotyPlugin();
+    ~RemotyPlugin() override;
 
 protected:
     void OnFolderContextMenu(clContextMenuEvent& event);
@@ -51,10 +51,10 @@ public:
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
     IManager* GetManager() { return m_mgr; }
 };
 

--- a/Rust/RustPlugin.hpp
+++ b/Rust/RustPlugin.hpp
@@ -43,7 +43,7 @@ class RustPlugin : public IPlugin
 
 public:
     RustPlugin(IManager* manager);
-    virtual ~RustPlugin();
+    ~RustPlugin() override;
 
 protected:
     void OnFolderContextMenu(clContextMenuEvent& event);
@@ -62,10 +62,10 @@ public:
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
     IManager* GetManager() { return m_mgr; }
 };
 

--- a/SFTP/sftp.h
+++ b/SFTP/sftp.h
@@ -52,7 +52,7 @@ class SFTP : public IPlugin
 
 public:
     SFTP(IManager* manager);
-    ~SFTP();
+    ~SFTP() override;
 
     void FileDownloadedSuccessfully(const SFTPClientData& cd);
     void OpenWithDefaultApp(const wxString& localFileName);
@@ -111,10 +111,10 @@ public:
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
     IManager* GetManager() { return m_mgr; }
 
     // Callbacks

--- a/SmartCompletion/smartcompletion.h
+++ b/SmartCompletion/smartcompletion.h
@@ -25,21 +25,21 @@ protected:
 
 public:
     SmartCompletion(IManager* manager);
-    ~SmartCompletion();
+    ~SmartCompletion() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
 };
 
 #endif // SmartCompletion

--- a/SnipWiz/snipwiz.h
+++ b/SnipWiz/snipwiz.h
@@ -52,15 +52,15 @@ public:
     swStringDb* GetStringDb() { return &m_StringDb; }
     wxMenu* CreateSubMenu();
     SnipWiz(IManager* manager);
-    ~SnipWiz();
+    ~SnipWiz() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 
     // event handler
     void OnEditorContextMenu(clContextMenuEvent& event);

--- a/SpellChecker/spellcheck.h
+++ b/SpellChecker/spellcheck.h
@@ -53,14 +53,14 @@ public:
     IEditor* GetEditor();
 
     SpellCheck(IManager* manager);
-    ~SpellCheck();
+    ~SpellCheck() override;
 
     // --------------------------------------------
     // Abstract methods
     // --------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar) override;
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu) override;
-    virtual void UnPlug() override;
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void UnPlug() override;
 
     void OnSettings(wxCommandEvent& e);
     void OnCheck(wxCommandEvent& e);

--- a/Subversion2/subversion2.h
+++ b/Subversion2/subversion2.h
@@ -125,15 +125,15 @@ public:
     
 public:
     Subversion2(IManager* manager);
-    ~Subversion2();
+    ~Subversion2() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 
     SvnConsole* GetConsole();
 

--- a/Tail/tail.h
+++ b/Tail/tail.h
@@ -23,7 +23,7 @@ protected:
     
 public:
     Tail(IManager* manager);
-    ~Tail();
+    ~Tail() override;
     
     /**
      * @brief detach the tail window from the output notebook
@@ -38,16 +38,16 @@ public:
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
     
     TailPanel* GetView() const { return m_view; }
 };

--- a/UnitTestCPP/unittestpp.h
+++ b/UnitTestCPP/unittestpp.h
@@ -47,14 +47,14 @@ class UnitTestPP : public IPlugin
     
 public:
     UnitTestPP(IManager* manager);
-    ~UnitTestPP();
+    ~UnitTestPP() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void UnPlug() override;
     bool IsUnitTestProject(ProjectPtr p);
     /**
      * @brief return list of the projects which are identified as UnitTests project

--- a/WebTools/webtools.h
+++ b/WebTools/webtools.h
@@ -77,14 +77,14 @@ public:
 
 public:
     WebTools(IManager* manager);
-    ~WebTools();
+    ~WebTools() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void UnPlug() override;
 };
 
 #endif // WebTools

--- a/WordCompletion/wordcompletion.h
+++ b/WordCompletion/wordcompletion.h
@@ -61,14 +61,14 @@ public:
 
 public:
     WordCompletionPlugin(IManager* manager);
-    ~WordCompletionPlugin();
+    ~WordCompletionPlugin() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void UnPlug() override;
 };
 
 #endif // WordCompletion

--- a/codelite_vim/codelite_vim.h
+++ b/codelite_vim/codelite_vim.h
@@ -14,24 +14,24 @@ private:
 
 public:
     CodeliteVim(IManager* manager);
-    ~CodeliteVim();
+    ~CodeliteVim() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
     /**
      * @brief Add plugin menu to the "Plugins" menu item in the menu bar
      */
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
 
     /**
      * @brief Unplug the plugin. Perform here any cleanup needed
          * (e.g. unbind events, destroy allocated windows)
      */
-    virtual void UnPlug();
+    void UnPlug() override;
 
-    // virtual int FilterEvent(wxEvent &event);
+    // int FilterEvent(wxEvent &event) override;
 protected:
     void onVimSetting(wxCommandEvent& event);
 };

--- a/codelitephp/php-plugin/php.h
+++ b/codelitephp/php-plugin/php.h
@@ -70,7 +70,7 @@ public:
 
 public:
     PhpPlugin(IManager* manager);
-    ~PhpPlugin();
+    ~PhpPlugin() override;
     void SafelyDetachAndDestroyPane(wxWindow* pane, const wxString& name);
     void EnsureAuiPaneIsVisible(const wxString& paneName, bool update = false);
     void FinalizeStartup();
@@ -86,10 +86,10 @@ public:
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
     void RunXDebugDiagnostics();
 
     IManager* GetManager() { return m_mgr; }

--- a/cppchecker/cppchecker.h
+++ b/cppchecker/cppchecker.h
@@ -58,15 +58,15 @@ protected:
 
 public:
     CppCheckPlugin(IManager* manager);
-    ~CppCheckPlugin();
+    ~CppCheckPlugin() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 
     /**
      * @brief return true if analysis currently running

--- a/cscope/cscope.h
+++ b/cscope/cscope.h
@@ -43,14 +43,14 @@ class Cscope : public IPlugin
 
 public:
     Cscope(IManager* manager);
-    ~Cscope();
+    ~Cscope() override;
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void UnPlug() override;
 
 protected:
     // Helper

--- a/git/git.h
+++ b/git/git.h
@@ -294,7 +294,7 @@ private:
 
 public:
     GitPlugin(IManager* manager);
-    virtual ~GitPlugin();
+    ~GitPlugin() override;
 
     const wxString& GetRepositoryPath() const { return m_repositoryDirectory; }
     void WorkspaceClosed();
@@ -372,10 +372,10 @@ public:
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 };
 
 #endif // git

--- a/wxcrafter/src/wxcrafter_plugin.h
+++ b/wxcrafter/src/wxcrafter_plugin.h
@@ -105,16 +105,16 @@ protected:
 
 public:
     wxCrafterPlugin(IManager* manager, bool serverMode);
-    ~wxCrafterPlugin();
+    ~wxCrafterPlugin() override;
 
     MainFrame* GetMainFrame() const { return m_mainFrame; }
 
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void UnPlug() override;
 
     IManager* GetManager() { return m_mgr; }
     bool IsTabMode() const { return !m_mainFrame; }

--- a/wxformbuilder/wxformbuilder.h
+++ b/wxformbuilder/wxformbuilder.h
@@ -40,7 +40,7 @@ class wxFormBuilder : public IPlugin
 
 public:
     wxFormBuilder(IManager* manager);
-    ~wxFormBuilder();
+    ~wxFormBuilder() override;
 
 protected:
 
@@ -63,10 +63,10 @@ public:
     //--------------------------------------------
     // Abstract methods
     //--------------------------------------------
-    virtual void CreateToolBar(clToolBarGeneric* toolbar);
-    virtual void CreatePluginMenu(wxMenu* pluginsMenu);
-    virtual void HookPopupMenu(wxMenu* menu, MenuType type);
-    virtual void UnPlug();
+    void CreateToolBar(clToolBarGeneric* toolbar) override;
+    void CreatePluginMenu(wxMenu* pluginsMenu) override;
+    void HookPopupMenu(wxMenu* menu, MenuType type) override;
+    void UnPlug() override;
 };
 
 #endif // wxFormBuilder


### PR DESCRIPTION
> 'Serialize' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]