### PR TITLE
Fix Linux clang/gcc compile error - include optional

### DIFF
--- a/Plugin/FileManager.hpp
+++ b/Plugin/FileManager.hpp
@@ -2,6 +2,7 @@
 
 #include "codelite_exports.h"
 
+#include <optional>
 #include <wx/string.h>
 
 /// Helper class for managing the file system. The class is workspace aware. What does that mean? if a user requests to


### PR DESCRIPTION
```
In file included from /tmp/Plugin/FileManager.cpp:1: /tmp/Plugin/FileManager.hpp:33:17: error: no template named 'optional' in namespace 'std'
   33 |     static std::optional<wxString> ReadContent(const wxString& filepath, const wxMBConv& conv = wxConvUTF8);
      |            ~~~~~^
/tmp/Plugin/FileManager.hpp:34:17: error: no template named 'optional' in namespace 'std'
   34 |     static std::optional<wxString> ReadSettingsFileContent(const wxString& name);
      |            ~~~~~^
2 errors generated.
```