### PR TITLE
Fix build for GCC

### DIFF
--- a/CodeLite/winprocess.h
+++ b/CodeLite/winprocess.h
@@ -29,6 +29,7 @@
 
 #include <wx/msw/wrapwin.h> // includes windows.h
 #include <wx/string.h>
+#include <limits> // Required for std::numeric_limits
 
 class WinProcess
 {


### PR DESCRIPTION
I build under MSys2 MinGW UCRT64 with other patches needed to build; but this patch is needed for GCC to fix an error caused by missing include.

Tim S.