### PR TITLE
[cleanup] Remove extra `;` 

### DIFF
--- a/CodeLite/AsyncProcess/processreaderthread.h
+++ b/CodeLite/AsyncProcess/processreaderthread.h
@@ -69,7 +69,7 @@ public:
      * Called when the thread exits
      * whether it terminates normally or is stopped with Delete() (but not when it is Kill()'ed!)
      */
-    virtual void OnExit(){};
+    virtual void OnExit() {}
 
     /**
      * Set the window to be notified when a change was done

--- a/CodeLite/PHP/PHPEntityBase.h
+++ b/CodeLite/PHP/PHPEntityBase.h
@@ -115,7 +115,7 @@ protected:
     
 public:
     PHPEntityBase();
-    virtual ~PHPEntityBase(){};
+    virtual ~PHPEntityBase() = default;
 
     const PHPEntityBase::List_t& GetChildren() const { return m_children; }
     PHPEntityBase* Parent() const { return m_parent; }

--- a/CodeLite/database/comment.h
+++ b/CodeLite/database/comment.h
@@ -51,7 +51,7 @@ public:
 	/**
 	 * Destructor
 	 */
-	virtual ~Comment() {};
+	virtual ~Comment() = default;
 
 	/// assignment operator
 	Comment& operator=(const Comment& rhs);

--- a/CodeLite/database/istorage.h
+++ b/CodeLite/database/istorage.h
@@ -63,7 +63,7 @@ public:
     {
     }
 
-    virtual ~ITagsStorage(){};
+    virtual ~ITagsStorage() = default;
     virtual void SetEnableCaseInsensitive(bool b) { m_enableCaseInsensitive = b; }
     virtual void SetUseCache(bool useCache) { this->m_useCache = useCache; }
 

--- a/CodeLite/worker_thread.h
+++ b/CodeLite/worker_thread.h
@@ -41,8 +41,8 @@
 class WXDLLIMPEXP_CL ThreadRequest
 {
 public:
-    ThreadRequest(){};
-    virtual ~ThreadRequest(){};
+    ThreadRequest() = default;
+    virtual ~ThreadRequest() = default;
 };
 
 /**
@@ -77,7 +77,7 @@ public:
      * Called when the thread exits
      * whether it terminates normally or is stopped with Delete() (but not when it is Kill()'ed!)
      */
-    virtual void OnExit(){};
+    virtual void OnExit() {}
 
     /**
      * Add a request to the worker thread

--- a/LiteEditor/context_base.h
+++ b/LiteEditor/context_base.h
@@ -116,7 +116,7 @@ public:
     // functions with default implementation:
     virtual bool IsDefaultContext() const { return true; }
     virtual void OnCallTipClick(wxStyledTextEvent& event) { event.Skip(); }
-    virtual void OnCalltipCancel(){};
+    virtual void OnCalltipCancel() {}
     virtual void OnDwellEnd(wxStyledTextEvent& event) { event.Skip(); }
     virtual void OnDbgDwellEnd(wxStyledTextEvent& event) { event.Skip(); }
     virtual void OnDbgDwellStart(wxStyledTextEvent& event) { event.Skip(); }

--- a/LiteEditor/cpp_symbol_tree.h
+++ b/LiteEditor/cpp_symbol_tree.h
@@ -43,7 +43,7 @@ public:
                   const wxSize& size = wxDefaultSize, long style = wxTR_HIDE_ROOT | wxTR_HAS_BUTTONS);
 
     /// destructor
-    virtual ~CppSymbolTree(){};
+    ~CppSymbolTree() override = default;
     
     /**
      * @brief emulate user activated the selected item

--- a/LiteEditor/generic_context.h
+++ b/LiteEditor/generic_context.h
@@ -50,9 +50,13 @@ public:
     //---------------------------------------
     ContextGeneric(clEditor* container, const wxString& name);
     ContextGeneric()
-        : ContextBase(wxT("Text")){};
+        : ContextBase(wxT("Text"))
+    {
+    }
     ContextGeneric(const wxString& name)
-        : ContextBase(name){};
+        : ContextBase(name)
+    {
+    }
 
     virtual ~ContextGeneric();
     virtual ContextBase* NewInstance(clEditor* container);

--- a/LiteEditor/menu_event_handlers.h
+++ b/LiteEditor/menu_event_handlers.h
@@ -38,9 +38,11 @@ protected:
     int m_id;
 
 public:
-    MenuEventHandler(int id)
-        : m_id(id){};
-    virtual ~MenuEventHandler(){};
+    explicit MenuEventHandler(int id)
+        : m_id(id)
+    {
+    }
+    virtual ~MenuEventHandler() = default;
 
     // handle an event
     virtual void ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event) = 0;
@@ -63,9 +65,11 @@ using MenuEventHandlerPtr = std::shared_ptr<MenuEventHandler>;
 class EditHandler : public MenuEventHandler
 {
 public:
-    EditHandler(int id)
-        : MenuEventHandler(id){};
-    virtual ~EditHandler(){};
+    explicit EditHandler(int id)
+        : MenuEventHandler(id)
+    {
+    }
+    ~EditHandler() override = default;
 
 public:
     virtual void ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event);
@@ -78,9 +82,11 @@ public:
 class BraceMatchHandler : public MenuEventHandler
 {
 public:
-    BraceMatchHandler(int id)
-        : MenuEventHandler(id){};
-    virtual ~BraceMatchHandler(){};
+    explicit BraceMatchHandler(int id)
+        : MenuEventHandler(id)
+    {
+    }
+    ~BraceMatchHandler() override = default;
 
 public:
     virtual void ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event);
@@ -88,14 +94,16 @@ public:
 };
 
 //------------------------------------
-// Find / Repalce
+// Find / Replace
 //------------------------------------
 class FindReplaceHandler : public MenuEventHandler
 {
 public:
-    FindReplaceHandler(int id)
-        : MenuEventHandler(id){};
-    virtual ~FindReplaceHandler(){};
+    explicit FindReplaceHandler(int id)
+        : MenuEventHandler(id)
+    {
+    }
+    ~FindReplaceHandler() override = default;
 
 public:
     virtual void ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event);
@@ -108,9 +116,11 @@ public:
 class GotoHandler : public MenuEventHandler
 {
 public:
-    GotoHandler(int id)
-        : MenuEventHandler(id){};
-    virtual ~GotoHandler(){};
+    explicit GotoHandler(int id)
+        : MenuEventHandler(id)
+    {
+    }
+    ~GotoHandler() override = default;
 
 public:
     virtual void ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event);
@@ -123,9 +133,11 @@ public:
 class BookmarkHandler : public MenuEventHandler
 {
 public:
-    BookmarkHandler(int id)
-        : MenuEventHandler(id){};
-    virtual ~BookmarkHandler(){};
+    explicit BookmarkHandler(int id)
+        : MenuEventHandler(id)
+    {
+    }
+    ~BookmarkHandler() override = default;
 
 public:
     virtual void ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event);
@@ -138,9 +150,11 @@ public:
 class GotoDefinitionHandler : public MenuEventHandler
 {
 public:
-    GotoDefinitionHandler(int id)
-        : MenuEventHandler(id){};
-    virtual ~GotoDefinitionHandler(){};
+    explicit GotoDefinitionHandler(int id)
+        : MenuEventHandler(id)
+    {
+    }
+    ~GotoDefinitionHandler() override = default;
 
 public:
     virtual void ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event);
@@ -153,9 +167,11 @@ public:
 class WordWrapHandler : public MenuEventHandler
 {
 public:
-    WordWrapHandler(int id)
-        : MenuEventHandler(id){};
-    virtual ~WordWrapHandler(){};
+    explicit WordWrapHandler(int id)
+        : MenuEventHandler(id)
+    {
+    }
+    ~WordWrapHandler() override = default;
 
 public:
     virtual void ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event);
@@ -168,9 +184,11 @@ public:
 class FoldHandler : public MenuEventHandler
 {
 public:
-    FoldHandler(int id)
-        : MenuEventHandler(id){};
-    virtual ~FoldHandler(){};
+    explicit FoldHandler(int id)
+        : MenuEventHandler(id)
+    {
+    }
+    ~FoldHandler() override = default;
 
 public:
     virtual void ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event);
@@ -183,9 +201,11 @@ public:
 class DebuggerMenuHandler : public MenuEventHandler
 {
 public:
-    DebuggerMenuHandler(int id)
-        : MenuEventHandler(id){};
-    virtual ~DebuggerMenuHandler(){};
+    explicit DebuggerMenuHandler(int id)
+        : MenuEventHandler(id)
+    {
+    }
+    ~DebuggerMenuHandler() override = default;
 
 public:
     virtual void ProcessCommandEvent(wxWindow* owner, wxCommandEvent& event);

--- a/MemCheck/imemcheckprocessor.h
+++ b/MemCheck/imemcheckprocessor.h
@@ -56,9 +56,11 @@ public:
     IMemCheckProcessor(MemCheckSettings* const settings)
         : m_settings(settings)
         , m_outputLogFileName(wxEmptyString)
-        , m_errorList(){};
+        , m_errorList()
+    {
+    }
 
-    virtual ~IMemCheckProcessor() {}
+    virtual ~IMemCheckProcessor() = default;
 
 protected:
     MemCheckSettings* m_settings;

--- a/MemCheck/memcheckerror.h
+++ b/MemCheck/memcheckerror.h
@@ -61,10 +61,12 @@ class MemCheckErrorReferrer: public wxClientData
 {
     MemCheckError & m_error;
 public:
-    MemCheckErrorReferrer(MemCheckError & error) : wxClientData(), m_error(error) {};
-    MemCheckError & Get() {
-        return m_error;
-    };
+    explicit MemCheckErrorReferrer(MemCheckError& error)
+        : wxClientData()
+        , m_error(error)
+    {
+    }
+    MemCheckError& Get() { return m_error; }
 };
 
 /**
@@ -75,12 +77,14 @@ public:
  */
 class MemCheckErrorLocationReferrer: public wxClientData
 {
-    MemCheckErrorLocation & m_location;
+    MemCheckErrorLocation& m_location;
+
 public:
-    MemCheckErrorLocationReferrer(MemCheckErrorLocation & location) : m_location(location) {};
-    MemCheckErrorLocation & Get() {
-        return m_location;
-    };
+    explicit MemCheckErrorLocationReferrer(MemCheckErrorLocation& location)
+        : m_location(location)
+    {
+    }
+    MemCheckErrorLocation& Get() { return m_location; }
 };
 
 

--- a/MemCheck/memchecklistctrlerrors.h
+++ b/MemCheck/memchecklistctrlerrors.h
@@ -45,15 +45,17 @@
 class MemCheckListCtrlErrors: public wxListCtrl
 {
 public:
-    MemCheckListCtrlErrors(wxWindow *parent,
+    MemCheckListCtrlErrors(wxWindow* parent,
                            wxWindowID id,
-                           const wxPoint &pos = wxDefaultPosition,
-                           const wxSize &size = wxDefaultSize,
+                           const wxPoint& pos = wxDefaultPosition,
+                           const wxSize& size = wxDefaultSize,
                            long style = wxLC_ICON,
-                           const wxValidator &validator = wxDefaultValidator,
-                           const wxString &name = wxListCtrlNameStr) :
-        wxListCtrl(parent, id, pos, size, style, validator, name) {};
-    virtual ~MemCheckListCtrlErrors() {};
+                           const wxValidator& validator = wxDefaultValidator,
+                           const wxString& name = wxListCtrlNameStr)
+        : wxListCtrl(parent, id, pos, size, style, validator, name)
+    {
+    }
+    ~MemCheckListCtrlErrors() override = default;
 
     virtual wxString OnGetItemText(long item, long column) const {
         return m_data->at(item)->label;

--- a/Plugin/configuration_object.h
+++ b/Plugin/configuration_object.h
@@ -43,8 +43,8 @@ class wxXmlNode;
 class WXDLLIMPEXP_LE_SDK ConfObject
 {
 public:
-    ConfObject(){};
-    virtual ~ConfObject() {}
+    ConfObject() = default;
+    virtual ~ConfObject() = default;
 
     virtual wxXmlNode* ToXml() const = 0;
 };

--- a/Subversion2/svn_command_handlers.h
+++ b/Subversion2/svn_command_handlers.h
@@ -36,8 +36,11 @@
 class SvnCommitHandler : public SvnDefaultCommandHandler
 {
 public:
-    SvnCommitHandler(Subversion2 *plugin, int commandId, wxEvtHandler *owner) : SvnDefaultCommandHandler(plugin, commandId, owner) {};
-    virtual ~SvnCommitHandler() {};
+    SvnCommitHandler(Subversion2* plugin, int commandId, wxEvtHandler* owner)
+        : SvnDefaultCommandHandler(plugin, commandId, owner)
+    {
+    }
+    ~SvnCommitHandler() override = default;
 
 public:
     virtual void Process(const wxString &output);
@@ -51,8 +54,11 @@ class SvnUpdateHandler : public SvnDefaultCommandHandler
 {
 
 public:
-    SvnUpdateHandler(Subversion2 *plugin, int commandId, wxEvtHandler *owner) : SvnDefaultCommandHandler(plugin, commandId, owner) {};
-    virtual ~SvnUpdateHandler() {};
+    SvnUpdateHandler(Subversion2* plugin, int commandId, wxEvtHandler* owner)
+        : SvnDefaultCommandHandler(plugin, commandId, owner)
+    {
+    }
+    ~SvnUpdateHandler() override = default;
 
 public:
     virtual void Process(const wxString &output);
@@ -66,8 +72,11 @@ class SvnDiffHandler : public SvnDefaultCommandHandler
 {
 
 public:
-    SvnDiffHandler(Subversion2 *plugin, int commandId, wxEvtHandler *owner) : SvnDefaultCommandHandler(plugin, commandId, owner) {};
-    virtual ~SvnDiffHandler() {};
+    SvnDiffHandler(Subversion2* plugin, int commandId, wxEvtHandler* owner)
+        : SvnDefaultCommandHandler(plugin, commandId, owner)
+    {
+    }
+    ~SvnDiffHandler() override = default;
 
 public:
     virtual void Process(const wxString &output);
@@ -82,12 +91,13 @@ class SvnPatchHandler : public SvnDefaultCommandHandler
     bool     delFileWhenDone;
     wxString patchFile;
 public:
-    SvnPatchHandler(Subversion2 *plugin, int commandId, wxEvtHandler *owner, bool d, const wxString &pf)
+    SvnPatchHandler(Subversion2* plugin, int commandId, wxEvtHandler* owner, bool d, const wxString& pf)
         : SvnDefaultCommandHandler(plugin, commandId, owner)
         , delFileWhenDone(d)
         , patchFile(pf)
-    {};
-    virtual ~SvnPatchHandler() {};
+    {
+    }
+    ~SvnPatchHandler() override = default;
 
 public:
     virtual void Process(const wxString &output);
@@ -103,12 +113,13 @@ class SvnPatchDryRunHandler : public SvnDefaultCommandHandler
     wxString patchFile;
 
 public:
-    SvnPatchDryRunHandler(Subversion2 *plugin, int commandId, wxEvtHandler *owner, bool d, const wxString &pf)
+    SvnPatchDryRunHandler(Subversion2* plugin, int commandId, wxEvtHandler* owner, bool d, const wxString& pf)
         : SvnDefaultCommandHandler(plugin, commandId, owner)
         , delFileWhenDone(d)
         , patchFile(pf)
-    {}
-    virtual ~SvnPatchDryRunHandler() {};
+    {
+    }
+    ~SvnPatchDryRunHandler() override = default;
 
 public:
     virtual void Process(const wxString &output);
@@ -122,8 +133,11 @@ class SvnVersionHandler : public SvnDefaultCommandHandler
 {
 
 public:
-    SvnVersionHandler(Subversion2 *plugin, int commandId, wxEvtHandler *owner) : SvnDefaultCommandHandler(plugin, commandId, owner) {};
-    virtual ~SvnVersionHandler() {};
+    SvnVersionHandler(Subversion2* plugin, int commandId, wxEvtHandler* owner)
+        : SvnDefaultCommandHandler(plugin, commandId, owner)
+    {
+    }
+    ~SvnVersionHandler() override = default;
 
 public:
     virtual void Process(const wxString &output);
@@ -160,8 +174,11 @@ public:
 class SvnCheckoutHandler : public SvnDefaultCommandHandler
 {
 public:
-    SvnCheckoutHandler(Subversion2 *plugin, int commandId, wxEvtHandler *owner) : SvnDefaultCommandHandler(plugin, commandId, owner) {};
-    virtual ~SvnCheckoutHandler() {};
+    SvnCheckoutHandler(Subversion2* plugin, int commandId, wxEvtHandler* owner)
+        : SvnDefaultCommandHandler(plugin, commandId, owner)
+    {
+    }
+    ~SvnCheckoutHandler() override = default;
 
 public:
     virtual void Process(const wxString &output);
@@ -175,11 +192,12 @@ class SvnBlameHandler : public SvnCommandHandler
 {
     wxString m_filename;
 public:
-    SvnBlameHandler(Subversion2 *plugin, int commandId, wxEvtHandler *owner, const wxString &filename) 
-        : SvnCommandHandler(plugin, commandId, owner) 
+    SvnBlameHandler(Subversion2* plugin, int commandId, wxEvtHandler* owner, const wxString& filename)
+        : SvnCommandHandler(plugin, commandId, owner)
         , m_filename(filename)
-    {}
-    virtual ~SvnBlameHandler() {};
+    {
+    }
+    ~SvnBlameHandler() override = default;
 
 public:
     virtual void Process(const wxString &output);
@@ -197,15 +215,21 @@ class SvnRepoListHandler : public SvnDefaultCommandHandler
     wxString m_excludeExtensions;
 
 public:
-    SvnRepoListHandler(Subversion2 *plugin,
-                       ProjectPtr proj, const wxString& workDir, bool excludeBin, const wxString& excludeExtensions,
-                       int commandId, wxEvtHandler *owner) : SvnDefaultCommandHandler(plugin, commandId, owner)
+    SvnRepoListHandler(Subversion2* plugin,
+                       ProjectPtr proj,
+                       const wxString& workDir,
+                       bool excludeBin,
+                       const wxString& excludeExtensions,
+                       int commandId,
+                       wxEvtHandler* owner)
+        : SvnDefaultCommandHandler(plugin, commandId, owner)
         , m_proj(proj)
         , m_workDir(workDir)
         , m_excludeBin(excludeBin)
         , m_excludeExtensions(excludeExtensions)
-    {};
-    virtual ~SvnRepoListHandler() {};
+    {
+    }
+    ~SvnRepoListHandler() override = default;
 
 public:
     virtual void Process(const wxString &output);

--- a/cscope/cscopedbbuilderthread.h
+++ b/cscope/cscopedbbuilderthread.h
@@ -50,7 +50,7 @@ typedef std::map<wxString, CScopeEntryDataVec_t*> CScopeResultTable_t;
  */
 class CscopeRequest : public ThreadRequest
 {
-    wxEvtHandler* m_owner;
+    wxEvtHandler* m_owner = nullptr;
     wxString m_cmd;
     wxString m_workingDir;
     wxString m_outfile;
@@ -58,8 +58,8 @@ class CscopeRequest : public ThreadRequest
     wxString m_findWhat;
 
 public:
-    CscopeRequest(){};
-    ~CscopeRequest(){};
+    CscopeRequest() = default;
+    ~CscopeRequest() override = default;
 
     // Setters
     void SetCmd(const wxString& cmd) { this->m_cmd = cmd; }


### PR DESCRIPTION
(use `= default`, `explicit`, `override` on touched lines when appropriate)