### PR TITLE
[CI][MacOS] update to wxWidgets v3.2.8

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/checkout@v4
       with:
           repository: wxWidgets/wxWidgets
-          ref: v3.2.5
+          ref: v3.2.8
           submodules: recursive
           path: wxWidgets
 


### PR DESCRIPTION
builtin libpng of wxWidgets has issue with recent MacOS (which remove `<fp.h>`)
Related to https://github.com/wxWidgets/wxWidgets/issues/24590