### PR TITLE
Fix compilation with msvc

### DIFF
--- a/CodeLite/Cxx/include_finder.l
+++ b/CodeLite/Cxx/include_finder.l
@@ -37,6 +37,7 @@ static std::string currentFile;
 %}
 
 %option yylineno
+%option never-interactive
 
 %%
 


### PR DESCRIPTION
Without `%option never-interactive`, `isatty` is added in generated code, unsupported by msvc