### PR TITLE
[cleanup] Replace call of `AddProperty(new XXXProperty(..));` by `Add<XXXProperty>(..);`

### DIFF
--- a/wxcrafter/aui/aui_manager_wrapper.cpp
+++ b/wxcrafter/aui/aui_manager_wrapper.cpp
@@ -28,27 +28,25 @@ AuiManagerWrapper::AuiManagerWrapper()
     // wxAUI_DOCKART_GRADIENT_TYPE
 
     SetPropertyString(_("Common Settings"), "wxAuiManager");
-    AddProperty(new CategoryProperty(_("General")));
-    AddProperty(new StringProperty(PROP_NAME, "", _("wxAuiManager member name")));
-    AddProperty(new ColorProperty(PROP_BG, "<Default>", _("Background Colour")));
-    AddProperty(new IntProperty(PROP_AUI_PANE_BORDER_SIZE, -1, _("Pane border size")));
+    Add<CategoryProperty>(_("General"));
+    Add<StringProperty>(PROP_NAME, "", _("wxAuiManager member name"));
+    Add<ColorProperty>(PROP_BG, "<Default>", _("Background Colour"));
+    Add<IntProperty>(PROP_AUI_PANE_BORDER_SIZE, -1, _("Pane border size"));
 
-    AddProperty(new CategoryProperty(_("Sash")));
-    AddProperty(new ColorProperty(PROP_AUI_SASH_COLOUR, "<Default>", _("Sash colour")));
-    AddProperty(new IntProperty(PROP_AUI_SASH_SIZE, -1, _("Set the wxAUI sash size")));
+    Add<CategoryProperty>(_("Sash"));
+    Add<ColorProperty>(PROP_AUI_SASH_COLOUR, "<Default>", _("Sash colour"));
+    Add<IntProperty>(PROP_AUI_SASH_SIZE, -1, _("Set the wxAUI sash size"));
 
-    AddProperty(new CategoryProperty(_("Caption")));
+    Add<CategoryProperty>(_("Caption"));
     wxArrayString gradientTypes = StdToWX::ToArrayString({"wxAUI_GRADIENT_NONE", "wxAUI_GRADIENT_VERTICAL", "wxAUI_GRADIENT_HORIZONTAL"});
-    AddProperty(new ChoiceProperty(PROP_AUI_GRADIENT_TYPE, gradientTypes, 0, _("Gradient type")));
+    Add<ChoiceProperty>(PROP_AUI_GRADIENT_TYPE, gradientTypes, 0, _("Gradient type"));
 
-    AddProperty(new ColorProperty(PROP_AUI_CAPTION_COLOUR, "<Default>", _("Active caption colour")));
-    AddProperty(new ColorProperty(PROP_AUI_CAPTION_COLOUR_GRADIENT, "<Default>", _("Active caption gradient colour")));
-    AddProperty(new ColorProperty(PROP_AUI_INACTIVE_CAPTION_COLOUR, "<Default>", _("Inactive caption colour")));
-    AddProperty(new ColorProperty(PROP_AUI_INACTIVE_CAPTION_COLOUR_GRADIENT, "<Default>",
-                                  _("Inactive caption gradient colour")));
-    AddProperty(new ColorProperty(PROP_AUI_ACTIVE_CAPTION_TEXT_COLOUR, "<Default>", _("Active caption text colour")));
-    AddProperty(
-        new ColorProperty(PROP_AUI_INACTIVE_CAPTION_TEXT_COLOUR, "<Default>", _("Inactive caption text colour")));
+    Add<ColorProperty>(PROP_AUI_CAPTION_COLOUR, "<Default>", _("Active caption colour"));
+    Add<ColorProperty>(PROP_AUI_CAPTION_COLOUR_GRADIENT, "<Default>", _("Active caption gradient colour"));
+    Add<ColorProperty>(PROP_AUI_INACTIVE_CAPTION_COLOUR, "<Default>", _("Inactive caption colour"));
+    Add<ColorProperty>(PROP_AUI_INACTIVE_CAPTION_COLOUR_GRADIENT, "<Default>", _("Inactive caption gradient colour"));
+    Add<ColorProperty>(PROP_AUI_ACTIVE_CAPTION_TEXT_COLOUR, "<Default>", _("Active caption text colour"));
+    Add<ColorProperty>(PROP_AUI_INACTIVE_CAPTION_TEXT_COLOUR, "<Default>", _("Inactive caption text colour"));
 
     m_styles.Clear();
 

--- a/wxcrafter/controls/AnimationCtrlWrapper.cpp
+++ b/wxcrafter/controls/AnimationCtrlWrapper.cpp
@@ -16,10 +16,10 @@ AnimationCtrlWrapper::AnimationCtrlWrapper()
 
     SetPropertyString(_("Common Settings"), "wxAnimationCtrl");
 
-    AddBool(PROP_ANIM_AUTO_PLAY, _("Load and play animation on creation"), false);
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", _("Select the animation file")));
-    AddProperty(new BitmapPickerProperty(
-        PROP_DISABLED_BITMAP_PATH, "", _("Sets the bitmap to show on the control when it's not playing an animation")));
+    Add<BoolProperty>(PROP_ANIM_AUTO_PLAY, false, _("Load and play animation on creation"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, "", _("Select the animation file"));
+    Add<BitmapPickerProperty>(
+        PROP_DISABLED_BITMAP_PATH, "", _("Sets the bitmap to show on the control when it's not playing an animation"));
 
     m_namePattern = "m_animationCtrl";
     SetName(GenerateName());

--- a/wxcrafter/controls/BitmapComboxWrapper.cpp
+++ b/wxcrafter/controls/BitmapComboxWrapper.cpp
@@ -11,11 +11,12 @@ BitmapComboxWrapper::BitmapComboxWrapper()
     : wxcWidget(ID_WXBITMAPCOMBOBOX)
 {
     SetPropertyString(_("Common Settings"), "wxBitmapComboBox");
-    AddProperty(new BitmapTextArrayProperty(PROP_CB_CHOICES, "", _("Combobox drop down choices")));
-    AddProperty(new StringProperty(
-        PROP_SELECTION, "-1",
-        _("The zero-based position of any initially selected string, or -1 if none are to be selected")));
-    AddProperty(new StringProperty(PROP_VALUE, "", _("The combobox initial value")));
+    Add<BitmapTextArrayProperty>(PROP_CB_CHOICES, "", _("Combobox drop down choices"));
+    Add<StringProperty>(
+        PROP_SELECTION,
+        "-1",
+        _("The zero-based position of any initially selected string, or -1 if none are to be selected"));
+    Add<StringProperty>(PROP_VALUE, "", _("The combobox initial value"));
 
     RegisterEventCommand("wxEVT_COMMAND_COMBOBOX_SELECTED",
                          _("Process a wxEVT_COMMAND_COMBOBOX_SELECTED event, when an item on the list is selected. "

--- a/wxcrafter/controls/SimpleHtmlListBoxWrapper.cpp
+++ b/wxcrafter/controls/SimpleHtmlListBoxWrapper.cpp
@@ -20,11 +20,12 @@ SimpleHtmlListBoxWrapper::SimpleHtmlListBoxWrapper()
     RegisterEvent("wxEVT_HTML_LINK_CLICKED", "wxHtmlLinkEvent",
                   _("A wxHtmlCell which contains an hyperlink was clicked. See wxHtmlLinkEvent"));
     SetPropertyString(_("Common Settings"), "wxSimpleHtmlListBox");
-    AddProperty(new MultiStringsProperty(
-        PROP_OPTIONS, _("The List Box Items. A semi-colon list of strings. This list may contain HTML fragments")));
-    AddProperty(new StringProperty(
-        PROP_SELECTION, wxT("-1"),
-        _("The zero-based position of any initially selected string, or -1 if none are to be selected")));
+    Add<MultiStringsProperty>(
+        PROP_OPTIONS, _("The List Box Items. A semi-colon list of strings. This list may contain HTML fragments"));
+    Add<StringProperty>(
+        PROP_SELECTION,
+        wxT("-1"),
+        _("The zero-based position of any initially selected string, or -1 if none are to be selected"));
 
     // Basic name pattern
     m_namePattern = "m_htmlListBox";

--- a/wxcrafter/controls/banner_window_wrapper.cpp
+++ b/wxcrafter/controls/banner_window_wrapper.cpp
@@ -17,22 +17,25 @@ BannerWindowWrapper::BannerWindowWrapper()
     const wxArrayString options = StdToWX::ToArrayString({ "wxTOP", "wxBOTTOM", "wxLEFT", "wxRIGHT" });
 
     SetPropertyString(_("Common Settings"), "wxBannerWindow");
-    AddProperty(new MultiStringsProperty(
-        PROP_TITLE, _("The Title\nTitle is rendered in bold and should be single line"), "\\n", ""));
-    AddProperty(new MultiStringsProperty(PROP_MESSAGE,
-                                         _("Message can have multiple lines but is not wrapped automatically\ninclude "
-                                           "explicit line breaks in the string if you want to have multiple lines"),
-                                         "\\n", ""));
-    AddProperty(
-        new ChoiceProperty(PROP_ORIENTATION, options, 2,
-                           _("The banner orientation changes how the text in it is displayed and also defines where is "
-                             "the bitmap truncated if it's too big to fit\nbut doesn't do anything for the banner "
-                             "position, this is supposed to be taken care of in the usual way, e.g. using sizers")));
-    AddProperty(new BitmapPickerProperty(
-        PROP_BITMAP_PATH, "",
-        _("Select the bitmap file\nImportant: You can set text and title OR a bitmap, but not both")));
-    AddProperty(new ColorProperty(PROP_COLOR_GRADIENT_START));
-    AddProperty(new ColorProperty(PROP_COLOR_GRADIENT_END));
+    Add<MultiStringsProperty>(
+        PROP_TITLE, _("The Title\nTitle is rendered in bold and should be single line"), "\\n", "");
+    Add<MultiStringsProperty>(PROP_MESSAGE,
+                              _("Message can have multiple lines but is not wrapped automatically\ninclude "
+                                "explicit line breaks in the string if you want to have multiple lines"),
+                              "\\n",
+                              "");
+    Add<ChoiceProperty>(PROP_ORIENTATION,
+                        options,
+                        2,
+                        _("The banner orientation changes how the text in it is displayed and also defines where is "
+                          "the bitmap truncated if it's too big to fit\nbut doesn't do anything for the banner "
+                          "position, this is supposed to be taken care of in the usual way, e.g. using sizers"));
+    Add<BitmapPickerProperty>(
+        PROP_BITMAP_PATH,
+        "",
+        _("Select the bitmap file\nImportant: You can set text and title OR a bitmap, but not both"));
+    Add<ColorProperty>(PROP_COLOR_GRADIENT_START);
+    Add<ColorProperty>(PROP_COLOR_GRADIENT_END);
 
     SetPropertyString(PROP_TITLE, "Title");
     SetPropertyString(PROP_MESSAGE, "Descriptive message");

--- a/wxcrafter/controls/bitmap_button_wrapper.cpp
+++ b/wxcrafter/controls/bitmap_button_wrapper.cpp
@@ -24,8 +24,8 @@ BitmapButtonWrapper::BitmapButtonWrapper()
 
     m_namePattern = wxT("m_bmpButton");
     SetPropertyString(_("Common Settings"), "wxBitmapButton");
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file")));
-    AddProperty(new BoolProperty(PROP_DEFAULT_BUTTON, false, _("Make this button the default button")));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file"));
+    Add<BoolProperty>(PROP_DEFAULT_BUTTON, false, _("Make this button the default button"));
 
     wxCrafter::ResourceLoader bl;
     m_properties.Item(PROP_BITMAP_PATH)->SetValue(bl.GetPlaceHolder16ImagePath().GetFullPath());

--- a/wxcrafter/controls/bitmap_wrapepr.cpp
+++ b/wxcrafter/controls/bitmap_wrapepr.cpp
@@ -15,12 +15,13 @@ BitmapWrapepr::BitmapWrapepr()
     m_styles.Clear();
     m_sizerFlags.Clear();
 
-    AddProperty(new CategoryProperty(_("wxBitmap")));
-    AddProperty(new StringProperty(
-        PROP_NAME, wxT(""),
+    Add<CategoryProperty>(_("wxBitmap"));
+    Add<StringProperty>(
+        PROP_NAME,
+        wxT(""),
         _("A unique name for the bitmap (across your project)\nThis name can be used later to load the bitmap from the "
-          "generated class\nby simply calling: wxBitmap bmp = myimglist.Bitmap(\"my-bitmap-name\")")));
-    AddProperty(new FilePickerProperty(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file")));
+          "generated class\nby simply calling: wxBitmap bmp = myimglist.Bitmap(\"my-bitmap-name\")"));
+    Add<FilePickerProperty>(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file"));
     m_namePattern = "m_bmp";
     SetName(GenerateName());
 }

--- a/wxcrafter/controls/bitmaptogglebuttonwrapper.cpp
+++ b/wxcrafter/controls/bitmaptogglebuttonwrapper.cpp
@@ -7,8 +7,8 @@ BitmapToggleButtonWrapper::BitmapToggleButtonWrapper()
     : wxcWidget(ID_WXBITMAPTOGGLEBUTTON)
 {
     SetPropertyString(_("Common Settings"), "wxBitmapToggleButton");
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", _("The bitmap")));
-    AddProperty(new BoolProperty(PROP_CHECKED, false, _("The button initial state")));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, "", _("The bitmap"));
+    Add<BoolProperty>(PROP_CHECKED, false, _("The button initial state"));
 
     PREPEND_STYLE(wxBU_BOTTOM, false);
     PREPEND_STYLE(wxBU_EXACTFIT, false);

--- a/wxcrafter/controls/button_wrapper.cpp
+++ b/wxcrafter/controls/button_wrapper.cpp
@@ -33,14 +33,16 @@ ButtonWrapper::ButtonWrapper()
 
     m_namePattern = wxT("m_button");
     SetPropertyString(_("Common Settings"), "wxButton");
-    AddProperty(new StringProperty(PROP_LABEL, _("My Button"), _("The button label")));
-    AddProperty(new BoolProperty(PROP_DEFAULT_BUTTON, false, _("Make this button the default button")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file (wx2.9.X and later)")));
-    AddProperty(new ChoiceProperty(PROP_DIRECTION, directions, 0,
-                                   _("The position of the bitmap inside the button. By default it is positioned to "
-                                     "the left of the text, near to the left button border. ")));
-    AddProperty(new StringProperty(PROP_MARGINS, "2,2",
-                                   _("Sets x/y margins between the bitmap and the button label (wx2.9.X and later)")));
+    Add<StringProperty>(PROP_LABEL, _("My Button"), _("The button label"));
+    Add<BoolProperty>(PROP_DEFAULT_BUTTON, false, _("Make this button the default button"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file (wx2.9.X and later)"));
+    Add<ChoiceProperty>(PROP_DIRECTION,
+                        directions,
+                        0,
+                        _("The position of the bitmap inside the button. By default it is positioned to "
+                          "the left of the text, near to the left button border. "));
+    Add<StringProperty>(
+        PROP_MARGINS, "2,2", _("Sets x/y margins between the bitmap and the button label (wx2.9.X and later)"));
 
     // wxCrafter::ResourceLoader bl;
     // m_properties.Item(PROP_BITMAP_PATH)->SetValue( bl.GetPlaceHolder16ImagePath().GetFullPath() );

--- a/wxcrafter/controls/check_box_wrapper.cpp
+++ b/wxcrafter/controls/check_box_wrapper.cpp
@@ -10,8 +10,8 @@ CheckBoxWrapper::CheckBoxWrapper()
     : wxcWidget(ID_WXCHECKBOX)
 {
     SetPropertyString(_("Common Settings"), "wxCheckBox");
-    AddProperty(new StringProperty(PROP_LABEL, _("My CheckBox"), _("The Checkbox label")));
-    AddProperty(new BoolProperty(PROP_VALUE, false, _("Value")));
+    Add<StringProperty>(PROP_LABEL, _("My CheckBox"), _("The Checkbox label"));
+    Add<BoolProperty>(PROP_VALUE, false, _("Value"));
 
     PREPEND_STYLE(wxCHK_2STATE, false);
     PREPEND_STYLE(wxCHK_3STATE, false);

--- a/wxcrafter/controls/check_list_box_wrapper.cpp
+++ b/wxcrafter/controls/check_list_box_wrapper.cpp
@@ -28,7 +28,7 @@ CheckListBoxWrapper::CheckListBoxWrapper()
                            "is checked or unchecked."));
 
     SetPropertyString(_("Common Settings"), "wxCheckListBox");
-    AddProperty(new MultiStringsProperty(PROP_OPTIONS, _("The List Box Items. A semi-colon list of strings")));
+    Add<MultiStringsProperty>(PROP_OPTIONS, _("The List Box Items. A semi-colon list of strings"));
 
     m_namePattern = wxT("m_checkListBox");
     SetName(GenerateName());

--- a/wxcrafter/controls/choice_wrapper.cpp
+++ b/wxcrafter/controls/choice_wrapper.cpp
@@ -11,9 +11,8 @@ ChoiceWrapper::ChoiceWrapper()
     : wxcWidget(ID_WXCHOICE)
 {
     SetPropertyString(_("Common Settings"), "wxChoice");
-    AddProperty(
-        new MultiStringsProperty(PROP_OPTIONS, _("The Choice drop down options. A semi-colon list of strings")));
-    AddProperty(new StringProperty(PROP_SELECTION, wxT(""), _("Selected string index")));
+    Add<MultiStringsProperty>(PROP_OPTIONS, _("The Choice drop down options. A semi-colon list of strings"));
+    Add<StringProperty>(PROP_SELECTION, wxT(""), _("Selected string index"));
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_CHOICE_SELECTED"),
                          _("Process a wxEVT_COMMAND_CHOICE_SELECTED event, when an item on the list is selected."));

--- a/wxcrafter/controls/collapsible_pane_wrapper.cpp
+++ b/wxcrafter/controls/collapsible_pane_wrapper.cpp
@@ -18,8 +18,8 @@ CollapsiblePaneWrapper::CollapsiblePaneWrapper()
     PREPEND_STYLE(wxCP_NO_TLW_RESIZE, false);
 
     SetPropertyString(_("Common Settings"), "wxCollapsiblePane");
-    AddProperty(new StringProperty(PROP_LABEL, _("Label"), _("The label")));
-    AddProperty(new BoolProperty(PROP_COLLAPSED, true, _("Set the state of the collapsible pane")));
+    Add<StringProperty>(PROP_LABEL, _("Label"), _("The label"));
+    Add<BoolProperty>(PROP_COLLAPSED, true, _("Set the state of the collapsible pane"));
     m_namePattern = "m_collPane";
     SetName(GenerateName());
 }

--- a/wxcrafter/controls/colour_picker_wrapper.cpp
+++ b/wxcrafter/controls/colour_picker_wrapper.cpp
@@ -16,7 +16,7 @@ ColourPickerWrapper::ColourPickerWrapper()
     PREPEND_STYLE(wxCLRP_SHOW_LABEL, false);
 
     SetPropertyString(_("Common Settings"), "wxColourPickerCtrl");
-    AddProperty(new ColorProperty(PROP_VALUE, wxT("<Default>"), _("Colour")));
+    Add<ColorProperty>(PROP_VALUE, wxT("<Default>"), _("Colour"));
     RegisterEvent(wxT("wxEVT_COMMAND_COLOURPICKER_CHANGED"), wxT("wxColourPickerEvent"),
                   _("The user changed the colour selected in the control either using the button or using text "
                     "control\n(see wxCLRP_USE_TEXTCTRL; note that in this case the event is fired only if the user's "

--- a/wxcrafter/controls/combox_wrapper.cpp
+++ b/wxcrafter/controls/combox_wrapper.cpp
@@ -11,12 +11,13 @@ ComboxWrapper::ComboxWrapper()
     : wxcWidget(ID_WXCOMBOBOX)
 {
     SetPropertyString(_("Common Settings"), "wxComboBox");
-    AddProperty(new MultiStringsProperty(PROP_CB_CHOICES, _("Combobox drop down choices")));
-    AddProperty(new StringProperty(PROP_HINT, "", _("Sets a hint shown in an empty unfocused text control")));
-    AddProperty(new StringProperty(
-        PROP_SELECTION, wxT("-1"),
-        _("The zero-based position of any initially selected string, or -1 if none are to be selected")));
-    AddProperty(new StringProperty(PROP_VALUE, "", _("The combobox initial value")));
+    Add<MultiStringsProperty>(PROP_CB_CHOICES, _("Combobox drop down choices"));
+    Add<StringProperty>(PROP_HINT, "", _("Sets a hint shown in an empty unfocused text control"));
+    Add<StringProperty>(
+        PROP_SELECTION,
+        wxT("-1"),
+        _("The zero-based position of any initially selected string, or -1 if none are to be selected"));
+    Add<StringProperty>(PROP_VALUE, "", _("The combobox initial value"));
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_COMBOBOX_SELECTED"),
                          _("Process a wxEVT_COMMAND_COMBOBOX_SELECTED event, when an item on the list is selected. "

--- a/wxcrafter/controls/command_link_button_wrapper.cpp
+++ b/wxcrafter/controls/command_link_button_wrapper.cpp
@@ -21,19 +21,20 @@ CommandLinkButtonWrapper::CommandLinkButtonWrapper()
 
     SetPropertyString(_("Common Settings"), "wxCommandLinkButton");
     DelProperty(_("Control Specific Settings"));
-    AddProperty(new CategoryProperty("wxCommandLinkButton"));
+    Add<CategoryProperty>("wxCommandLinkButton");
 
     RegisterEvent("wxEVT_COMMAND_BUTTON_CLICKED", "wxCommandEvent",
                   _("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),
                   "wxCommandEventHandler");
 
-    AddProperty(new StringProperty(PROP_LABEL, _("Label"),
-                                   _("First line of text on the button, typically the label of an action that will be "
-                                     "made when the button is pressed")));
-    AddProperty(new StringProperty(
-        PROP_NOTE, "", _("Second line of text describing the action performed when the button is pressed")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", _("Select the bitmap file")));
-    AddProperty(new BoolProperty(PROP_DEFAULT_BUTTON, false, _("Make this button the default button")));
+    Add<StringProperty>(PROP_LABEL,
+                        _("Label"),
+                        _("First line of text on the button, typically the label of an action that will be "
+                          "made when the button is pressed"));
+    Add<StringProperty>(
+        PROP_NOTE, "", _("Second line of text describing the action performed when the button is pressed"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, "", _("Select the bitmap file"));
+    Add<BoolProperty>(PROP_DEFAULT_BUTTON, false, _("Make this button the default button"));
 
     m_namePattern = "m_cmdLnkBtn";
     SetName(GenerateName());

--- a/wxcrafter/controls/custom_control_wrapper.cpp
+++ b/wxcrafter/controls/custom_control_wrapper.cpp
@@ -12,7 +12,7 @@ CustomControlWrapper::CustomControlWrapper()
     : wxcWidget(ID_WXCUSTOMCONTROL)
 {
     DelProperty(_("Control Specific Settings"));
-    AddProperty(new CategoryProperty(m_templInfoName, "Custom Control"));
+    Add<CategoryProperty>(m_templInfoName, "Custom Control");
     m_namePattern = wxT("m_custom");
 
     // Generate a name if there isn't one; but don't overwrite e.g. an imported one

--- a/wxcrafter/controls/data_view_list_ctrl_column.cpp
+++ b/wxcrafter/controls/data_view_list_ctrl_column.cpp
@@ -23,19 +23,19 @@ DataViewListCtrlColumn::DataViewListCtrlColumn()
     const wxArrayString cellType =
         StdToWX::ToArrayString({ "wxDATAVIEW_CELL_INERT", "wxDATAVIEW_CELL_ACTIVATABLE", "wxDATAVIEW_CELL_EDITABLE" });
 
-    AddProperty(new CategoryProperty(_("wxDataViewListCtrl Column")));
-    AddProperty(new StringProperty(PROP_NAME, _("My Column"), _("Column Caption")));
-    AddProperty(new StringProperty(PROP_WIDTH, wxT("-2"),
-                                   _("Column Width (in pixels)\n-1 - special value for column width meaning "
-                                     "unspecified/default\n-2 - size the column automatically to fit all values")));
-    AddProperty(new ChoiceProperty(PROP_DV_LISTCTRL_COL_TYPES, coltype, 2, _("Column Type")));
-    AddProperty(new MultiStringsProperty(PROP_OPTIONS, _("Choices strings\nRelevant only for column of type 'choice'"),
-                                         ";", "Enter choices"));
-    AddProperty(new ChoiceProperty(PROP_DV_LISTCTRL_COL_ALIGN, alignment, 0, _("Cell Alignment")));
-    AddProperty(
-        new ChoiceProperty(PROP_DV_CELLMODE, cellType, 0, _("Cell mode (can be editable, activatable or inert)")));
-    AddProperty(new ColHeaderFlagsProperty(
-        PROP_DV_COLFLAGS, 0, _("One or more flags of the wxDataViewColumnFlags enumeration"), eColumnKind::kDataView));
+    Add<CategoryProperty>(_("wxDataViewListCtrl Column"));
+    Add<StringProperty>(PROP_NAME, _("My Column"), _("Column Caption"));
+    Add<StringProperty>(PROP_WIDTH,
+                        wxT("-2"),
+                        _("Column Width (in pixels)\n-1 - special value for column width meaning "
+                          "unspecified/default\n-2 - size the column automatically to fit all values"));
+    Add<ChoiceProperty>(PROP_DV_LISTCTRL_COL_TYPES, coltype, 2, _("Column Type"));
+    Add<MultiStringsProperty>(
+        PROP_OPTIONS, _("Choices strings\nRelevant only for column of type 'choice'"), ";", "Enter choices");
+    Add<ChoiceProperty>(PROP_DV_LISTCTRL_COL_ALIGN, alignment, 0, _("Cell Alignment"));
+    Add<ChoiceProperty>(PROP_DV_CELLMODE, cellType, 0, _("Cell mode (can be editable, activatable or inert)"));
+    Add<ColHeaderFlagsProperty>(
+        PROP_DV_COLFLAGS, 0, _("One or more flags of the wxDataViewColumnFlags enumeration"), eColumnKind::kDataView);
 }
 
 DataViewListCtrlColumn::~DataViewListCtrlColumn() {}

--- a/wxcrafter/controls/data_view_tree_list_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/data_view_tree_list_ctrl_wrapper.cpp
@@ -66,7 +66,7 @@ DataViewTreeListCtrlWrapper::DataViewTreeListCtrlWrapper()
 
     SetPropertyString(_("Common Settings"), "wxDataViewTreeListCtrl");
     DelProperty(_("Control Specific Settings"));
-    AddProperty(new CategoryProperty(_("Inherited C++ Class Properties")));
+    Add<CategoryProperty>(_("Inherited C++ Class Properties"));
 
     wxString tip;
     tip << _("The generated model class name\n")
@@ -79,10 +79,11 @@ DataViewTreeListCtrlWrapper::DataViewTreeListCtrlWrapper()
     if(name.Left(2) == "m_") {
         name = name.Mid(2);
     }
-    AddProperty(new StringProperty(PROP_DV_MODEL_CLASS_NAME, name + "Model", tip));
-    AddProperty(new BoolProperty(PROP_DV_CONTAINER_ITEM_HAS_COLUMNS, true,
-                                 _("Indicate if a container item merely acts as a headline (or for categorisation) or "
-                                   "if it also acts a normal item with entries for further columns")));
+    Add<StringProperty>(PROP_DV_MODEL_CLASS_NAME, name + "Model", tip);
+    Add<BoolProperty>(PROP_DV_CONTAINER_ITEM_HAS_COLUMNS,
+                      true,
+                      _("Indicate if a container item merely acts as a headline (or for categorisation) or "
+                        "if it also acts a normal item with entries for further columns"));
 }
 
 DataViewTreeListCtrlWrapper::~DataViewTreeListCtrlWrapper() {}

--- a/wxcrafter/controls/dir_picker_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/dir_picker_ctrl_wrapper.cpp
@@ -9,8 +9,8 @@ DirPickerCtrlWrapper::DirPickerCtrlWrapper()
     : wxcWidget(ID_WXDIRPICKER)
 {
     SetPropertyString(_("Common Settings"), "wxDirPickerCtrl");
-    AddProperty(new StringProperty(PROP_VALUE, wxT(""), _("Value")));
-    AddProperty(new StringProperty(PROP_MESSAGE, _("Select a folder"), _("Message to show to the user")));
+    Add<StringProperty>(PROP_VALUE, wxT(""), _("Value"));
+    Add<StringProperty>(PROP_MESSAGE, _("Select a folder"), _("Message to show to the user"));
 
     PREPEND_STYLE(wxDIRP_CHANGE_DIR, false);
     PREPEND_STYLE(wxDIRP_DIR_MUST_EXIST, false);

--- a/wxcrafter/controls/file_picker_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/file_picker_ctrl_wrapper.cpp
@@ -9,9 +9,9 @@ FilePickerCtrlWrapper::FilePickerCtrlWrapper()
     : wxcWidget(ID_WXFILEPICKER)
 {
     SetPropertyString(_("Common Settings"), "wxFilePickerCtrl");
-    AddProperty(new StringProperty(PROP_VALUE, wxT(""), _("Default value")));
-    AddProperty(new StringProperty(PROP_MESSAGE, _("Select a file"), _("Message to show to the user")));
-    AddProperty(new StringProperty(PROP_WILDCARD, wxT("*"), _("Wildcard")));
+    Add<StringProperty>(PROP_VALUE, wxT(""), _("Default value"));
+    Add<StringProperty>(PROP_MESSAGE, _("Select a file"), _("Message to show to the user"));
+    Add<StringProperty>(PROP_WILDCARD, wxT("*"), _("Wildcard"));
 
     PREPEND_STYLE(wxFLP_OPEN, false);
     PREPEND_STYLE(wxFLP_SAVE, false);

--- a/wxcrafter/controls/font_picker_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/font_picker_ctrl_wrapper.cpp
@@ -19,7 +19,7 @@ FontPickerCtrlWrapper::FontPickerCtrlWrapper()
 
     RegisterEvent(wxT("wxEVT_COMMAND_FONTPICKER_CHANGED"), wxT("wxFontPickerEvent"),
                   _("Generated whenever the selected font changes."));
-    AddProperty(new FontProperty(PROP_VALUE, wxEmptyString, _("Initial font")));
+    Add<FontProperty>(PROP_VALUE, wxEmptyString, _("Initial font"));
     m_namePattern = wxT("m_fontPicker");
     SetName(GenerateName());
 }

--- a/wxcrafter/controls/gauge_wrapper.cpp
+++ b/wxcrafter/controls/gauge_wrapper.cpp
@@ -12,10 +12,11 @@ GaugeWrapper::GaugeWrapper()
     PREPEND_STYLE(wxGA_VERTICAL, false);
     PREPEND_STYLE(wxGA_SMOOTH, false);
 
-    AddProperty(new StringProperty(
-        PROP_RANGE, wxT("100"),
-        _("Integer range (maximum value) of the gauge. It is ignored when the gauge is used in indeterminate mode.")));
-    AddProperty(new StringProperty(PROP_VALUE, wxT("10"), _("Sets the position of the gauge")));
+    Add<StringProperty>(
+        PROP_RANGE,
+        wxT("100"),
+        _("Integer range (maximum value) of the gauge. It is ignored when the gauge is used in indeterminate mode."));
+    Add<StringProperty>(PROP_VALUE, wxT("10"), _("Sets the position of the gauge"));
 
     m_namePattern = wxT("m_gauge");
     SetName(GenerateName());

--- a/wxcrafter/controls/generic_dir_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/generic_dir_ctrl_wrapper.cpp
@@ -10,11 +10,11 @@ GenericDirCtrlWrapper::GenericDirCtrlWrapper()
     : wxcWidget(ID_WXGENERICDIRCTRL)
 {
     SetPropertyString(_("Common Settings"), "wxGenericDirCtrl");
-    AddProperty(new StringProperty(PROP_DEFAULT_FOLDER, wxT(""), _("Sets the default path")));
-    AddProperty(new StringProperty(PROP_FILTER, wxT(""),
-                                   _("Sets the filter string. The syntax is similar to the one used in wxFileDialog")));
-    AddProperty(new StringProperty(PROP_DEFAULT_FILTER, wxT(""), _("Sets the current filter index (zero-based).")));
-    AddProperty(new BoolProperty(PROP_SHOW_HIDDEN, false, _("Show hidden files")));
+    Add<StringProperty>(PROP_DEFAULT_FOLDER, wxT(""), _("Sets the default path"));
+    Add<StringProperty>(
+        PROP_FILTER, wxT(""), _("Sets the filter string. The syntax is similar to the one used in wxFileDialog"));
+    Add<StringProperty>(PROP_DEFAULT_FILTER, wxT(""), _("Sets the current filter index (zero-based)."));
+    Add<BoolProperty>(PROP_SHOW_HIDDEN, false, _("Show hidden files"));
 
     PREPEND_STYLE_FALSE(wxDIRCTRL_DIR_ONLY);
     PREPEND_STYLE_TRUE(wxDIRCTRL_3D_INTERNAL);

--- a/wxcrafter/controls/gl_canvas_wrapper.cpp
+++ b/wxcrafter/controls/gl_canvas_wrapper.cpp
@@ -10,64 +10,60 @@ GLCanvasWrapper::GLCanvasWrapper()
 
     SetPropertyString(_("Common Settings"), "wxGLCanvas");
     DelProperty(PROP_CONTROL_SPECIFIC_SETTINGS);
-    AddCategory(_("wxGLCanvas Attribute List"));
+    Add<CategoryProperty>(_("wxGLCanvas Attribute List"));
 
-    AddProperty(new StringProperty("WX_GL_RGBA", _("Use true color palette (on if no attrs specified)")));
+    Add<StringProperty>("WX_GL_RGBA", _("Use true color palette (on if no attrs specified)"));
     m_attrs.Add("WX_GL_RGBA");
 
-    AddProperty(new StringProperty("WX_GL_BUFFER_SIZE", _("bits for buffer if not WX_GL_RGBA")));
+    Add<StringProperty>("WX_GL_BUFFER_SIZE", _("bits for buffer if not WX_GL_RGBA"));
     m_attrs.Add("WX_GL_BUFFER_SIZE");
 
-    AddProperty(new StringProperty("WX_GL_LEVEL", _("0 for main buffer, >0 for overlay, <0 for underlay")));
+    Add<StringProperty>("WX_GL_LEVEL", _("0 for main buffer, >0 for overlay, <0 for underlay"));
     m_attrs.Add("WX_GL_LEVEL");
 
-    AddProperty(new StringProperty("WX_GL_DOUBLEBUFFER", _("use double buffering (on if no attrs specified)")));
+    Add<StringProperty>("WX_GL_DOUBLEBUFFER", _("use double buffering (on if no attrs specified)"));
     m_attrs.Add("WX_GL_DOUBLEBUFFER");
 
-    AddProperty(new StringProperty("WX_GL_STEREO", _("use stereoscopic display")));
+    Add<StringProperty>("WX_GL_STEREO", _("use stereoscopic display"));
     m_attrs.Add("WX_GL_STEREO");
 
-    AddProperty(new StringProperty("WX_GL_AUX_BUFFERS", _("number of auxiliary buffers")));
+    Add<StringProperty>("WX_GL_AUX_BUFFERS", _("number of auxiliary buffers"));
     m_attrs.Add("WX_GL_AUX_BUFFERS");
 
-    AddProperty(new StringProperty("WX_GL_MIN_RED", _("use red buffer with most bits (> MIN_RED bits)")));
+    Add<StringProperty>("WX_GL_MIN_RED", _("use red buffer with most bits (> MIN_RED bits)"));
     m_attrs.Add("WX_GL_MIN_RED");
 
-    AddProperty(new StringProperty("WX_GL_MIN_GREEN", _("use green buffer with most bits (> MIN_GREEN bits)")));
+    Add<StringProperty>("WX_GL_MIN_GREEN", _("use green buffer with most bits (> MIN_GREEN bits)"));
     m_attrs.Add("WX_GL_MIN_GREEN");
 
-    AddProperty(new StringProperty("WX_GL_MIN_BLUE", _("use blue buffer with most bits (> MIN_BLUE bits)")));
+    Add<StringProperty>("WX_GL_MIN_BLUE", _("use blue buffer with most bits (> MIN_BLUE bits)"));
     m_attrs.Add("WX_GL_MIN_BLUE");
 
-    AddProperty(new StringProperty("WX_GL_MIN_ALPHA", _("use alpha buffer with most bits (> MIN_ALPHA bits)")));
+    Add<StringProperty>("WX_GL_MIN_ALPHA", _("use alpha buffer with most bits (> MIN_ALPHA bits)"));
     m_attrs.Add("WX_GL_MIN_ALPHA");
 
-    AddProperty(new StringProperty("WX_GL_DEPTH_SIZE", _("bits for Z-buffer (0,16,32)")));
+    Add<StringProperty>("WX_GL_DEPTH_SIZE", _("bits for Z-buffer (0,16,32)"));
     m_attrs.Add("WX_GL_DEPTH_SIZE");
 
-    AddProperty(new StringProperty("WX_GL_STENCIL_SIZE", _("bits for stencil buffer")));
+    Add<StringProperty>("WX_GL_STENCIL_SIZE", _("bits for stencil buffer"));
     m_attrs.Add("WX_GL_STENCIL_SIZE");
 
-    AddProperty(
-        new StringProperty("WX_GL_MIN_ACCUM_RED", _("use red accum buffer with most bits (> MIN_ACCUM_RED bits)")));
+    Add<StringProperty>("WX_GL_MIN_ACCUM_RED", _("use red accum buffer with most bits (> MIN_ACCUM_RED bits)"));
     m_attrs.Add("WX_GL_MIN_ACCUM_RED");
 
-    AddProperty(
-        new StringProperty("WX_GL_MIN_ACCUM_GREEN", _("use green buffer with most bits (> MIN_ACCUM_GREEN bits)")));
+    Add<StringProperty>("WX_GL_MIN_ACCUM_GREEN", _("use green buffer with most bits (> MIN_ACCUM_GREEN bits)"));
     m_attrs.Add("WX_GL_MIN_ACCUM_GREEN");
 
-    AddProperty(
-        new StringProperty("WX_GL_MIN_ACCUM_BLUE", _("use blue buffer with most bits (> MIN_ACCUM_BLUE bits)")));
+    Add<StringProperty>("WX_GL_MIN_ACCUM_BLUE", _("use blue buffer with most bits (> MIN_ACCUM_BLUE bits)"));
     m_attrs.Add("WX_GL_MIN_ACCUM_BLUE");
 
-    AddProperty(
-        new StringProperty("WX_GL_MIN_ACCUM_ALPHA", _("use alpha buffer with most bits (> MIN_ACCUM_ALPHA bits)")));
+    Add<StringProperty>("WX_GL_MIN_ACCUM_ALPHA", _("use alpha buffer with most bits (> MIN_ACCUM_ALPHA bits)"));
     m_attrs.Add("WX_GL_MIN_ACCUM_ALPHA");
 
-    AddProperty(new StringProperty("WX_GL_SAMPLE_BUFFERS", _("1 for multisampling support (antialiasing)")));
+    Add<StringProperty>("WX_GL_SAMPLE_BUFFERS", _("1 for multisampling support (antialiasing)"));
     m_attrs.Add("WX_GL_SAMPLE_BUFFERS");
 
-    AddProperty(new StringProperty("WX_GL_SAMPLES", _("4 for 2x2 antialiasing supersampling on most graphics cards")));
+    Add<StringProperty>("WX_GL_SAMPLES", _("4 for 2x2 antialiasing supersampling on most graphics cards"));
     m_attrs.Add("WX_GL_SAMPLES");
 
     SetName(GenerateName());

--- a/wxcrafter/controls/grid_column_wrapper.cpp
+++ b/wxcrafter/controls/grid_column_wrapper.cpp
@@ -11,12 +11,13 @@ GridColumnWrapper::GridColumnWrapper()
     m_properties.DeleteValues();
 
     SetPropertyString(_("Common Settings"), "wxGridColumn");
-    AddProperty(new CategoryProperty(_("wxGrid Column")));
-    AddText(PROP_NAME, _("The Column Label"), _("My Column"));
-    AddInteger(PROP_WIDTH,
-               _("Sets the width of the specified column.\nThe new column width in pixels, 0 to hide the column or -1 "
-                 "to fit the column width to its label width"),
-               -1);
+    Add<CategoryProperty>(_("wxGrid Column"));
+    Add<StringProperty>(PROP_NAME, _("My Column"), _("The Column Label"));
+    Add<IntProperty>(
+        PROP_WIDTH,
+        -1,
+        _("Sets the width of the specified column.\nThe new column width in pixels, 0 to hide the column or -1 "
+          "to fit the column width to its label width"));
 
     m_namePattern = "Column";
     SetName(GenerateName());

--- a/wxcrafter/controls/grid_row_wrapper.cpp
+++ b/wxcrafter/controls/grid_row_wrapper.cpp
@@ -10,9 +10,9 @@ GridRowWrapper::GridRowWrapper()
     m_properties.DeleteValues();
 
     SetPropertyString(_("Common Settings"), "wxGridRow");
-    AddProperty(new CategoryProperty(_("wxGrid Row")));
-    AddText(PROP_NAME, _("The Row Label"), _("My Row"));
-    AddInteger(PROP_HEIGHT, _("Sets the height of the row\nDefault -1 fits to the label height"), -1);
+    Add<CategoryProperty>(_("wxGrid Row"));
+    Add<StringProperty>(PROP_NAME, _("My Row"), _("The Row Label"));
+    Add<IntProperty>(PROP_HEIGHT, -1, _("Sets the height of the row\nDefault -1 fits to the label height"));
 
     m_namePattern = "Row";
     SetName(GenerateName());

--- a/wxcrafter/controls/grid_wrapper.cpp
+++ b/wxcrafter/controls/grid_wrapper.cpp
@@ -19,25 +19,23 @@ GridWrapper::GridWrapper()
     const wxArrayString hOpts = StdToWX::ToArrayString({ "wxALIGN_LEFT", "wxALIGN_CENTRE", "wxALIGN_RIGHT" });
 
     SetPropertyString(_("Common Settings"), "wxGrid");
-    AddProperty(new CategoryProperty(_("wxGrid Header")));
-    AddProperty(new BoolProperty(PROP_AUTOSIZE_COL, true, _("Auto size column content to fit the column header")));
-    AddProperty(
-        new BoolProperty(PROP_GRID_NATIVE_LOOK, true, _("Enable the use of native header window for column labels")));
-    // AddProperty(new BoolProperty(PROP_GRID_NATIVE_COL_LABELS, true, _("Call this in order to make the column labels
-    // use a native look")));
+    Add<CategoryProperty>(_("wxGrid Header"));
+    Add<BoolProperty>(PROP_AUTOSIZE_COL, true, _("Auto size column content to fit the column header"));
+    Add<BoolProperty>(PROP_GRID_NATIVE_LOOK, true, _("Enable the use of native header window for column labels"));
+    // Add<BoolProperty>(PROP_GRID_NATIVE_COL_LABELS, true, _("Call this in order to make the column labels use a native look"));
 
-    AddProperty(new CategoryProperty(_("wxGrid Columns Labels")));
-    AddInteger(PROP_HEIGHT, _("Sets the height of the column label"), -1);
-    AddProperty(new ChoiceProperty(PROP_COL_LABEL_H_ALIGN, hOpts, 1, _("Sets the horizontal alignment of the label")));
-    AddProperty(new ChoiceProperty(PROP_COL_LABEL_V_ALIGN, vOpts, 1, _("Sets the vertical alignment of the label")));
+    Add<CategoryProperty>(_("wxGrid Columns Labels"));
+    Add<IntProperty>(PROP_HEIGHT, -1, _("Sets the height of the column label"));
+    Add<ChoiceProperty>(PROP_COL_LABEL_H_ALIGN, hOpts, 1, _("Sets the horizontal alignment of the label"));
+    Add<ChoiceProperty>(PROP_COL_LABEL_V_ALIGN, vOpts, 1, _("Sets the vertical alignment of the label"));
 
-    AddProperty(new CategoryProperty(_("wxGrid Rows Labels")));
-    AddInteger(PROP_WIDTH, _("Sets the width of the row labels"), -1);
-    AddProperty(new ChoiceProperty(PROP_ROW_LABEL_H_ALIGN, hOpts, 2, _("Sets the horizontal alignment of the label")));
-    AddProperty(new ChoiceProperty(PROP_ROW_LABEL_V_ALIGN, vOpts, 1, _("Sets the vertical alignment of the label")));
+    Add<CategoryProperty>(_("wxGrid Rows Labels"));
+    Add<IntProperty>(PROP_WIDTH, -1, _("Sets the width of the row labels"));
+    Add<ChoiceProperty>(PROP_ROW_LABEL_H_ALIGN, hOpts, 2, _("Sets the horizontal alignment of the label"));
+    Add<ChoiceProperty>(PROP_ROW_LABEL_V_ALIGN, vOpts, 1, _("Sets the vertical alignment of the label"));
 
-    AddProperty(new CategoryProperty(_("wxGrid Cells")));
-    AddProperty(new BoolProperty(PROP_ALLOW_EDITING, true, _("Allow editing grid content")));
+    Add<CategoryProperty>(_("wxGrid Cells"));
+    Add<BoolProperty>(PROP_ALLOW_EDITING, true, _("Allow editing grid content"));
 
     RegisterEvent(wxT("wxEVT_GRID_CELL_CHANGING"), wxT("wxGridEvent"),
                   _("The user is about to change the data in a cell. The new cell value as string is available from "

--- a/wxcrafter/controls/html_window_wrapper.cpp
+++ b/wxcrafter/controls/html_window_wrapper.cpp
@@ -14,8 +14,8 @@ HtmlWindowWrapper::HtmlWindowWrapper()
     PREPEND_STYLE(wxHW_NO_SELECTION, false);
 
     SetPropertyString(_("Common Settings"), "wxHtmlWindow");
-    AddProperty(new StringProperty(PROP_HTMLCODE, wxT("<b>wxHtmlWindow control!</b>"), _("HTML code to load")));
-    AddProperty(new StringProperty(PROP_URL, wxT(""), _("URL to load")));
+    Add<StringProperty>(PROP_HTMLCODE, wxT("<b>wxHtmlWindow control!</b>"), _("HTML code to load"));
+    Add<StringProperty>(PROP_URL, wxT(""), _("URL to load"));
 
     RegisterEvent(wxT("wxEVT_COMMAND_HTML_CELL_CLICKED"), wxT("wxHtmlCellEvent"), _("A wxHtmlCell was clicked."));
     RegisterEvent(wxT("wxEVT_COMMAND_HTML_CELL_HOVER"), wxT("wxHtmlCellEvent"),

--- a/wxcrafter/controls/hyper_link_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/hyper_link_ctrl_wrapper.cpp
@@ -20,19 +20,20 @@ HyperLinkCtrlWrapper::HyperLinkCtrlWrapper()
                     "see wxEvent::Skip)\nthen a call to wxLaunchDefaultBrowser is done with the hyperlink's URL."));
 
     SetPropertyString(_("Common Settings"), "wxHyperLinkCtrl");
-    AddProperty(new StringProperty(PROP_LABEL, wxT("codelite IDE"), _("The label of the hyperlink")));
-    AddProperty(
-        new StringProperty(PROP_URL, wxT("http://www.codelite.org"), _("The URL associated with the given label")));
-    AddProperty(
-        new ColorProperty(PROP_NORMAL_COLOR, wxT("#0000FF"),
-                          _("Sets the colour used to print the label when the link has never been clicked "
-                            "before\n(i.e. the link has not been visited) and the mouse is not over the control.")));
-    AddProperty(new ColorProperty(PROP_VISITED_COLOR, wxT("#FF0000"),
-                                  _("Sets the colour used to print the label when the mouse is not over the control "
-                                    "and the link has already been clicked before\n(i.e. the link has been visited)")));
-    AddProperty(new ColorProperty(
-        PROP_HOVER_COLOR, wxT("#0000FF"),
-        _("Sets the colour used to print the label of the hyperlink when the mouse is over the control")));
+    Add<StringProperty>(PROP_LABEL, wxT("codelite IDE"), _("The label of the hyperlink"));
+    Add<StringProperty>(PROP_URL, wxT("http://www.codelite.org"), _("The URL associated with the given label"));
+    Add<ColorProperty>(PROP_NORMAL_COLOR,
+                       wxT("#0000FF"),
+                       _("Sets the colour used to print the label when the link has never been clicked "
+                         "before\n(i.e. the link has not been visited) and the mouse is not over the control."));
+    Add<ColorProperty>(PROP_VISITED_COLOR,
+                       wxT("#FF0000"),
+                       _("Sets the colour used to print the label when the mouse is not over the control "
+                         "and the link has already been clicked before\n(i.e. the link has been visited)"));
+    Add<ColorProperty>(
+        PROP_HOVER_COLOR,
+        wxT("#0000FF"),
+        _("Sets the colour used to print the label of the hyperlink when the mouse is over the control"));
 
     m_namePattern = wxT("m_hyperLink");
     SetName(GenerateName());

--- a/wxcrafter/controls/info_bar_button_wrapper.cpp
+++ b/wxcrafter/controls/info_bar_button_wrapper.cpp
@@ -11,13 +11,13 @@ InfoBarButtonWrapper::InfoBarButtonWrapper()
     m_sizerFlags.Clear();
 
     SetPropertyString(_("Common Settings"), "wxInfoBarButton");
-    AddProperty(new CategoryProperty(_("Common Settings")));
-    AddProperty(new WinIdProperty());
-    AddProperty(new StringProperty(PROP_NAME, "", _("Name")));
-    AddProperty(
-        new StringProperty(PROP_LABEL, _("My Label"),
-                           _("The label of the button. It may only be empty if the button ID is one of the stock ids "
-                             "in which case the corresponding stock label (see wxGetStockLabel()) will be used")));
+    Add<CategoryProperty>(_("Common Settings"));
+    Add<WinIdProperty>();
+    Add<StringProperty>(PROP_NAME, "", _("Name"));
+    Add<StringProperty>(PROP_LABEL,
+                        _("My Label"),
+                        _("The label of the button. It may only be empty if the button ID is one of the stock ids "
+                          "in which case the corresponding stock label (see wxGetStockLabel()) will be used"));
 
     RegisterEvent(wxT("wxEVT_COMMAND_BUTTON_CLICKED"), wxT("wxCommandEvent"),
                   _("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),

--- a/wxcrafter/controls/list_box_wrapper.cpp
+++ b/wxcrafter/controls/list_box_wrapper.cpp
@@ -25,10 +25,11 @@ ListBoxWrapper::ListBoxWrapper()
         _("Process a wxEVT_COMMAND_LISTBOX_DOUBLECLICKED event, when the listbox is double-clicked."));
 
     SetPropertyString(_("Common Settings"), "wxListBox");
-    AddProperty(new MultiStringsProperty(PROP_OPTIONS, _("The List Box Items. A semi-colon list of strings")));
-    AddProperty(new StringProperty(
-        PROP_SELECTION, wxT("-1"),
-        _("The zero-based position of any initially selected string, or -1 if none are to be selected")));
+    Add<MultiStringsProperty>(PROP_OPTIONS, _("The List Box Items. A semi-colon list of strings"));
+    Add<StringProperty>(
+        PROP_SELECTION,
+        wxT("-1"),
+        _("The zero-based position of any initially selected string, or -1 if none are to be selected"));
 
     m_namePattern = wxT("m_listBox");
     SetName(GenerateName());

--- a/wxcrafter/controls/list_ctrl_column_wrapper.cpp
+++ b/wxcrafter/controls/list_ctrl_column_wrapper.cpp
@@ -11,12 +11,13 @@ ListCtrlColumnWrapper::ListCtrlColumnWrapper()
     m_properties.DeleteValues();
 
     SetPropertyString(_("Common Settings"), "wxListCtrlColumn");
-    AddProperty(new CategoryProperty(_("wxListCtrl Column")));
-    AddProperty(new StringProperty(PROP_NAME, _("My Column"), _("Column caption")));
-    AddProperty(new StringProperty(
-        PROP_WIDTH, wxT("-1"),
+    Add<CategoryProperty>(_("wxListCtrl Column"));
+    Add<StringProperty>(PROP_NAME, _("My Column"), _("Column caption"));
+    Add<StringProperty>(
+        PROP_WIDTH,
+        wxT("-1"),
         _("Column Width\nSet it to -1 for auto sizing.\nOr set it to -2 to fit the column width to heading or to "
-          "extend to fill all the remaining space for the last column\nValue > 0 will set the width in pixels")));
+          "extend to fill all the remaining space for the last column\nValue > 0 will set the width in pixels"));
 }
 
 ListCtrlColumnWrapper::~ListCtrlColumnWrapper() {}

--- a/wxcrafter/controls/media_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/media_ctrl_wrapper.cpp
@@ -22,12 +22,12 @@ MediaCtrlWrapper::MediaCtrlWrapper()
     });
 
     SetPropertyString(_("Common Settings"), "wxMediaCtrl");
-    AddProperty(new ChoiceProperty(PROP_MC_BACKENDNAME, backendList, 0,
-                                   _("Select the media control backend, leave empty for the default")));
+    Add<ChoiceProperty>(
+        PROP_MC_BACKENDNAME, backendList, 0, _("Select the media control backend, leave empty for the default"));
     wxArrayString controls;
     controls.Add(PROP_MC_NO_CONTROLS);
     controls.Add(PROP_MC_DEFAULT_CONTROLS);
-    AddProperty(new ChoiceProperty(PROP_MC_CONTROLS, controls, 0, _("Show the player controls")));
+    Add<ChoiceProperty>(PROP_MC_CONTROLS, controls, 0, _("Show the player controls"));
 
     RegisterEvent("wxEVT_MEDIA_LOADED", "wxMediaEvent",
                   _("Sent when a media has loaded enough data that it can start playing"));

--- a/wxcrafter/controls/menu_item_wrapper.cpp
+++ b/wxcrafter/controls/menu_item_wrapper.cpp
@@ -27,21 +27,21 @@ MenuItemWrapper::MenuItemWrapper()
     m_properties.DeleteValues();
 
     SetPropertyString(_("Common Settings"), "wxMenuItem");
-    AddProperty(new CategoryProperty(_("Common Settings")));
-    AddProperty(new WinIdProperty());
-    AddProperty(new StringProperty(PROP_NAME, "", _("C++ variable name")));
-    AddProperty(new CategoryProperty(_("Menu Item")));
-    AddProperty(new StringProperty(PROP_LABEL, label, _("The menu item label")));
-    AddProperty(new StringProperty(PROP_ACCELERATOR, "", _("Keyboard Shortcut")));
-    AddProperty(new StringProperty(PROP_HELP, "", _("Short help string")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", _("Menu item image")));
+    Add<CategoryProperty>(_("Common Settings"));
+    Add<WinIdProperty>();
+    Add<StringProperty>(PROP_NAME, "", _("C++ variable name"));
+    Add<CategoryProperty>(_("Menu Item"));
+    Add<StringProperty>(PROP_LABEL, label, _("The menu item label"));
+    Add<StringProperty>(PROP_ACCELERATOR, "", _("Keyboard Shortcut"));
+    Add<StringProperty>(PROP_HELP, "", _("Short help string"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, "", _("Menu item image"));
 
     m_namePattern = wxT("m_menuItem");
     SetName(GenerateName());
 
-    AddProperty(new ChoiceProperty(PROP_KIND, wxCrafter::GetToolTypes(), 0,
-                                   _("The type of menu item: normal, radio, checkable or separator")));
-    AddProperty(new BoolProperty(PROP_CHECKED, false, _("For a checkable menu item, should this be checked")));
+    Add<ChoiceProperty>(
+        PROP_KIND, wxCrafter::GetToolTypes(), 0, _("The type of menu item: normal, radio, checkable or separator"));
+    Add<BoolProperty>(PROP_CHECKED, false, _("For a checkable menu item, should this be checked"));
 }
 
 MenuItemWrapper::~MenuItemWrapper() {}

--- a/wxcrafter/controls/menu_wrapper.cpp
+++ b/wxcrafter/controls/menu_wrapper.cpp
@@ -19,9 +19,9 @@ MenuWrapper::MenuWrapper()
     RegisterEvent("wxEVT_MENU_CLOSE", "wxMenuEvent", _("The menu is about to close"));
 
     SetPropertyString(_("Common Settings"), "wxMenu");
-    AddProperty(new CategoryProperty(_("Menu")));
-    AddProperty(new StringProperty(PROP_NAME, "", _("C++ variable name")));
-    AddProperty(new StringProperty(PROP_LABEL, _("Menu"), _("A title for the popup menu")));
+    Add<CategoryProperty>(_("Menu"));
+    Add<StringProperty>(PROP_NAME, "", _("C++ variable name"));
+    Add<StringProperty>(PROP_LABEL, _("Menu"), _("A title for the popup menu"));
 
     m_namePattern = wxT("m_menu");
     SetName(GenerateName());

--- a/wxcrafter/controls/notebook_page_wrapper.cpp
+++ b/wxcrafter/controls/notebook_page_wrapper.cpp
@@ -23,12 +23,12 @@ NotebookPageWrapper::NotebookPageWrapper()
 {
 
     SetPropertyString(_("Common Settings"), "wxNotebookPage");
-    AddProperty(new StringProperty(PROP_LABEL, _("Page"), _("The tab's label")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), _("Tab Image")));
-    AddProperty(new BoolProperty(PROP_SELECTED, false, _("Select this page")));
-    AddProperty(
-        new BoolProperty(PROP_NULL_BOOK_PAGE, false,
-                         _("Add a NULL page. This is only makes sense when the notebook is of type wxTreebook")));
+    Add<StringProperty>(PROP_LABEL, _("Page"), _("The tab's label"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, wxT(""), _("Tab Image"));
+    Add<BoolProperty>(PROP_SELECTED, false, _("Select this page"));
+    Add<BoolProperty>(PROP_NULL_BOOK_PAGE,
+                      false,
+                      _("Add a NULL page. This is only makes sense when the notebook is of type wxTreebook"));
 
     // Enable the 'wxTAB_TRAVERSAL' style
     EnableStyle(wxT("wxTAB_TRAVERSAL"), true);
@@ -200,7 +200,7 @@ void NotebookPageWrapper::SetParent(wxcWidget* parent)
         DelProperty(PROP_BITMAP_PATH);
 
     } else if(IsTreebookPage()) {
-        AddProperty(new BoolProperty(PROP_EXPANDED, true, _("Expand this node")));
+        Add<BoolProperty>(PROP_EXPANDED, true, _("Expand this node"));
     }
 }
 

--- a/wxcrafter/controls/property_grid_manager_wrapper.cpp
+++ b/wxcrafter/controls/property_grid_manager_wrapper.cpp
@@ -61,9 +61,10 @@ PropertyGridManagerWrapper::PropertyGridManagerWrapper()
     RegisterEvent("wxEVT_COMMAND_BUTTON_CLICKED", "wxCommandEvent",
                   _("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the custom editor button is clicked."));
 
-    AddInteger(PROP_SASH_POS, _("Sets x coordinate of the splitter"), -1);
-    AddBool(PROP_SPLITTER_LEFT,
-            _("Moves splitter as left as possible, while still allowing all labels to be shown in full"), false);
+    Add<IntProperty>(PROP_SASH_POS, -1, _("Sets x coordinate of the splitter"));
+    Add<BoolProperty>(PROP_SPLITTER_LEFT,
+                      false,
+                      _("Moves splitter as left as possible, while still allowing all labels to be shown in full"));
 
     m_namePattern = "m_pgMgr";
     SetName(GenerateName());

--- a/wxcrafter/controls/property_grid_wrapper.cpp
+++ b/wxcrafter/controls/property_grid_wrapper.cpp
@@ -40,12 +40,12 @@ PropertyGridWrapper::PropertyGridWrapper()
     });
 
     SetPropertyString(_("Common Settings"), "wxPropertyGrid");
-    AddProperty(new CategoryProperty("wxPGProperty"));
-    AddProperty(new StringProperty(PROP_NAME, "", _("The property name")));
-    AddProperty(new StringProperty(PROP_LABEL, wxString("My Label") << ++labelCount, _("The property label")));
-    AddProperty(new MultiStringsProperty(PROP_TOOLTIP, _("The property help string")));
-    AddProperty(new ColorProperty(PROP_BG, "<Default>", _("Property background colour")));
-    AddProperty(new ChoiceProperty(PROP_CUSTOM_EDITOR, customEditors, 0, _("Set custom editor control to a property")));
+    Add<CategoryProperty>("wxPGProperty");
+    Add<StringProperty>(PROP_NAME, "", _("The property name"));
+    Add<StringProperty>(PROP_LABEL, wxString("My Label") << ++labelCount, _("The property label"));
+    Add<MultiStringsProperty>(PROP_TOOLTIP, _("The property help string"));
+    Add<ColorProperty>(PROP_BG, "<Default>", _("Property background colour"));
+    Add<ChoiceProperty>(PROP_CUSTOM_EDITOR, customEditors, 0, _("Set custom editor control to a property"));
 
     const wxArrayString kindArr = StdToWX::ToArrayString({
         "wxPropertyCategory",     // 0
@@ -66,29 +66,29 @@ PropertyGridWrapper::PropertyGridWrapper()
         "wxSystemColourProperty", // 15
     });
 
-    AddProperty(new ChoiceProperty(PROP_KIND, kindArr, 4, _("The property kind")));
+    Add<ChoiceProperty>(PROP_KIND, kindArr, 4, _("The property kind"));
 
-    AddProperty(new CategoryProperty("wxPGProperty"));
-    AddProperty(new StringProperty(PROP_PG_STRING_VALUE, "", _("Initial string value")));
-    AddProperty(new MultiStringsProperty(PROP_PG_CHOICES,
-                                         _("For properties that accepts array of strings (wxEnumProperty, "
-                                           "wxEditEnumProperty and wxFlagsProperty) set the strings display name")));
-    AddProperty(new MultiStringsProperty(
+    Add<CategoryProperty>("wxPGProperty");
+    Add<StringProperty>(PROP_PG_STRING_VALUE, "", _("Initial string value"));
+    Add<MultiStringsProperty>(PROP_PG_CHOICES,
+                              _("For properties that accepts array of strings (wxEnumProperty, "
+                                "wxEditEnumProperty and wxFlagsProperty) set the strings display name"));
+    Add<MultiStringsProperty>(
         PROP_PG_CHOICES_VALUES,
         _("For properties that accepts array of strings (wxEnumProperty, wxEditEnumProperty and wxFlagsProperty) set "
-          "the strings values (optional for wxEnumProperty and wxEditEnumProperty)")));
+          "the strings values (optional for wxEnumProperty and wxEditEnumProperty)"));
 
-    AddProperty(new CategoryProperty("wxBoolProperty"));
-    AddProperty(new BoolProperty(PROP_PG_BOOL_VALUE, true, _("Initial value, relevant to wxBoolProperty")));
+    Add<CategoryProperty>("wxBoolProperty");
+    Add<BoolProperty>(PROP_PG_BOOL_VALUE, true, _("Initial value, relevant to wxBoolProperty"));
 
-    AddProperty(new CategoryProperty("wxFileProperty"));
-    AddProperty(new StringProperty(PROP_PG_WILDCARD, "", _("wxFileProperty's wildcard")));
+    Add<CategoryProperty>("wxFileProperty");
+    Add<StringProperty>(PROP_PG_WILDCARD, "", _("wxFileProperty's wildcard"));
 
-    AddProperty(new CategoryProperty("wxFontProperty"));
-    AddProperty(new FontProperty(PROP_FONT, "", _("Initial font")));
+    Add<CategoryProperty>("wxFontProperty");
+    Add<FontProperty>(PROP_FONT, "", _("Initial font"));
 
-    AddProperty(new CategoryProperty("wxSystemColourProperty"));
-    AddProperty(new ColorProperty(PROP_PG_COLOUR_DEFAULT, "<Default>", _("Initial Colour")));
+    Add<CategoryProperty>("wxSystemColourProperty");
+    Add<ColorProperty>(PROP_PG_COLOUR_DEFAULT, "<Default>", _("Initial Colour"));
 
     m_namePattern = "m_pgProp";
     SetName(GenerateName());

--- a/wxcrafter/controls/radio_box_wrapper.cpp
+++ b/wxcrafter/controls/radio_box_wrapper.cpp
@@ -13,12 +13,13 @@ RadioBoxWrapper::RadioBoxWrapper()
     PREPEND_STYLE(wxRA_SPECIFY_COLS, false);
 
     SetPropertyString(_("Common Settings"), "wxRadioBox");
-    AddProperty(new StringProperty(PROP_LABEL, _("My RadioBox"), _("Label")));
-    AddProperty(new MultiStringsProperty(PROP_OPTIONS, _("An array of choices with which to initialize the radiobox")));
-    AddProperty(new StringProperty(PROP_SELECTION, wxT("0"), _("The zero-based position of the selected button")));
-    AddProperty(new StringProperty(PROP_MAJORDIM, wxT("1"),
-                                   _("Specifies the maximum number of rows (if style contains wxRA_SPECIFY_ROWS) or "
-                                     "columns (if style contains wxRA_SPECIFY_COLS) for a two-dimensional radiobox")));
+    Add<StringProperty>(PROP_LABEL, _("My RadioBox"), _("Label"));
+    Add<MultiStringsProperty>(PROP_OPTIONS, _("An array of choices with which to initialize the radiobox"));
+    Add<StringProperty>(PROP_SELECTION, wxT("0"), _("The zero-based position of the selected button"));
+    Add<StringProperty>(PROP_MAJORDIM,
+                        wxT("1"),
+                        _("Specifies the maximum number of rows (if style contains wxRA_SPECIFY_ROWS) or "
+                          "columns (if style contains wxRA_SPECIFY_COLS) for a two-dimensional radiobox"));
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_RADIOBOX_SELECTED"),
                          _("Process a wxEVT_COMMAND_RADIOBOX_SELECTED event, when a radiobutton is clicked."));

--- a/wxcrafter/controls/radio_button_wrapper.cpp
+++ b/wxcrafter/controls/radio_button_wrapper.cpp
@@ -11,8 +11,8 @@ RadioButtonWrapper::RadioButtonWrapper()
     PREPEND_STYLE(wxRB_SINGLE, false);
 
     SetPropertyString(_("Common Settings"), "wxRadioButton");
-    AddProperty(new StringProperty(PROP_LABEL, _("My RadioButton"), _("Label")));
-    AddProperty(new BoolProperty(PROP_VALUE, true, _("Initial value")));
+    Add<StringProperty>(PROP_LABEL, _("My RadioButton"), _("Label"));
+    Add<BoolProperty>(PROP_VALUE, true, _("Initial value"));
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_RADIOBUTTON_SELECTED"),
                          _("Process a wxEVT_COMMAND_RADIOBUTTON_SELECTED event, when the radiobutton is clicked."));

--- a/wxcrafter/controls/ribbon_bar_wrapper.cpp
+++ b/wxcrafter/controls/ribbon_bar_wrapper.cpp
@@ -37,10 +37,10 @@ RibbonBarWrapper::RibbonBarWrapper()
 
     SetPropertyString(_("Common Settings"), "wxRibbonBar");
     DelProperty(PROP_CONTROL_SPECIFIC_SETTINGS);
-    AddProperty(new CategoryProperty("wxRibbonBar"));
+    Add<CategoryProperty>("wxRibbonBar");
 
     const wxArrayString themes = StdToWX::ToArrayString({ "Default", "Generic", "MSW" });
-    AddProperty(new ChoiceProperty(PROP_RIBBON_THEME, themes, 0, _("Select the ribbon bar theme")));
+    Add<ChoiceProperty>(PROP_RIBBON_THEME, themes, 0, _("Select the ribbon bar theme"));
     m_namePattern = "m_ribbonBar";
     SetName(GenerateName());
 }

--- a/wxcrafter/controls/ribbon_button.cpp
+++ b/wxcrafter/controls/ribbon_button.cpp
@@ -28,10 +28,10 @@ RibbonButtonBase::RibbonButtonBase(int type)
         selection = 3;
     }
 
-    AddProperty(new StringProperty(PROP_LABEL, _("Button"), _("The button label")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", _("Select the bitmap file")));
-    AddProperty(new StringProperty(PROP_HELP, "Help String", _("Help string")));
-    AddProperty(new ChoiceProperty(PROP_KIND, kind, selection, _("The button type")));
+    Add<StringProperty>(PROP_LABEL, _("Button"), _("The button label"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, "", _("Select the bitmap file"));
+    Add<StringProperty>(PROP_HELP, "Help String", _("Help string"));
+    Add<ChoiceProperty>(PROP_KIND, kind, selection, _("The button type"));
 
     wxCrafter::ResourceLoader bl;
     if(m_isButtonBar) {

--- a/wxcrafter/controls/ribbon_gallery_item_wrapper.cpp
+++ b/wxcrafter/controls/ribbon_gallery_item_wrapper.cpp
@@ -11,7 +11,7 @@ RibbonGalleryItemWrapper::RibbonGalleryItemWrapper()
     : wxcWidget(ID_WXRIBBONGALLERYITME)
 {
     SetPropertyString(_("Common Settings"), "wxRibbonGalleryItem");
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", _("Select the bitmap file")));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, "", _("Select the bitmap file"));
 
     wxCrafter::ResourceLoader bl;
     m_properties.Item(PROP_BITMAP_PATH)->SetValue(bl.GetPlaceHolderImagePath().GetFullPath());

--- a/wxcrafter/controls/ribbon_page_wrapper.cpp
+++ b/wxcrafter/controls/ribbon_page_wrapper.cpp
@@ -14,9 +14,9 @@ RibbonPageWrapper::RibbonPageWrapper()
     , m_selected(false)
 {
     SetPropertyString(_("Common Settings"), "wxRibbonPage");
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", _("Page Icon")));
-    AddProperty(new StringProperty(PROP_LABEL, "Page", _("Page Label")));
-    AddProperty(new BoolProperty(PROP_SELECTED, false, _("Selected")));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, "", _("Page Icon"));
+    Add<StringProperty>(PROP_LABEL, "Page", _("Page Label"));
+    Add<BoolProperty>(PROP_SELECTED, false, _("Selected"));
     m_namePattern = "m_ribbonPage";
     SetName(GenerateName());
 }

--- a/wxcrafter/controls/ribbon_panel_wrapper.cpp
+++ b/wxcrafter/controls/ribbon_panel_wrapper.cpp
@@ -19,9 +19,9 @@ RibbonPanelWrapper::RibbonPanelWrapper()
     PREPEND_STYLE_FALSE(wxRIBBON_PANEL_FLEXIBLE);
 
     SetPropertyString(_("Common Settings"), "wxRibbonPanel");
-    AddProperty(new StringProperty(PROP_LABEL, _("My Label"), _("The Label")));
-    AddProperty(new BitmapPickerProperty(
-        PROP_BITMAP_PATH, "", _("Icon to be used in place of the panel's children when the panel is minimised")));
+    Add<StringProperty>(PROP_LABEL, _("My Label"), _("The Label"));
+    Add<BitmapPickerProperty>(
+        PROP_BITMAP_PATH, "", _("Icon to be used in place of the panel's children when the panel is minimised"));
 
     RegisterEvent("wxEVT_COMMAND_RIBBONPANEL_EXTBUTTON_ACTIVATED", "wxRibbonPanelEvent",
                   _("Triggered when the user activate the panel extension button"));

--- a/wxcrafter/controls/ribbon_tool_bar_wrapper.cpp
+++ b/wxcrafter/controls/ribbon_tool_bar_wrapper.cpp
@@ -10,13 +10,13 @@ RibbonToolBarWrapper::RibbonToolBarWrapper()
 {
     SetPropertyString(_("Common Settings"), "wxRibbonToolBar");
     DelProperty(PROP_CONTROL_SPECIFIC_SETTINGS);
-    AddProperty(new CategoryProperty("wxRibbonToolBar"));
+    Add<CategoryProperty>("wxRibbonToolBar");
 
-    AddProperty(new IntProperty(PROP_RIBBON_TOOLBAR_MIN_ROWS, 1,
-                                _("Set the minimum number of rows to distribute tool groups over")));
-    AddProperty(
-        new IntProperty(PROP_RIBBON_TOOLBAR_MAX_ROWS, -1,
-                        _("Set the maximum number of rows to distribute tool groups over. Use -1 as default value")));
+    Add<IntProperty>(
+        PROP_RIBBON_TOOLBAR_MIN_ROWS, 1, _("Set the minimum number of rows to distribute tool groups over"));
+    Add<IntProperty>(PROP_RIBBON_TOOLBAR_MAX_ROWS,
+                     -1,
+                     _("Set the maximum number of rows to distribute tool groups over. Use -1 as default value"));
 
     m_namePattern = "m_ribbonToolbar";
     SetName(GenerateName());

--- a/wxcrafter/controls/ribbon_tool_separator.cpp
+++ b/wxcrafter/controls/ribbon_tool_separator.cpp
@@ -11,8 +11,8 @@ RibbonToolSeparator::RibbonToolSeparator()
     m_properties.DeleteValues();
     m_sizerFlags.Clear();
 
-    AddProperty(new CategoryProperty(_("wxRibbonToolBar Separator")));
-    AddProperty(new StringProperty(PROP_NAME, wxT(""), _("Name")));
+    Add<CategoryProperty>(_("wxRibbonToolBar Separator"));
+    Add<StringProperty>(PROP_NAME, wxT(""), _("Name"));
 
     m_namePattern = "m_separator";
     SetName(GenerateName());

--- a/wxcrafter/controls/rich_text_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/rich_text_ctrl_wrapper.cpp
@@ -58,7 +58,7 @@ RichTextCtrlWrapper::RichTextCtrlWrapper()
                            "control\n(which must have wxTE_PROCESS_ENTER style for this event to be generated)."));
 
     SetPropertyString(_("Common Settings"), "wxRichTextCtrl");
-    AddProperty(new StringProperty(PROP_VALUE, wxT("wxRichTextCtrl!"), _("Value")));
+    Add<StringProperty>(PROP_VALUE, wxT("wxRichTextCtrl!"), _("Value"));
 
     m_namePattern = wxT("m_richTextCtrl");
     SetName(GenerateName());

--- a/wxcrafter/controls/scroll_bar_wrapper.cpp
+++ b/wxcrafter/controls/scroll_bar_wrapper.cpp
@@ -30,14 +30,14 @@ ScrollBarWrapper::ScrollBarWrapper()
                   _("Process wxEVT_SCROLL_CHANGED end of scrolling events (MSW only)."));
 
     SetPropertyString(_("Common Settings"), "wxScrollBar");
-    AddProperty(new StringProperty(PROP_VALUE, wxT("0"), _("The position of the scrollbar in scroll units.")));
-    AddProperty(new StringProperty(PROP_THUMBSIZE, wxT("1"),
-                                   _("The size of the thumb, or visible portion of the scrollbar, in scroll units.")));
-    AddProperty(new StringProperty(PROP_RANGE, wxT("10"), _("The maximum position of the scrollbar.")));
-    AddProperty(
-        new StringProperty(PROP_PAGESIZE, wxT("1"),
-                           _("The size of the page size in scroll units. This is the number of units the scrollbar "
-                             "will scroll when it is paged up or down.\nOften it is the same as the thumb size.")));
+    Add<StringProperty>(PROP_VALUE, wxT("0"), _("The position of the scrollbar in scroll units."));
+    Add<StringProperty>(
+        PROP_THUMBSIZE, wxT("1"), _("The size of the thumb, or visible portion of the scrollbar, in scroll units."));
+    Add<StringProperty>(PROP_RANGE, wxT("10"), _("The maximum position of the scrollbar."));
+    Add<StringProperty>(PROP_PAGESIZE,
+                        wxT("1"),
+                        _("The size of the page size in scroll units. This is the number of units the scrollbar "
+                          "will scroll when it is paged up or down.\nOften it is the same as the thumb size."));
 
     m_namePattern = wxT("m_scrollBar");
     SetName(GenerateName());

--- a/wxcrafter/controls/scrolled_window_wrapper.cpp
+++ b/wxcrafter/controls/scrolled_window_wrapper.cpp
@@ -12,10 +12,8 @@ ScrolledWindowWrapper::ScrolledWindowWrapper()
     EnableStyle(wxT("wxVSCROLL"), true);
 
     SetPropertyString(_("Common Settings"), "wxScrolledWindow");
-    AddProperty(
-        new StringProperty(PROP_SCROLL_RATE_X, wxT("5"), _("Pixels per scroll unit in the horizontal direction")));
-    AddProperty(
-        new StringProperty(PROP_SCROLL_RATE_Y, wxT("5"), _("Pixels per scroll unit in the vertical direction")));
+    Add<StringProperty>(PROP_SCROLL_RATE_X, wxT("5"), _("Pixels per scroll unit in the horizontal direction"));
+    Add<StringProperty>(PROP_SCROLL_RATE_Y, wxT("5"), _("Pixels per scroll unit in the vertical direction"));
 
     RegisterEvent("wxEVT_SCROLLWIN_TOP", "wxScrollWinEvent",
                   _("Since wxWidgets 2.9.X\nProcess wxEVT_SCROLLWIN_TOP scroll-to-top events"));

--- a/wxcrafter/controls/search_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/search_ctrl_wrapper.cpp
@@ -16,9 +16,9 @@ SearchCtrlWrapper::SearchCtrlWrapper()
     PREPEND_STYLE(wxTE_CAPITALIZE, false);
 
     SetPropertyString(_("Common Settings"), "wxSearchCtrl");
-    AddProperty(new StringProperty(PROP_VALUE, wxT(""), _("Default text value.")));
-    AddProperty(new BoolProperty(PROP_SHOW_CANCEL_BTN, false, _("Show the 'Cancel' button")));
-    AddProperty(new BoolProperty(PROP_SHOW_SEARCH_BTN, true, _("Show the 'Search' button")));
+    Add<StringProperty>(PROP_VALUE, wxT(""), _("Default text value."));
+    Add<BoolProperty>(PROP_SHOW_CANCEL_BTN, false, _("Show the 'Cancel' button"));
+    Add<BoolProperty>(PROP_SHOW_SEARCH_BTN, true, _("Show the 'Search' button"));
 
     RegisterEventCommand(wxT("wxEVT_COMMAND_TEXT_UPDATED"),
                          _("Respond to a wxEVT_COMMAND_TEXT_UPDATED event, generated when the text changes.\nNotice "

--- a/wxcrafter/controls/simple_book_wrapper.cpp
+++ b/wxcrafter/controls/simple_book_wrapper.cpp
@@ -26,8 +26,7 @@ SimpleBookWrapper::SimpleBookWrapper()
           "wxSHOW_EFFECT_SLIDE_TO_RIGHT", "wxSHOW_EFFECT_SLIDE_TO_TOP", "wxSHOW_EFFECT_SLIDE_TO_BOTTOM",
           "wxSHOW_EFFECT_BLEND", "wxSHOW_EFFECT_EXPAND" });
     SetPropertyString(_("Common Settings"), "wxSimplebook");
-    AddProperty(new ChoiceProperty(PROP_EFFECT, effects, 0,
-                                   _("Set the same effect to use for both showing and hiding the pages")));
+    Add<ChoiceProperty>(PROP_EFFECT, effects, 0, _("Set the same effect to use for both showing and hiding the pages"));
     m_namePattern = wxT("m_simpleBook");
     SetName(GenerateName());
 }

--- a/wxcrafter/controls/slider_wrapper.cpp
+++ b/wxcrafter/controls/slider_wrapper.cpp
@@ -7,9 +7,9 @@ SliderWrapper::SliderWrapper()
     : wxcWidget(ID_WXSLIDER)
 {
     SetPropertyString(_("Common Settings"), "wxSlider");
-    AddProperty(new StringProperty(PROP_VALUE, wxT("50"), _("Value")));
-    AddProperty(new StringProperty(PROP_MINVALUE, wxT("0"), _("Minimum slider value")));
-    AddProperty(new StringProperty(PROP_MAXVALUE, wxT("100"), _("Maximum slider value")));
+    Add<StringProperty>(PROP_VALUE, wxT("50"), _("Value"));
+    Add<StringProperty>(PROP_MINVALUE, wxT("0"), _("Minimum slider value"));
+    Add<StringProperty>(PROP_MAXVALUE, wxT("100"), _("Maximum slider value"));
 
     PREPEND_STYLE(wxSL_HORIZONTAL, true);
     PREPEND_STYLE(wxSL_VERTICAL, false);

--- a/wxcrafter/controls/spacer_wrapper.cpp
+++ b/wxcrafter/controls/spacer_wrapper.cpp
@@ -10,10 +10,10 @@ SpacerWrapper::SpacerWrapper()
     m_styles.Clear();
     m_properties.DeleteValues();
 
-    AddProperty(new CategoryProperty(_("Spacer")));
-    AddProperty(new StringProperty(PROP_NAME, wxT("Spacer"), wxT("")));
+    Add<CategoryProperty>(_("Spacer"));
+    Add<StringProperty>(PROP_NAME, wxT("Spacer"), wxT(""));
     // This was removed above because sizers don't do 'size'. But wxSpacer does...
-    AddProperty(new StringProperty(PROP_SIZE, wxT("0,0"), _("The spacer's size: width,height")));
+    Add<StringProperty>(PROP_SIZE, wxT("0,0"), _("The spacer's size: width,height"));
 
     m_namePattern = wxT("Spacer");
     SetName(GenerateName());

--- a/wxcrafter/controls/spin_button_wrapper.cpp
+++ b/wxcrafter/controls/spin_button_wrapper.cpp
@@ -18,9 +18,9 @@ SpinButtonWrapper::SpinButtonWrapper()
     RegisterEvent(wxT("wxEVT_SPIN"), wxT("wxSpinEvent"), _("Generated whenever an arrow is pressed."));
 
     SetPropertyString(_("Common Settings"), "wxSpinButton");
-    AddProperty(new StringProperty(PROP_VALUE, wxT("0"), _("The initial value")));
-    AddProperty(new StringProperty(PROP_MINVALUE, wxT("0"), _("Minimal value")));
-    AddProperty(new StringProperty(PROP_MAXVALUE, wxT("100"), _("Maximal value")));
+    Add<StringProperty>(PROP_VALUE, wxT("0"), _("The initial value"));
+    Add<StringProperty>(PROP_MINVALUE, wxT("0"), _("Minimal value"));
+    Add<StringProperty>(PROP_MAXVALUE, wxT("100"), _("Maximal value"));
 
     m_namePattern = wxT("m_spinButton");
     SetName(GenerateName());

--- a/wxcrafter/controls/spin_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/spin_ctrl_wrapper.cpp
@@ -20,9 +20,9 @@ SpinCtrlWrapper::SpinCtrlWrapper()
                          _("Process a wxEVT_COMMAND_TEXT_UPDATED event, when the combobox text changes."));
 
     SetPropertyString(_("Common Settings"), "wxSpinCtrl");
-    AddProperty(new StringProperty(PROP_VALUE, wxT("0"), _("The initial value")));
-    AddProperty(new StringProperty(PROP_MINVALUE, wxT("0"), _("Minimal value")));
-    AddProperty(new StringProperty(PROP_MAXVALUE, wxT("100"), _("Maximal value")));
+    Add<StringProperty>(PROP_VALUE, wxT("0"), _("The initial value"));
+    Add<StringProperty>(PROP_MINVALUE, wxT("0"), _("Minimal value"));
+    Add<StringProperty>(PROP_MAXVALUE, wxT("100"), _("Maximal value"));
 
     m_namePattern = wxT("m_spinCtrl");
     SetName(GenerateName());

--- a/wxcrafter/controls/splitter_window_wrapper.cpp
+++ b/wxcrafter/controls/splitter_window_wrapper.cpp
@@ -15,7 +15,7 @@ SplitterWindowWrapper::SplitterWindowWrapper()
     options.Add(wxT("wxSPLIT_HORIZONTAL"));
 
     SetPropertyString(_("Common Settings"), "wxSplitterWindow");
-    AddProperty(new ChoiceProperty(PROP_SPLIT_MODE, options, 0, _("Sets the split mode")));
+    Add<ChoiceProperty>(PROP_SPLIT_MODE, options, 0, _("Sets the split mode"));
 
     wxString tip;
     tip << _("Gravity is real factor which controls position of sash while resizing wxSplitterWindow. \n")
@@ -24,9 +24,9 @@ SplitterWindowWrapper::SplitterWindowWrapper()
         << _("0.5 - both windows grow by equal size\n") << _("1.0 - only left/top window grows\n")
         << _("(Gravity should be a real value between 0.0 and 1.0)");
 
-    AddProperty(new StringProperty(PROP_SASH_GRAVITY, wxT("0.5"), tip));
-    AddProperty(new StringProperty(PROP_MIN_PANE_SIZE, wxT("10"), _("Sets the minimum pane size")));
-    AddProperty(new StringProperty(PROP_SASH_POS, wxT("0"), _("Sets the sash initial position")));
+    Add<StringProperty>(PROP_SASH_GRAVITY, wxT("0.5"), tip);
+    Add<StringProperty>(PROP_MIN_PANE_SIZE, wxT("10"), _("Sets the minimum pane size"));
+    Add<StringProperty>(PROP_SASH_POS, wxT("0"), _("Sets the sash initial position"));
 
     PREPEND_STYLE_TRUE(wxSP_3D);
     PREPEND_STYLE_FALSE(wxSP_3DSASH);

--- a/wxcrafter/controls/static_bitmap_wrapper.cpp
+++ b/wxcrafter/controls/static_bitmap_wrapper.cpp
@@ -10,7 +10,7 @@ StaticBitmapWrapper::StaticBitmapWrapper()
     : wxcWidget(ID_WXSTATICBITMAP)
 {
     SetPropertyString(_("Common Settings"), "wxStaticBitmap");
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file")));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, wxT(""), _("Select the bitmap file"));
     m_namePattern = wxT("m_staticBitmap");
     SetName(GenerateName());
 }

--- a/wxcrafter/controls/static_text_wrapper.cpp
+++ b/wxcrafter/controls/static_text_wrapper.cpp
@@ -13,11 +13,10 @@ StaticTextWrapper::StaticTextWrapper()
     PREPEND_STYLE(wxST_NO_AUTORESIZE, false);
 
     SetPropertyString(_("Common Settings"), "wxStaticText");
-    AddProperty(new MultiStringsProperty(PROP_LABEL, _("Static Text Label"), wxT("\\n"), _("Label:")));
+    Add<MultiStringsProperty>(PROP_LABEL, _("Static Text Label"), wxT("\\n"), _("Label:"));
     m_properties.Item(PROP_LABEL)->SetValue(_("Static Text Label"));
 
-    AddProperty(
-        new StringProperty(PROP_WRAP, wxT("-1"), _("Wrap the text after N pixels. If set to -1, don't wrap")));
+    Add<StringProperty>(PROP_WRAP, wxT("-1"), _("Wrap the text after N pixels. If set to -1, don't wrap"));
 
     m_namePattern = wxT("m_staticText");
     SetName(GenerateName());

--- a/wxcrafter/controls/status_bar_wrapper.cpp
+++ b/wxcrafter/controls/status_bar_wrapper.cpp
@@ -16,7 +16,7 @@ StatusBarWrapper::StatusBarWrapper()
     PREPEND_STYLE_TRUE(wxSTB_DEFAULT_STYLE);
 
     SetPropertyString(_("Common Settings"), "wxStatusBar");
-    AddProperty(new StringProperty(PROP_FIELD_COUNT, wxT("1"), _("Sets the number of fields")));
+    Add<StringProperty>(PROP_FIELD_COUNT, wxT("1"), _("Sets the number of fields"));
 
     m_namePattern = wxT("m_statusBar");
     SetName(GenerateName());

--- a/wxcrafter/controls/styled_text_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/styled_text_ctrl_wrapper.cpp
@@ -180,34 +180,32 @@ StyledTextCtrlWrapper::StyledTextCtrlWrapper()
                   _("The user deleted a character while auto-completion list was active"));
 
     SetPropertyString(_("Common Settings"), "wxStyledTextCtrl");
-    AddProperty(new BoolProperty(PROP_STC_MARGIN_FOLD, true, ""));
-    AddProperty(new BoolProperty(PROP_STC_MARGIN_LINE_NUMBERS, true, ""));
-    AddProperty(new BoolProperty(PROP_STC_MARGIN_SEPARATOR, false, ""));
-    AddProperty(new BoolProperty(PROP_STC_MARGIN_SYMBOL, false, ""));
+    Add<BoolProperty>(PROP_STC_MARGIN_FOLD, true, "");
+    Add<BoolProperty>(PROP_STC_MARGIN_LINE_NUMBERS, true, "");
+    Add<BoolProperty>(PROP_STC_MARGIN_SEPARATOR, false, "");
+    Add<BoolProperty>(PROP_STC_MARGIN_SYMBOL, false, "");
 
+    Add<ChoiceProperty>(PROP_STC_WRAP, m_wrapOptions, 0, _("Wrap text"));
 
-    AddProperty(new ChoiceProperty(PROP_STC_WRAP, m_wrapOptions, 0, _("Wrap text")));
+    Add<ChoiceProperty>(PROP_STC_INDENT_GUIDES, m_indentGuides, 0, _("Display indentation guides (vertical lines)"));
 
-    AddProperty(new ChoiceProperty(PROP_STC_INDENT_GUIDES, m_indentGuides, 0,
-                                   _("Display indentation guides (vertical lines)")));
-
-
-    AddProperty(new ChoiceProperty(PROP_STC_EOL_MODE, m_eolMode, 3, _("EOL Mode")));
-    AddProperty(new BoolProperty(PROP_STC_VIEW_EOL, false, _("Display the line endings characters")));
+    Add<ChoiceProperty>(PROP_STC_EOL_MODE, m_eolMode, 3, _("EOL Mode"));
+    Add<BoolProperty>(PROP_STC_VIEW_EOL, false, _("Display the line endings characters"));
 
     wxArrayString lexersArr = GetLexers();
     int sel = lexersArr.Index("wxSTC_LEX_NULL");
-    AddProperty(
-        new ChoiceProperty(PROP_STC_LEXER, lexersArr, sel,
-                           _("Set the wxStyledTextCtrl lexer.\nThe lexer affects the syntax highlight of control")));
-    AddProperty(new FontProperty(PROP_FONT, "", _("Set the basic styles font")));
+    Add<ChoiceProperty>(PROP_STC_LEXER,
+                        lexersArr,
+                        sel,
+                        _("Set the wxStyledTextCtrl lexer.\nThe lexer affects the syntax highlight of control"));
+    Add<FontProperty>(PROP_FONT, "", _("Set the basic styles font"));
 
-    AddProperty(new CategoryProperty(_("Keywords")));
-    AddProperty(new MultiStringsProperty(PROP_KEYWORDS_SET_1, _("Keywords set 1"), " "));
-    AddProperty(new MultiStringsProperty(PROP_KEYWORDS_SET_2, _("Keywords set 2"), " "));
-    AddProperty(new MultiStringsProperty(PROP_KEYWORDS_SET_3, _("Keywords set 3"), " "));
-    AddProperty(new MultiStringsProperty(PROP_KEYWORDS_SET_4, _("Keywords set 4"), " "));
-    AddProperty(new MultiStringsProperty(PROP_KEYWORDS_SET_5, _("Keywords set 5"), " "));
+    Add<CategoryProperty>(_("Keywords"));
+    Add<MultiStringsProperty>(PROP_KEYWORDS_SET_1, _("Keywords set 1"), " ");
+    Add<MultiStringsProperty>(PROP_KEYWORDS_SET_2, _("Keywords set 2"), " ");
+    Add<MultiStringsProperty>(PROP_KEYWORDS_SET_3, _("Keywords set 3"), " ");
+    Add<MultiStringsProperty>(PROP_KEYWORDS_SET_4, _("Keywords set 4"), " ");
+    Add<MultiStringsProperty>(PROP_KEYWORDS_SET_5, _("Keywords set 5"), " ");
 
     m_namePattern = "m_stc";
     SetName(GenerateName());

--- a/wxcrafter/controls/task_bar_icon_wrapper.cpp
+++ b/wxcrafter/controls/task_bar_icon_wrapper.cpp
@@ -14,14 +14,13 @@ TaskBarIconWrapper::TaskBarIconWrapper()
     : wxcWidget(ID_WXTASKBARICON)
 {
     m_styles.Clear();
-    AddText(PROP_TOOLTIP, _("Set the wxTaskBarIcon tooltip"));
+    Add<StringProperty>(PROP_TOOLTIP, _("Set the wxTaskBarIcon tooltip"));
     const wxArrayString types =
         StdToWX::ToArrayString({ "wxTBI_DEFAULT_TYPE", "wxTBI_DOCK", "wxTBI_CUSTOM_STATUSITEM" });
 
     SetPropertyString(_("Common Settings"), "wxTaskBarIcon");
-    AddProperty(
-        new ChoiceProperty(PROP_TASKBAR_ICONTYPE, types, 0, _("The iconType is only applicable on wxOSX_Cocoa")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, "", _("Set the wxTaskBarIcon icon")));
+    Add<ChoiceProperty>(PROP_TASKBAR_ICONTYPE, types, 0, _("The iconType is only applicable on wxOSX_Cocoa"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, "", _("Set the wxTaskBarIcon icon"));
 
     RegisterEvent("wxEVT_TASKBAR_MOVE", "wxTaskBarIconEvent", _("Process a wxEVT_TASKBAR_MOVE event"));
     RegisterEvent("wxEVT_TASKBAR_LEFT_DOWN", "wxTaskBarIconEvent", _("Process a wxEVT_TASKBAR_LEFT_DOWN event"));

--- a/wxcrafter/controls/text_ctrl_wrapper.cpp
+++ b/wxcrafter/controls/text_ctrl_wrapper.cpp
@@ -39,23 +39,26 @@ TextCtrlWrapper::TextCtrlWrapper()
                          _("A mouse event occurred over an URL in the text control (wxMSW and wxGTK2 only)"));
 
     SetPropertyString(_("Common Settings"), "wxTextCtrl");
-    AddProperty(new StringProperty(PROP_VALUE, wxT(""), _("Default text control value")));
-    AddProperty(new StringProperty(PROP_HINT, "", _("Sets a hint shown in an empty unfocused text control")));
-    AddProperty(new StringProperty(PROP_MAXLENGTH, wxT("0"),
-                                   _("The maximum length of user entered text. Only for single-line wxTextCtrls.")));
+    Add<StringProperty>(PROP_VALUE, wxT(""), _("Default text control value"));
+    Add<StringProperty>(PROP_HINT, "", _("Sets a hint shown in an empty unfocused text control"));
+    Add<StringProperty>(
+        PROP_MAXLENGTH, wxT("0"), _("The maximum length of user entered text. Only for single-line wxTextCtrls."));
 #if wxUSE_SPELLCHECK
-    AddProperty(new BoolProperty(PROP_SPELLCHECK, false, 
-        _("Enable spell checking using the operating system provided text proofing tools. "
-          "This function is only available on OSX, Windows 8 (or newer), and GTK3 (or newer).")));
+    Add<BoolProperty>(PROP_SPELLCHECK,
+                      false,
+                      _("Enable spell checking using the operating system provided text proofing tools. "
+                        "This function is only available on OSX, Windows 8 (or newer), and GTK3 (or newer)."));
 #endif // wxUSE_SPELLCHECK
-    AddProperty(new BoolProperty(
-        PROP_AUTO_COMPLETE_DIRS, false,
+    Add<BoolProperty>(
+        PROP_AUTO_COMPLETE_DIRS,
+        false,
         _("Enable auto-completion of the text using the file system directories. Notice that currently this function "
-          "is only implemented in wxMSW port and does nothing under the other platforms.")));
-    AddProperty(new BoolProperty(PROP_AUTO_COMPLETE_FILES, false,
-                                 _("Enable auto-completion of the text typed in a single-line text control using all "
-                                   "valid file system path. Notice that currently this function is only implemented in "
-                                   "wxMSW port and does nothing under the other platforms.")));
+          "is only implemented in wxMSW port and does nothing under the other platforms."));
+    Add<BoolProperty>(PROP_AUTO_COMPLETE_FILES,
+                      false,
+                      _("Enable auto-completion of the text typed in a single-line text control using all "
+                        "valid file system path. Notice that currently this function is only implemented in "
+                        "wxMSW port and does nothing under the other platforms."));
     m_namePattern = wxT("m_textCtrl");
     SetName(GenerateName());
 }

--- a/wxcrafter/controls/timer_wrapper.cpp
+++ b/wxcrafter/controls/timer_wrapper.cpp
@@ -14,13 +14,13 @@ TimerWrapper::TimerWrapper()
     m_sizerFlags.Clear();
 
     SetPropertyString(_("Common Settings"), "wxTimer");
-    AddProperty(new CategoryProperty(_("wxTimer")));
-    AddProperty(new StringProperty(PROP_NAME, "", _("Control name")));
-    AddProperty(new IntProperty(PROP_INTERVAL, 1000, _("Sets the current interval for the timer (in milliseconds)")));
-    AddProperty(new BoolProperty(PROP_START_TIMER, true, _("Start the timer")));
-    AddProperty(
-        new BoolProperty(PROP_ONE_SHOT_TIMER, false,
-                         _("A one shot timer - sets whether the timer event is called repeatedly or only once")));
+    Add<CategoryProperty>(_("wxTimer"));
+    Add<StringProperty>(PROP_NAME, "", _("Control name"));
+    Add<IntProperty>(PROP_INTERVAL, 1000, _("Sets the current interval for the timer (in milliseconds)"));
+    Add<BoolProperty>(PROP_START_TIMER, true, _("Start the timer"));
+    Add<BoolProperty>(PROP_ONE_SHOT_TIMER,
+                      false,
+                      _("A one shot timer - sets whether the timer event is called repeatedly or only once"));
     RegisterEvent("wxEVT_TIMER", "wxTimerEvent", _("Process a timer event"));
 
     m_namePattern = "m_timer";

--- a/wxcrafter/controls/toggle_button_wrapper.cpp
+++ b/wxcrafter/controls/toggle_button_wrapper.cpp
@@ -10,8 +10,8 @@ ToggleButtonWrapper::ToggleButtonWrapper()
     : wxcWidget(ID_WXTOGGLEBUTTON)
 {
     SetPropertyString(_("Common Settings"), "wxToggleButton");
-    AddProperty(new StringProperty(PROP_LABEL, _("My Button"), _("The button label")));
-    AddProperty(new BoolProperty(PROP_CHECKED, false, _("The button initial state")));
+    Add<StringProperty>(PROP_LABEL, _("My Button"), _("The button label"));
+    Add<BoolProperty>(PROP_CHECKED, false, _("The button initial state"));
 
     PREPEND_STYLE(wxBU_BOTTOM, false);
     PREPEND_STYLE(wxBU_EXACTFIT, false);

--- a/wxcrafter/controls/tool_bar_item_wrapper.cpp
+++ b/wxcrafter/controls/tool_bar_item_wrapper.cpp
@@ -32,21 +32,19 @@ ToolBarItemWrapper::ToolBarItemWrapper(int type)
     m_properties.DeleteValues();
 
     wxCrafter::ResourceLoader bmps;
-    AddProperty(new CategoryProperty(_("Common Settings"), "wxToolBarItem"));
-    AddProperty(new WinIdProperty());
-    AddProperty(new StringProperty(PROP_NAME, "", _("C++ variable name")));
+    Add<CategoryProperty>(_("Common Settings"), "wxToolBarItem");
+    Add<WinIdProperty>();
+    Add<StringProperty>(PROP_NAME, "", _("C++ variable name"));
 
-    AddProperty(new CategoryProperty(_("ToolBar Item")));
-    AddProperty(new StringProperty(PROP_LABEL, _("Tool Label"), _("The tool label")));
-    AddProperty(new MultiStringsProperty(PROP_TOOLTIP, _("Tooltip"), wxT("\\n"),
-                                         _("Short help string. This will appear as the tool's tooltip")));
-    AddProperty(new StringProperty(PROP_HELP, "", _("Long help string. This will be displayed in the statusbar")));
-    AddProperty(
-        new BitmapPickerProperty(PROP_BITMAP_PATH, bmps.GetPlaceHolder16ImagePath().GetFullPath(), _("Bitmap")));
-    AddProperty(new FilePickerProperty(PROP_DISABLED_BITMAP_PATH, "", _("Disabled bitmap")));
-    AddProperty(new ChoiceProperty(PROP_KIND, wxCrafter::GetToolTypes(true), 0, _("The tool kind")));
-    AddProperty(
-        new BoolProperty(PROP_DROPDOWN_MENU, true, _("Use wxCrafter to construct the menu called by the dropdown")));
+    Add<CategoryProperty>(_("ToolBar Item"));
+    Add<StringProperty>(PROP_LABEL, _("Tool Label"), _("The tool label"));
+    Add<MultiStringsProperty>(
+        PROP_TOOLTIP, _("Tooltip"), wxT("\\n"), _("Short help string. This will appear as the tool's tooltip"));
+    Add<StringProperty>(PROP_HELP, "", _("Long help string. This will be displayed in the statusbar"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, bmps.GetPlaceHolder16ImagePath().GetFullPath(), _("Bitmap"));
+    Add<FilePickerProperty>(PROP_DISABLED_BITMAP_PATH, "", _("Disabled bitmap"));
+    Add<ChoiceProperty>(PROP_KIND, wxCrafter::GetToolTypes(true), 0, _("The tool kind"));
+    Add<BoolProperty>(PROP_DROPDOWN_MENU, true, _("Use wxCrafter to construct the menu called by the dropdown"));
 
     m_namePattern = wxT("m_toolbarItem");
     SetName(GenerateName());
@@ -373,9 +371,9 @@ ToolBarItemSeparatorWrapper::ToolBarItemSeparatorWrapper()
     wxArrayString kinds;
     kinds.Add(ITEM_SEPARATOR);
 
-    AddCategory(_("ToolBar Item Separator"));
-    AddProperty(new StringProperty(PROP_NAME, "", "Name"));
-    AddProperty(new ChoiceProperty(PROP_KIND, kinds, 0, _("The tool kind")));
+    Add<CategoryProperty>(_("ToolBar Item Separator"));
+    Add<StringProperty>(PROP_NAME, "", "Name");
+    Add<ChoiceProperty>(PROP_KIND, kinds, 0, _("The tool kind"));
 
     m_namePattern = "m_tbSeparator";
     SetName(GenerateName());
@@ -401,9 +399,9 @@ ToolBarItemSpaceWrapper::ToolBarItemSpaceWrapper()
     wxArrayString kinds;
     kinds.Add(ITEM_SPACE);
 
-    AddCategory(_("ToolBar Item Space"));
-    AddProperty(new StringProperty(PROP_NAME, "", "Name"));
-    AddProperty(new ChoiceProperty(PROP_KIND, kinds, 0, _("The tool kind")));
+    Add<CategoryProperty>(_("ToolBar Item Space"));
+    Add<StringProperty>(PROP_NAME, "", "Name");
+    Add<ChoiceProperty>(PROP_KIND, kinds, 0, _("The tool kind"));
 
     m_namePattern = "m_toolbarSpacer";
     SetName(GenerateName());
@@ -424,9 +422,9 @@ AuiToolBarItemNonStretchSpaceWrapper::AuiToolBarItemNonStretchSpaceWrapper()
     m_properties.DeleteValues();
     m_sizerFlags.Clear();
 
-    AddCategory(_("AuiToolBar Item Space"));
-    AddProperty(new StringProperty(PROP_NAME, "", "Name"));
-    AddProperty(new StringProperty(PROP_WIDTH, "0", _("The width of the space in pixels")));
+    Add<CategoryProperty>(_("AuiToolBar Item Space"));
+    Add<StringProperty>(PROP_NAME, "", "Name");
+    Add<StringProperty>(PROP_WIDTH, "0", _("The width of the space in pixels"));
 
     m_namePattern = "m_auitbarNonstretchSpace";
     SetName(GenerateName());
@@ -453,9 +451,9 @@ AuiToolBarItemSpaceWrapper::AuiToolBarItemSpaceWrapper()
     m_properties.DeleteValues();
     m_sizerFlags.Clear();
 
-    AddCategory(_("ToolBar Item Space"));
-    AddProperty(new StringProperty(PROP_NAME, "", "Name"));
-    AddProperty(new StringProperty(PROP_PROPORTION, "1", _("How stretchable the space is. The normal value is 1.")));
+    Add<CategoryProperty>(_("ToolBar Item Space"));
+    Add<StringProperty>(PROP_NAME, "", "Name");
+    Add<StringProperty>(PROP_PROPORTION, "1", _("How stretchable the space is. The normal value is 1."));
 
     m_namePattern = "m_auitbarStretchSpace";
     SetName(GenerateName());
@@ -483,11 +481,11 @@ AuiToolBarLabelWrapper::AuiToolBarLabelWrapper(int type)
     m_properties.DeleteValues();
 
     wxCrafter::ResourceLoader bmps;
-    AddProperty(new CategoryProperty(_("wxAuiToolBar Label")));
-    AddProperty(new WinIdProperty());
-    AddProperty(new StringProperty(PROP_NAME, "", _("C++ variable name")));
-    AddProperty(new StringProperty(PROP_LABEL, _("My toolbar label"), _("The label's text")));
-    AddProperty(new StringProperty(PROP_WIDTH, "-1", _("Optionally, specify the label's width")));
+    Add<CategoryProperty>(_("wxAuiToolBar Label"));
+    Add<WinIdProperty>();
+    Add<StringProperty>(PROP_NAME, "", _("C++ variable name"));
+    Add<StringProperty>(PROP_LABEL, _("My toolbar label"), _("The label's text"));
+    Add<StringProperty>(PROP_WIDTH, "-1", _("Optionally, specify the label's width"));
 
     m_namePattern = wxT("m_auitbarLabel");
     SetName(GenerateName());

--- a/wxcrafter/controls/toolbar_base_wrapper.cpp
+++ b/wxcrafter/controls/toolbar_base_wrapper.cpp
@@ -30,29 +30,31 @@ ToolbarBaseWrapper::ToolbarBaseWrapper(int type)
     PREPEND_STYLE_FALSE(wxTB_HORZ_TEXT);
 
     m_properties.DeleteValues();
-    AddProperty(new CategoryProperty(_("Common Settings"), "wxToolBar"));
-    AddProperty(new WinIdProperty());
-    AddProperty(new StringProperty(PROP_SIZE, wxT("-1,-1"),
-                                   _("The control size. It is recommended to leave it as -1,-1 and "
-                                     "let\nthe sizers calculate the best size for the window")));
-    AddProperty(new StringProperty(PROP_NAME, wxT(""), _("C++ member name")));
-    AddProperty(new StringProperty(PROP_TOOLTIP, wxT(""), _("Tooltip")));
+    Add<CategoryProperty>(_("Common Settings"), "wxToolBar");
+    Add<WinIdProperty>();
+    Add<StringProperty>(PROP_SIZE,
+                        wxT("-1,-1"),
+                        _("The control size. It is recommended to leave it as -1,-1 and let\n"
+                          "the sizers calculate the best size for the window"));
+    Add<StringProperty>(PROP_NAME, wxT(""), _("C++ member name"));
+    Add<StringProperty>(PROP_TOOLTIP, wxT(""), _("Tooltip"));
 
-    AddProperty(new CategoryProperty(_("ToolBar")));
-    AddProperty(new StringProperty(PROP_BITMAP_SIZE, wxT("16,16"), _("Sets the default size of each tool bitmap")));
-    AddProperty(
-        new StringProperty(PROP_MARGINS, wxT("-1,-1"), _("Sets the values to be used as margins for the toolbar.")));
-    AddProperty(new StringProperty(PROP_PADDING, wxT("1"), _("Sets the space between tools.")));
-    AddProperty(new StringProperty(PROP_SEPARATOR_SIZE, wxT("5"), _("Sets the width of separators.")));
+    Add<CategoryProperty>(_("ToolBar"));
+    Add<StringProperty>(PROP_BITMAP_SIZE, wxT("16,16"), _("Sets the default size of each tool bitmap"));
+    Add<StringProperty>(PROP_MARGINS, wxT("-1,-1"), _("Sets the values to be used as margins for the toolbar."));
+    Add<StringProperty>(PROP_PADDING, wxT("1"), _("Sets the space between tools."));
+    Add<StringProperty>(PROP_SEPARATOR_SIZE, wxT("5"), _("Sets the width of separators."));
 
-    AddProperty(new CategoryProperty(_("Subclass")));
-    AddProperty(new StringProperty(PROP_SUBCLASS_NAME, wxT(""),
-                                   _("The name of the derived class. Used both for C++ and XRC generated code.")));
-    AddProperty(
-        new StringProperty(PROP_SUBCLASS_INCLUDE, wxT(""),
-                           _("(C++ only) The name of any extra header file to be #included e.g. mydialog.hpp")));
-    AddText(PROP_SUBCLASS_STYLE,
-            _("Override the default class style with the content of this field.\nThe style should be | separated"));
+    Add<CategoryProperty>(_("Subclass"));
+    Add<StringProperty>(
+        PROP_SUBCLASS_NAME, wxT(""), _("The name of the derived class. Used both for C++ and XRC generated code."));
+    Add<StringProperty>(PROP_SUBCLASS_INCLUDE,
+                        wxT(""),
+                        _("(C++ only) The name of any extra header file to be #included e.g. mydialog.hpp"));
+    Add<StringProperty>(
+        PROP_SUBCLASS_STYLE,
+        "",
+        _("Override the default class style with the content of this field.\nThe style should be | separated"));
     m_namePattern = wxT("m_toolbar");
     SetName(GenerateName());
 }
@@ -207,18 +209,18 @@ AuiToolbarWrapper::AuiToolbarWrapper()
     m_properties.DeleteValues();
     EnableSizerFlag(wxT("wxEXPAND"), true);
 
-    AddProperty(new CategoryProperty(_("Common Settings")));
-    AddProperty(new WinIdProperty());
-    AddProperty(new StringProperty(PROP_SIZE, wxT("-1,-1"),
-                                   _("The control size. It is recommended to leave it as -1,-1 and "
-                                     "let\nthe sizers calculate the best size for the window")));
-    AddProperty(new StringProperty(PROP_NAME, wxT(""), _("C++ member name")));
-    AddProperty(new StringProperty(PROP_TOOLTIP, wxT(""), _("Tooltip")));
+    Add<CategoryProperty>(_("Common Settings"));
+    Add<WinIdProperty>();
+    Add<StringProperty>(PROP_SIZE,
+                        wxT("-1,-1"),
+                        _("The control size. It is recommended to leave it as -1,-1 and let\n"
+                          "the sizers calculate the best size for the window"));
+    Add<StringProperty>(PROP_NAME, wxT(""), _("C++ member name"));
+    Add<StringProperty>(PROP_TOOLTIP, wxT(""), _("Tooltip"));
 
-    AddProperty(new CategoryProperty(_("wxAuiToolBar")));
-    AddProperty(new StringProperty(PROP_BITMAP_SIZE, wxT("16,16"), _("Sets the default size of each tool bitmap")));
-    AddProperty(
-        new StringProperty(PROP_MARGINS, wxT("-1,-1"), _("Set the values to be used as margins for the toolbar.")));
+    Add<CategoryProperty>(_("wxAuiToolBar"));
+    Add<StringProperty>(PROP_BITMAP_SIZE, wxT("16,16"), _("Sets the default size of each tool bitmap"));
+    Add<StringProperty>(PROP_MARGINS, wxT("-1,-1"), _("Set the values to be used as margins for the toolbar."));
 
     PREPEND_STYLE_FALSE(wxAUI_TB_TEXT);
     PREPEND_STYLE_FALSE(wxAUI_TB_NO_TOOLTIPS);

--- a/wxcrafter/controls/top_level_win_wrapper.cpp
+++ b/wxcrafter/controls/top_level_win_wrapper.cpp
@@ -46,31 +46,35 @@ TopLevelWinWrapper::TopLevelWinWrapper(int type)
     DoSetPropertyStringValue(PROP_SIZE, "500,300");
     if(IsWxTopLevelWindow()) {
         // Add a persistency object support
-        AddBool(PROP_PERSISTENT,
-                _("When enabled, the generated code will add support for wxPersistenceManager (i.e. the Window will "
-                  "remember its size, position and any child wxBookCtrlBase control will remember its selection)"),
-                true);
+        Add<BoolProperty>(
+            PROP_PERSISTENT,
+            true,
+            _("When enabled, the generated code will add support for wxPersistenceManager (i.e. the Window will "
+              "remember its size, position and any child wxBookCtrlBase control will remember its selection)"));
     }
 
     const wxArrayString arr = StdToWX::ToArrayString({ "", "wxBOTH", "wxVERTICAL", "wxHORIZONTAL" });
-    AddProperty(new StringProperty(PROP_TITLE, "", _("The title, if any")));
-    AddProperty(
-        new VirtualFolderProperty(PROP_VIRTUAL_FOLDER, "", _("CodeLite's virtual folder for the generated files")));
-    AddProperty(new ChoiceProperty(PROP_CENTRE_ON_SCREEN, arr, 1,
-                                   _("Centre on parent. This may be in both dimensions (the default); only "
-                                     "vertically or horizontally; or not at all.")));
+    Add<StringProperty>(PROP_TITLE, "", _("The title, if any"));
+    Add<VirtualFolderProperty>(PROP_VIRTUAL_FOLDER, "", _("CodeLite's virtual folder for the generated files"));
+    Add<ChoiceProperty>(PROP_CENTRE_ON_SCREEN,
+                        arr,
+                        1,
+                        _("Centre on parent. This may be in both dimensions (the default); only "
+                          "vertically or horizontally; or not at all."));
 
-    AddProperty(new CategoryProperty(_("Inherited C++ Class Properties")));
-    AddProperty(new StringProperty(PROP_INHERITED_CLASS, "",
-                                   _("Inherited class name\nFill this field to generate a class that inherits from the "
-                                     "base class,\nwhere you should place all your application logic.\ne.g. for a "
-                                     "generated class 'FooDialogBase', you might enter 'FooDialog' here.")));
-    AddProperty(new StringProperty(PROP_FILE, "",
-                                   _("The name for the inherited class's files (without any file "
-                                     "extension).\nwxCrafter will generate a $(FILE).cpp and $(FILE).hpp\ne.g. "
-                                     "for an inherited class 'FooDialog', you might enter 'foodialog' here.")));
-    AddProperty(new StringProperty(PROP_CLASS_DECORATOR, "",
-                                   _("MSW Only\nC++ macro decorator - allows exporting this class from a DLL")));
+    Add<CategoryProperty>(_("Inherited C++ Class Properties"));
+    Add<StringProperty>(PROP_INHERITED_CLASS,
+                        "",
+                        _("Inherited class name\nFill this field to generate a class that inherits from the "
+                          "base class,\nwhere you should place all your application logic.\ne.g. for a "
+                          "generated class 'FooDialogBase', you might enter 'FooDialog' here."));
+    Add<StringProperty>(PROP_FILE,
+                        "",
+                        _("The name for the inherited class's files (without any file extension).\n"
+                          "wxCrafter will generate a $(FILE).cpp and $(FILE).hpp\ne.g. "
+                          "for an inherited class 'FooDialog', you might enter 'foodialog' here."));
+    Add<StringProperty>(
+        PROP_CLASS_DECORATOR, "", _("MSW Only\nC++ macro decorator - allows exporting this class from a DLL"));
 
     if(m_properties.Contains(PROP_NAME)) {
         m_properties.Item(PROP_NAME)->SetTooltip(_("The generated C++ class name"));

--- a/wxcrafter/controls/tree_list_ctrl_column_wrapper.cpp
+++ b/wxcrafter/controls/tree_list_ctrl_column_wrapper.cpp
@@ -18,19 +18,21 @@ TreeListCtrlColumnWrapper::TreeListCtrlColumnWrapper()
     const wxArrayString alignment = StdToWX::ToArrayString({ "wxALIGN_LEFT", "wxALIGN_RIGHT", "wxALIGN_CENTER" });
 
     // FIXME: add alignment + column flags here
-    AddProperty(new CategoryProperty(_("wxTreeListCtrl Column")));
-    AddProperty(new StringProperty(PROP_NAME, _("My Column"), _("Column caption")));
-    AddProperty(new ChoiceProperty(PROP_DV_LISTCTRL_COL_ALIGN, alignment, 0,
-                                   _("Alignment of both the column header and its items")));
-    AddProperty(new StringProperty(
-        PROP_WIDTH, "-2",
+    Add<CategoryProperty>(_("wxTreeListCtrl Column"));
+    Add<StringProperty>(PROP_NAME, _("My Column"), _("Column caption"));
+    Add<ChoiceProperty>(
+        PROP_DV_LISTCTRL_COL_ALIGN, alignment, 0, _("Alignment of both the column header and its items"));
+    Add<StringProperty>(
+        PROP_WIDTH,
+        "-2",
         _("The width of the column in pixels or the special wxCOL_WIDTH_AUTOSIZE(-2) value indicating that the column "
           "should adjust to its contents. Notice that the first column is special and will be always resized to fill "
-          "all the space not taken by the other columns, i.e. the width specified here is ignored for it")));
-    AddProperty(new ColHeaderFlagsProperty(
-        PROP_COL_FLAGS, wxCOL_DEFAULT_FLAGS,
+          "all the space not taken by the other columns, i.e. the width specified here is ignored for it"));
+    Add<ColHeaderFlagsProperty>(
+        PROP_COL_FLAGS,
+        wxCOL_DEFAULT_FLAGS,
         _("Column flags, currently can include wxCOL_RESIZABLE to allow the user to resize the column and "
-          "wxCOL_SORTABLE to allow the user to resort the control contents by clicking on this column")));
+          "wxCOL_SORTABLE to allow the user to resort the control contents by clicking on this column"));
 }
 
 TreeListCtrlColumnWrapper::~TreeListCtrlColumnWrapper() {}

--- a/wxcrafter/controls/web_view_wrapper.cpp
+++ b/wxcrafter/controls/web_view_wrapper.cpp
@@ -31,9 +31,10 @@ WebViewWrapper::WebViewWrapper()
                     "GetString to get the title."));
 
     SetPropertyString(_("Common Settings"), "wxWebView");
-    AddProperty(new StringProperty(PROP_URL, _("about:blank"),
-                                   _("URL to load by default in the web view.\nNote that the designer will display "
-                                     "about:blank. The preview and generated code will use the actual URL")));
+    Add<StringProperty>(PROP_URL,
+                        _("about:blank"),
+                        _("URL to load by default in the web view.\nNote that the designer will display "
+                          "about:blank. The preview and generated code will use the actual URL"));
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);

--- a/wxcrafter/controls/wizard_page_wrapper.cpp
+++ b/wxcrafter/controls/wizard_page_wrapper.cpp
@@ -15,8 +15,8 @@ WizardPageWrapper::WizardPageWrapper()
     SetPropertyString(_("Common Settings"), "wxWizardPage");
     m_type = ID_WXWIZARDPAGE;
     m_namePattern = wxT("m_wizardPage");
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""),
-                                         _("The page-specific bitmap if different from the global one")));
+    Add<BitmapPickerProperty>(
+        PROP_BITMAP_PATH, wxT(""), _("The page-specific bitmap if different from the global one"));
     DoSetPropertyStringValue(PROP_SIZE, wxT("500,300"));
     SetName(GenerateName());
 }

--- a/wxcrafter/controls/wx_collapsible_pane_pane_wrapper.cpp
+++ b/wxcrafter/controls/wx_collapsible_pane_pane_wrapper.cpp
@@ -9,7 +9,7 @@ wxCollapsiblePanePaneWrapper::wxCollapsiblePanePaneWrapper()
     m_styles.Clear();
     m_sizerFlags.Clear();
 
-    AddProperty(new StringProperty(PROP_NAME, _("Name"), _("Name")));
+    Add<StringProperty>(PROP_NAME, _("Name"), _("Name"));
     m_namePattern = "m_collpaneWin";
     SetName(GenerateName());
 }

--- a/wxcrafter/sizers/box_sizer_wrapper.cpp
+++ b/wxcrafter/sizers/box_sizer_wrapper.cpp
@@ -15,7 +15,7 @@ BoxSizerWrapper::BoxSizerWrapper()
     const wxArrayString arr = StdToWX::ToArrayString({ "wxVERTICAL", "wxHORIZONTAL" });
 
     SetPropertyString(_("Common Settings"), "wxBoxSizer");
-    AddProperty(new ChoiceProperty(PROP_ORIENTATION, arr, 0, _("Sizer orientation")));
+    Add<ChoiceProperty>(PROP_ORIENTATION, arr, 0, _("Sizer orientation"));
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);

--- a/wxcrafter/sizers/flexgridsizer_wrapper.cpp
+++ b/wxcrafter/sizers/flexgridsizer_wrapper.cpp
@@ -10,12 +10,12 @@ FlexGridSizerWrapper::FlexGridSizerWrapper()
     m_styles.Clear(); // Sizer has no styles
 
     SetPropertyString(_("Common Settings"), "wxFlexGridSizer");
-    AddProperty(new StringProperty(PROP_COLS, "2", _("Number of columns in the grid")));
-    AddProperty(new StringProperty(PROP_ROWS, "0", _("Number of rows in the grid")));
-    AddProperty(new StringProperty(PROP_GROW_COLS, "", _("Which columns are allowed to grow. Comma separated list")));
-    AddProperty(new StringProperty(PROP_GROW_ROWS, "", _("Which rows are allowed to grow. Comma separated list")));
-    AddProperty(new StringProperty(PROP_HGAP, "0", _("The horizontal gap between grid cells")));
-    AddProperty(new StringProperty(PROP_VGAP, "0", _("The vertical gap between grid cells")));
+    Add<StringProperty>(PROP_COLS, "2", _("Number of columns in the grid"));
+    Add<StringProperty>(PROP_ROWS, "0", _("Number of rows in the grid"));
+    Add<StringProperty>(PROP_GROW_COLS, "", _("Which columns are allowed to grow. Comma separated list"));
+    Add<StringProperty>(PROP_GROW_ROWS, "", _("Which rows are allowed to grow. Comma separated list"));
+    Add<StringProperty>(PROP_HGAP, "0", _("The horizontal gap between grid cells"));
+    Add<StringProperty>(PROP_VGAP, "0", _("The vertical gap between grid cells"));
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);

--- a/wxcrafter/sizers/grid_bag_sizer_wrapper.cpp
+++ b/wxcrafter/sizers/grid_bag_sizer_wrapper.cpp
@@ -9,10 +9,10 @@ GridBagSizerWrapper::GridBagSizerWrapper()
     m_type = ID_WXGRIDBAGSIZER;
     m_styles.Clear(); // Sizer has no styles
     SetPropertyString(_("Common Settings"), "wxGridBagSizer");
-    AddProperty(new StringProperty(PROP_GROW_COLS, "", _("Which columns are allowed to grow. Comma separated list")));
-    AddProperty(new StringProperty(PROP_GROW_ROWS, "", _("Which rows are allowed to grow. Comma separated list")));
-    AddProperty(new StringProperty(PROP_HGAP, "0", _("The horizontal gap between grid cells")));
-    AddProperty(new StringProperty(PROP_VGAP, "0", _("The vertical gap between grid cells")));
+    Add<StringProperty>(PROP_GROW_COLS, "", _("Which columns are allowed to grow. Comma separated list"));
+    Add<StringProperty>(PROP_GROW_ROWS, "", _("Which rows are allowed to grow. Comma separated list"));
+    Add<StringProperty>(PROP_HGAP, "0", _("The horizontal gap between grid cells"));
+    Add<StringProperty>(PROP_VGAP, "0", _("The vertical gap between grid cells"));
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);

--- a/wxcrafter/sizers/grid_sizer_wrapper.cpp
+++ b/wxcrafter/sizers/grid_sizer_wrapper.cpp
@@ -10,10 +10,10 @@ GridSizerWrapper::GridSizerWrapper()
     m_styles.Clear(); // Sizer has no styles
 
     SetPropertyString(_("Common Settings"), "wxGridSizer");
-    AddProperty(new StringProperty(PROP_COLS, "2", _("Number of columns in the grid")));
-    AddProperty(new StringProperty(PROP_ROWS, "0", _("Number of rows in the grid")));
-    AddProperty(new StringProperty(PROP_HGAP, "0", _("The horizontal gap between grid cells")));
-    AddProperty(new StringProperty(PROP_VGAP, "0", _("The vertical gap between grid cells")));
+    Add<StringProperty>(PROP_COLS, "2", _("Number of columns in the grid"));
+    Add<StringProperty>(PROP_ROWS, "0", _("Number of rows in the grid"));
+    Add<StringProperty>(PROP_HGAP, "0", _("The horizontal gap between grid cells"));
+    Add<StringProperty>(PROP_VGAP, "0", _("The vertical gap between grid cells"));
 
     EnableSizerFlag("wxEXPAND", true);
     m_sizerItem.SetProportion(1);

--- a/wxcrafter/sizers/sizer_wrapper_base.cpp
+++ b/wxcrafter/sizers/sizer_wrapper_base.cpp
@@ -5,8 +5,8 @@
 SizerWrapperBase::SizerWrapperBase()
     : wxcWidget(-1)
 {
-    AddProperty(new BoolProperty(PROP_KEEP_CLASS_MEMBER, false,
-                                 _("When enabled, this sizer is kept as a class member and become accessible")));
+    Add<BoolProperty>(
+        PROP_KEEP_CLASS_MEMBER, false, _("When enabled, this sizer is kept as a class member and become accessible"));
 
     DelProperty(PROP_WINDOW_ID);
     DelProperty(PROP_SIZE);

--- a/wxcrafter/sizers/static_box_sizer_wrapper.cpp
+++ b/wxcrafter/sizers/static_box_sizer_wrapper.cpp
@@ -15,8 +15,8 @@ StaticBoxSizerWrapper::StaticBoxSizerWrapper()
     const wxArrayString arr = StdToWX::ToArrayString({ "Vertical", "Horizontal" });
 
     SetPropertyString(_("Common Settings"), "wxStaticBoxSizer");
-    AddProperty(new ChoiceProperty(PROP_ORIENTATION, arr, 0, _("Sizer orientation")));
-    AddProperty(new StringProperty(PROP_LABEL, _("My Label"), _("Label")));
+    Add<ChoiceProperty>(PROP_ORIENTATION, arr, 0, _("Sizer orientation"));
+    Add<StringProperty>(PROP_LABEL, _("My Label"), _("Label"));
 
     m_namePattern = "staticBoxSizer";
     SetName(GenerateName());

--- a/wxcrafter/sizers/std_button_wrapper.cpp
+++ b/wxcrafter/sizers/std_button_wrapper.cpp
@@ -19,11 +19,11 @@ StdButtonWrapper::StdButtonWrapper()
                   _("Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked."),
                   wxT("wxCommandEventHandler"));
 
-    AddProperty(new CategoryProperty(_("Standard wxButton")));
-    AddProperty(new ChoiceProperty(PROP_WINDOW_ID, ids, 0, _("Button ID")));
-    AddProperty(new StringProperty(PROP_NAME, wxT(""), _("C++ member name")));
-    AddProperty(new MultiStringsProperty(PROP_TOOLTIP, _("Tooltip"), wxT("\\n"), _("Tooltip text:")));
-    AddProperty(new BoolProperty(PROP_DEFAULT_BUTTON, false, wxT("Make this button the default button")));
+    Add<CategoryProperty>(_("Standard wxButton"));
+    Add<ChoiceProperty>(PROP_WINDOW_ID, ids, 0, _("Button ID"));
+    Add<StringProperty>(PROP_NAME, wxT(""), _("C++ member name"));
+    Add<MultiStringsProperty>(PROP_TOOLTIP, _("Tooltip"), wxT("\\n"), _("Tooltip text:"));
+    Add<BoolProperty>(PROP_DEFAULT_BUTTON, false, wxT("Make this button the default button"));
     m_namePattern = "m_button";
     SetName(GenerateName());
 }

--- a/wxcrafter/src/wxc_widget.cpp
+++ b/wxcrafter/src/wxc_widget.cpp
@@ -101,34 +101,37 @@ wxcWidget::wxcWidget(int type)
         ADD_SIZER_FLAG(wxRESERVE_SPACE_EVEN_IF_HIDDEN, false);
     }
 
-    AddProperty(new CategoryProperty(_("Common Settings")));
-    AddProperty(new WinIdProperty());
-    AddProperty(new StringProperty(PROP_SIZE, "-1,-1",
-                                   _("The control's size. It is recommended to leave it as -1,-1 and "
-                                     "let\nthe sizers calculate the best size for the window")));
-    AddProperty(new StringProperty(PROP_MINSIZE, "-1,-1",
-                                   _("The control's minimum size, to indicate to the sizer layout "
-                                     "mechanism that this is the minimum required size")));
-    AddProperty(new StringProperty(PROP_NAME, "", _("C++ member name")));
-    AddProperty(new MultiStringsProperty(PROP_TOOLTIP, _("Tooltip"), "\\n", _("Tooltip text:")));
-    AddProperty(new ColorProperty(PROP_BG, "<Default>", _("Set the control's background colour")));
-    AddProperty(new ColorProperty(PROP_FG, "<Default>", _("Set the control's foreground colour")));
-    AddProperty(new FontProperty(PROP_FONT, "", _("Set the control's font")));
+    Add<CategoryProperty>(_("Common Settings"));
+    Add<WinIdProperty>();
+    Add<StringProperty>(PROP_SIZE,
+                        "-1,-1",
+                        _("The control's size. It is recommended to leave it as -1,-1 and let\n"
+                          "the sizers calculate the best size for the window"));
+    Add<StringProperty>(PROP_MINSIZE,
+                        "-1,-1",
+                        _("The control's minimum size, to indicate to the sizer layout "
+                          "mechanism that this is the minimum required size"));
+    Add<StringProperty>(PROP_NAME, "", _("C++ member name"));
+    Add<MultiStringsProperty>(PROP_TOOLTIP, _("Tooltip"), "\\n", _("Tooltip text:"));
+    Add<ColorProperty>(PROP_BG, "<Default>", _("Set the control's background colour"));
+    Add<ColorProperty>(PROP_FG, "<Default>", _("Set the control's foreground colour"));
+    Add<FontProperty>(PROP_FONT, "", _("Set the control's font"));
 
-    AddProperty(new CategoryProperty(_("Initial State")));
-    AddProperty(new BoolProperty(PROP_STATE_HIDDEN, false, _("Sets the control initial state to 'Hidden'")));
-    AddProperty(new BoolProperty(PROP_STATE_DISABLED, false, _("Sets the control initial state to 'Disabled'")));
-    AddProperty(new BoolProperty(PROP_HAS_FOCUS, false, _("This control should have keyboard focus")));
+    Add<CategoryProperty>(_("Initial State"));
+    Add<BoolProperty>(PROP_STATE_HIDDEN, false, _("Sets the control initial state to 'Hidden'"));
+    Add<BoolProperty>(PROP_STATE_DISABLED, false, _("Sets the control initial state to 'Disabled'"));
+    Add<BoolProperty>(PROP_HAS_FOCUS, false, _("This control should have keyboard focus"));
 
-    AddProperty(new CategoryProperty(_("Subclass")));
-    AddProperty(new StringProperty(PROP_SUBCLASS_NAME, "",
-                                   _("The name of the derived class. Used both for C++ and XRC generated code.")));
-    AddProperty(
-        new StringProperty(PROP_SUBCLASS_INCLUDE, "",
-                           _("(C++ only) The name of any extra header file to be #included e.g. mydialog.hpp")));
-    AddText(PROP_SUBCLASS_STYLE,
-            _("Override the default class style with the content of this field.\nThe style should be | separated"));
-    AddProperty(new CategoryProperty(_("Control Specific Settings")));
+    Add<CategoryProperty>(_("Subclass"));
+    Add<StringProperty>(
+        PROP_SUBCLASS_NAME, "", _("The name of the derived class. Used both for C++ and XRC generated code."));
+    Add<StringProperty>(
+        PROP_SUBCLASS_INCLUDE, "", _("(C++ only) The name of any extra header file to be #included e.g. mydialog.hpp"));
+    Add<StringProperty>(
+        PROP_SUBCLASS_STYLE,
+        "",
+        _("Override the default class style with the content of this field.\nThe style should be | separated"));
+    Add<CategoryProperty>(_("Control Specific Settings"));
 }
 
 wxcWidget::~wxcWidget()

--- a/wxcrafter/src/wxc_widget.h
+++ b/wxcrafter/src/wxc_widget.h
@@ -188,29 +188,10 @@ protected:
     const wxString& GetCondname() const { return m_condname; }
 
     /// aliases for adding property
-    void AddCategory(const wxString& name) { AddProperty(new CategoryProperty(name)); }
-    /**
-     * @brief add string property
-     */
-    void AddText(const wxString& name, const wxString& description, const wxString& defaultValue = wxEmptyString)
+    template <typename T, typename... Ts>
+    void Add(Ts&&... args)
     {
-        AddProperty(new StringProperty(name, defaultValue, description));
-    }
-
-    /**
-     * @brief add bool property
-     */
-    void AddBool(const wxString& name, const wxString& description, bool defaultValue)
-    {
-        AddProperty(new BoolProperty(name, defaultValue, description));
-    }
-
-    /**
-     * @brief add integer property
-     */
-    void AddInteger(const wxString& name, const wxString& description, int defaultValue)
-    {
-        AddProperty(new IntProperty(name, defaultValue, description));
+        AddProperty(new T{ std::forward<Ts>(args)... });
     }
 
     void DelProperty(const wxString& name);

--- a/wxcrafter/top_level_windows/AuiToolBarTopLevel.cpp
+++ b/wxcrafter/top_level_windows/AuiToolBarTopLevel.cpp
@@ -15,36 +15,38 @@ AuiToolBarTopLevelWrapper::AuiToolBarTopLevelWrapper()
 
     SetPropertyString(_("Common Settings"), "wxAuiToolBar");
 
-    AddCategory(_("wxAuiToolBar"));
-    AddProperty(new WinIdProperty());
-    AddProperty(new StringProperty(PROP_NAME, "", _("The generated C++ class name")));
-    AddProperty(new StringProperty(PROP_SIZE, "-1,-1",
-                                   _("The control size. It is recommended to leave it as -1,-1 and "
-                                     "let\nthe sizers calculate the best size for the window")));
-    AddProperty(new StringProperty(PROP_TOOLTIP, "", _("Tooltip")));
+    Add<CategoryProperty>(_("wxAuiToolBar"));
+    Add<WinIdProperty>();
+    Add<StringProperty>(PROP_NAME, "", _("The generated C++ class name"));
+    Add<StringProperty>(PROP_SIZE,
+                        "-1,-1",
+                        _("The control size. It is recommended to leave it as -1,-1 and let\n"
+                          "the sizers calculate the best size for the window"));
+    Add<StringProperty>(PROP_TOOLTIP, "", _("Tooltip"));
 
-    AddCategory(_("Inherited C++ Class Properties"));
-    AddProperty(new StringProperty(PROP_INHERITED_CLASS, "",
-                                   _("Inherited class name\nFill this field to generate a class that inherits from the "
-                                     "base class,\nwhere you should place all your application logic.\ne.g. for a "
-                                     "generated class 'FooDialogBase', you might enter 'FooDialog' here.")));
-    AddProperty(new StringProperty(
-        PROP_FILE, "",
+    Add<CategoryProperty>(_("Inherited C++ Class Properties"));
+    Add<StringProperty>(PROP_INHERITED_CLASS,
+                        "",
+                        _("Inherited class name\nFill this field to generate a class that inherits from the "
+                          "base class,\nwhere you should place all your application logic.\ne.g. for a "
+                          "generated class 'FooDialogBase', you might enter 'FooDialog' here."));
+    Add<StringProperty>(
+        PROP_FILE,
+        "",
         _("The name for the inherited class's files (without any file extension).\nwxCrafter will generate a "
-          "$(FILE).cpp and $(FILE).hpp\ne.g. for an inherited class 'FooDialog', you might enter 'foodialog' here.")));
-    AddProperty(new StringProperty(PROP_CLASS_DECORATOR, "",
-                                   _("MSW Only\nC++ macro decorator - allows exporting this class from a DLL")));
+          "$(FILE).cpp and $(FILE).hpp\ne.g. for an inherited class 'FooDialog', you might enter 'foodialog' here."));
+    Add<StringProperty>(
+        PROP_CLASS_DECORATOR, "", _("MSW Only\nC++ macro decorator - allows exporting this class from a DLL"));
 
     if(m_properties.Contains(PROP_NAME)) {
         m_properties.Item(PROP_NAME)->SetTooltip(_("The generated C++ class name"));
     }
 
-    AddProperty(
-        new VirtualFolderProperty(PROP_VIRTUAL_FOLDER, "", _("codelite's virtual folder for the generated files")));
+    Add<VirtualFolderProperty>(PROP_VIRTUAL_FOLDER, "", _("codelite's virtual folder for the generated files"));
 
-    AddCategory(_("Control Specific Settings"));
-    AddProperty(new StringProperty(PROP_BITMAP_SIZE, "16,16", _("Sets the default size of each tool bitmap")));
-    AddProperty(new StringProperty(PROP_MARGINS, "-1,-1", _("Set the values to be used as margins for the toolbar.")));
+    Add<CategoryProperty>(_("Control Specific Settings"));
+    Add<StringProperty>(PROP_BITMAP_SIZE, "16,16", _("Sets the default size of each tool bitmap"));
+    Add<StringProperty>(PROP_MARGINS, "-1,-1", _("Set the values to be used as margins for the toolbar."));
 
     PREPEND_STYLE_FALSE(wxAUI_TB_TEXT);
     PREPEND_STYLE_FALSE(wxAUI_TB_NO_TOOLTIPS);

--- a/wxcrafter/top_level_windows/dialog_wrapper.cpp
+++ b/wxcrafter/top_level_windows/dialog_wrapper.cpp
@@ -27,12 +27,12 @@ DialogWrapper::DialogWrapper()
     DoSetPropertyStringValue(PROP_TITLE, _("My Dialog"));
     m_namePattern = wxT("MyDialog");
 
-    AddCategory(_("Dialog Icons"));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_16, wxT(""), _("Select a 16x16 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_32, wxT(""), _("Select a 32x32 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_64, wxT(""), _("Select a 64x64 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_128, wxT(""), _("Select a 128x128 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_256, wxT(""), _("Select a 256x256 bitmap")));
+    Add<CategoryProperty>(_("Dialog Icons"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_16, wxT(""), _("Select a 16x16 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_32, wxT(""), _("Select a 32x32 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_64, wxT(""), _("Select a 64x64 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_128, wxT(""), _("Select a 128x128 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_256, wxT(""), _("Select a 256x256 bitmap"));
     SetName(GenerateName());
 }
 

--- a/wxcrafter/top_level_windows/frame_wrapper.cpp
+++ b/wxcrafter/top_level_windows/frame_wrapper.cpp
@@ -36,17 +36,17 @@ FrameWrapper::FrameWrapper()
     RegisterEvent(wxT("wxEVT_ACTIVATE"), wxT("wxActivateEvent"), _("Process a wxEVT_ACTIVATE event"));
     RegisterEvent(wxT("wxEVT_ACTIVATE_APP"), wxT("wxActivateEvent"), _("Process a wxEVT_ACTIVATE_APP event"));
 
-    AddCategory(_("Frame Type"));
+    Add<CategoryProperty>(_("Frame Type"));
     const wxArrayString frameTypes = StdToWX::ToArrayString({ "wxFrame", "wxDocMDIParentFrame", "wxDocMDIChildFrame",
                                                               "wxDocParentFrame", "wxDocChildFrame", "wxMiniFrame" });
-    AddProperty(new ChoiceProperty(PROP_FRAME_TYPE, frameTypes, 0, _("Select the wxFrame type you want")));
+    Add<ChoiceProperty>(PROP_FRAME_TYPE, frameTypes, 0, _("Select the wxFrame type you want"));
 
-    AddCategory(_("Frame Icons"));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_16, wxT(""), _("Select a 16x16 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_32, wxT(""), _("Select a 32x32 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_64, wxT(""), _("Select a 64x64 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_128, wxT(""), _("Select a 128x128 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_256, wxT(""), _("Select a 256x256 bitmap")));
+    Add<CategoryProperty>(_("Frame Icons"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_16, wxT(""), _("Select a 16x16 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_32, wxT(""), _("Select a 32x32 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_64, wxT(""), _("Select a 64x64 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_128, wxT(""), _("Select a 128x128 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_256, wxT(""), _("Select a 256x256 bitmap"));
 
     m_namePattern = wxT("MyFrame");
     SetName(GenerateName());

--- a/wxcrafter/top_level_windows/image_list_wrapper.cpp
+++ b/wxcrafter/top_level_windows/image_list_wrapper.cpp
@@ -14,16 +14,15 @@ ImageListWrapper::ImageListWrapper()
     m_sizerFlags.Clear();
 
     SetPropertyString(_("Common Settings"), "wxImageList");
-    AddProperty(new CategoryProperty(_("Inherited C++ Class Properties")));
-    AddProperty(new StringProperty(PROP_NAME, "", _("The generated C++ class name")));
-    AddProperty(new StringProperty(PROP_FILE, "", _("The filenames for the generated files")));
-    AddProperty(
-        new VirtualFolderProperty(PROP_VIRTUAL_FOLDER, "", _("codelite's virtual folder for the generated files")));
-    AddProperty(new StringProperty(PROP_CLASS_DECORATOR, "",
-                                   _("MSW Only\nC++ macro decorator - allows exporting this class from a DLL")));
-    AddProperty(new CategoryProperty(_("wxImageList")));
-    AddProperty(new IntProperty(PROP_BITMAP_SIZE, 16, _("The bitmaps size")));
-    AddProperty(new BoolProperty(PROP_IMGLIST_MASK, true, _("True if masks should be created for all images")));
+    Add<CategoryProperty>(_("Inherited C++ Class Properties"));
+    Add<StringProperty>(PROP_NAME, "", _("The generated C++ class name"));
+    Add<StringProperty>(PROP_FILE, "", _("The filenames for the generated files"));
+    Add<VirtualFolderProperty>(PROP_VIRTUAL_FOLDER, "", _("codelite's virtual folder for the generated files"));
+    Add<StringProperty>(
+        PROP_CLASS_DECORATOR, "", _("MSW Only\nC++ macro decorator - allows exporting this class from a DLL"));
+    Add<CategoryProperty>(_("wxImageList"));
+    Add<IntProperty>(PROP_BITMAP_SIZE, 16, _("The bitmaps size"));
+    Add<BoolProperty>(PROP_IMGLIST_MASK, true, _("True if masks should be created for all images"));
 }
 
 ImageListWrapper::~ImageListWrapper() {}

--- a/wxcrafter/top_level_windows/wizard_wrapper.cpp
+++ b/wxcrafter/top_level_windows/wizard_wrapper.cpp
@@ -14,8 +14,7 @@ WizardWrapper::WizardWrapper()
 {
     SetPropertyString(_("Common Settings"), "wxWizard");
     DoSetPropertyStringValue(PROP_TITLE, _("My Wizard"));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH, wxT(""),
-                                         _("The default bitmap used in the left side of the wizard.")));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH, wxT(""), _("The default bitmap used in the left side of the wizard."));
 
     PREPEND_STYLE(wxDEFAULT_DIALOG_STYLE, true);
     EnableStyle(wxT("wxCLOSE_BOX"), false);
@@ -45,12 +44,12 @@ WizardWrapper::WizardWrapper()
     RegisterEvent(wxT("wxEVT_ACTIVATE"), wxT("wxActivateEvent"), _("Process a wxEVT_ACTIVATE event"));
     RegisterEvent(wxT("wxEVT_ACTIVATE_APP"), wxT("wxActivateEvent"), _("Process a wxEVT_ACTIVATE_APP event"));
 
-    AddCategory(_("Wizard Icons"));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_16, wxT(""), _("Select a 16x16 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_32, wxT(""), _("Select a 32x32 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_64, wxT(""), _("Select a 64x64 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_128, wxT(""), _("Select a 128x128 bitmap")));
-    AddProperty(new BitmapPickerProperty(PROP_BITMAP_PATH_256, wxT(""), _("Select a 256x256 bitmap")));
+    Add<CategoryProperty>(_("Wizard Icons"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_16, wxT(""), _("Select a 16x16 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_32, wxT(""), _("Select a 32x32 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_64, wxT(""), _("Select a 64x64 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_128, wxT(""), _("Select a 128x128 bitmap"));
+    Add<BitmapPickerProperty>(PROP_BITMAP_PATH_256, wxT(""), _("Select a 256x256 bitmap"));
 
     m_namePattern = wxT("MyWizard");
     SetName(GenerateName());


### PR DESCRIPTION
It is a first step before using smart pointer for `m_properties`, all allocation pass by a unique function