### PR TITLE
Fix build and installation on CYGWIN

### DIFF
--- a/CodeLite/AsyncProcess/UnixProcess.cpp
+++ b/CodeLite/AsyncProcess/UnixProcess.cpp
@@ -9,7 +9,9 @@
 #include <string.h>
 #include <sys/select.h>
 #include <sys/types.h>
+#ifndef __CYGWIN__
 #include <sys/syscall.h>
+#endif
 
 UnixProcess::UnixProcess(wxEvtHandler* owner, const wxArrayString& args)
     : m_owner(owner)

--- a/CodeLite/CMakeLists.txt
+++ b/CodeLite/CMakeLists.txt
@@ -114,7 +114,7 @@ if(USE_PCH)
   codelite_add_pch(libcodelite)
 endif()
 
-if(NOT MINGW)
+if(NOT MINGW AND NOT CYGWIN)
   if(APPLE)
     install(TARGETS libcodelite
             DESTINATION ${CMAKE_BINARY_DIR}/codelite.app/Contents/MacOS/)

--- a/LiteEditor/CMakeLists.txt
+++ b/LiteEditor/CMakeLists.txt
@@ -361,7 +361,7 @@ endif()
 
 # generate PostInstall.cmake script
 set(POST_INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/post_install.cmake")
-if(MINGW)
+if(MINGW OR CYGWIN)
     message(STATUS "Generating post_install.cmake script")
     # on MinGW, we do not want to include PluginName.dll.a files
     write_file(${POST_INSTALL_SCRIPT} "file(GLOB FILES_TO_REMOVE \"${CL_INSTALL_BIN}/plugins/*.a\")")

--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -114,7 +114,7 @@ if(USE_PCH)
   codelite_add_pch(plugin)
 endif()
 
-if(NOT MINGW)
+if(NOT MINGW AND NOT CYGWIN)
   if(APPLE)
     install(TARGETS plugin
             DESTINATION ${CMAKE_BINARY_DIR}/codelite.app/Contents/MacOS/)

--- a/cmake/Modules/OSXInstall.cmake
+++ b/cmake/Modules/OSXInstall.cmake
@@ -44,7 +44,10 @@ macro(CL_INSTALL_PLUGIN _target_)
       DESTINATION
         ${CMAKE_BINARY_DIR}/codelite.app/Contents/SharedSupport/plugins)
   else()
-    install(TARGETS ${_target_} DESTINATION ${PLUGINS_DIR})
+    install(TARGETS ${_target_}
+      # Under Windows (MinGW/CYGWIN), avoid to install import libraries
+      RUNTIME DESTINATION ${PLUGINS_DIR}
+      LIBRARY DESTINATION ${PLUGINS_DIR})
   endif()
 endmacro()
 

--- a/cmake/Modules/UtilsHelper.cmake
+++ b/cmake/Modules/UtilsHelper.cmake
@@ -227,12 +227,12 @@ macro(codelite_install_library_target TARGET)
   if(APPLE)
     install(TARGETS ${TARGET}
             DESTINATION ${CMAKE_BINARY_DIR}/codelite.app/Contents/MacOS/)
-  elseif(MINGW)
-    # under windows (MinGW) we install libraries under the "bin" folder
-    install(TARGETS ${TARGET} DESTINATION "${CL_INSTALL_BIN}")
   else()
-    # Under linux, we install libraries in the plugins directory
-    install(TARGETS ${TARGET} DESTINATION ${PLUGINS_DIR})
+    install(TARGETS ${TARGET}
+            # under Windows (MinGW/CYGWIN) we install libraries under the "bin" folder
+            RUNTIME DESTINATION "${CL_INSTALL_BIN}"
+            # Under linux, we install libraries in the plugins directory
+            LIBRARY DESTINATION ${PLUGINS_DIR})
   endif()
 endmacro()
 

--- a/sdk/wxsqlite3/CMakeLists.txt
+++ b/sdk/wxsqlite3/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 target_link_libraries(wxsqlite3 ${LINKER_OPTIONS} ${wxWidgets_LIBRARIES} -L"${CL_LIBPATH}" ${SQLite3_LIBRARIES})
 
-if(NOT MINGW)
+if(NOT MINGW AND NOT CYGWIN)
     if(APPLE)
         install(TARGETS wxsqlite3 DESTINATION ${CMAKE_BINARY_DIR}/codelite.app/Contents/MacOS/)
     else()


### PR DESCRIPTION
This PR fixes the last bits for building and installing Codelite for CYGWIN.
This commit to wxdap is also important:
https://github.com/eranif/wxdap/pull/18
and the link to the submodule needs to be updated for including it in the future.

Compiling Codelite for CYGWIN is very similar to the guidelines for linux.
After installing needed development libraries, the build tools and the X server with setup utility, you can clone the sources:
```
git clone https://github.com/eranif/codelite.git
cd codelite
git submodule update --init --recursive
```
Next, you can perform the build with these commands
```
mkdir build-release
cd build-release
cmake .. -DCMAKE_BUILD_TYPE=Release -G Ninja -DCMAKE_INSTALL_PREFIX=${HOME)/inst_codelite_wx32 -DCMAKE_C_FLAGS="-D_GNU_SOURCE" -DCMAKE_CXX_FLAGS="-D_GNU_SOURCE" -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--export-all-symbols"
ninja
```
Here, I used ninja but you can also use the traditional GNU make tool, if you want.
Finally, when the build process completes, you can install the binaries with:
```
ninja install
```
Now that you installed Codelite, you can run the X server with the following commands:
```
export DISPLAY=:0.0
XWin -multiwindow &
```
and run Codelite:
```
cd ${HOME)/inst_codelite_wx32/bin
./codelite
```
and after few seconds the IDE will appear on your screen:

<img width="989" height="695" alt="codelite" src="https://github.com/user-attachments/assets/7f7ca61f-ec30-409d-80d1-d65182944cc2" />

Thank you very much for making this possible.
Sincerely,

Carlo Bramini.