### PR TITLE
Fix compile errors - missing #include <mutex>

### DIFF
--- a/Plugin/ai/LLMManager.hpp
+++ b/Plugin/ai/LLMManager.hpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Fix compile errors - missing #include  \<mutex\>

```
/tmp/codelite-devel.git/Plugin/ai/LLMManager.hpp: In member function ‘wxArrayString llm::Manager::GetModels() const’:
/tmp/codelite-devel.git/Plugin/ai/LLMManager.hpp:190:14: error: ‘unique_lock’ is not a member of ‘std’
  190 |         std::unique_lock lk{m_models_mutex};
      |              ^~~~~~~~~~~

/tmp/codelite-devel.git/Plugin/ai/LLMManager.hpp: In member function ‘void llm::Manager::SetModels(const wxArrayString&, wxString)’:
/tmp/codelite-devel.git/Plugin/ai/LLMManager.hpp:197:14: error: ‘unique_lock’ is not a member of ‘std’
  197 |         std::unique_lock lk{m_models_mutex};
      |              ^~~~~~~~~~~

/tmp/codelite-devel.git/Plugin/ai/LLMManager.hpp: In member function ‘wxString llm::Manager::GetActiveModel() const’:
/tmp/codelite-devel.git/Plugin/ai/LLMManager.hpp:204:14: error: ‘unique_lock’ is not a member of ‘std’
  204 |         std::unique_lock lk{m_models_mutex};
      |              ^~~~~~~~~~~
```