### PR TITLE
CMake: Change CMAKE_INSTALL_PREFIX cache type to PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if(UNIX AND NOT APPLE)
     # that..
     set(CMAKE_INSTALL_PREFIX
         "/usr"
-        CACHE ON "Install prefix" FORCE)
+        CACHE PATH "Install prefix" FORCE)
   endif()
 endif()
 


### PR DESCRIPTION
Configuring codelite with CMake prints this message on the console:
```
CMake Warning (dev) at CMakeLists.txt:71 (set):
  implicitly converting 'ON' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
This warning looks correct to me.
The right type to apply to that `set()` statement should be `PATH`, in my opinion.