### PR TITLE
CMake: MemCheck: use cl_install_plugin() for installation

### DIFF
--- a/MemCheck/CMakeLists.txt
+++ b/MemCheck/CMakeLists.txt
@@ -30,6 +30,6 @@ if(UNIX AND NOT APPLE)
 
     # Make sure that the plugin will not start build before 'plugin.so' is ready
     add_dependencies(${PLUGIN_NAME} plugin)
-    install(TARGETS ${PLUGIN_NAME} DESTINATION ${PLUGINS_DIR})
+    cl_install_plugin(${PLUGIN_NAME})
 
 endif()


### PR DESCRIPTION
Installation of MemCheck failed with CYGWIN.
By looking CMakeLists.txt, the plugin is installed by calling `install()` instead of `cl_install_plugin()`.
I fixed that line and now it is installed correctly.