### PR TITLE
Remove "WXDLLIMPEXP_SDK" in forward class declarations it causes

### DIFF
--- a/Plugin/clWorkspaceManager.h
+++ b/Plugin/clWorkspaceManager.h
@@ -66,7 +66,7 @@ public:
 };
 
 /// A convenience class with common implementation for local workspace (i.e. non remote)
-class WXDLLIMPEXP_SDK IEditor;
+class IEditor;
 class WXDLLIMPEXP_SDK LocalWorkspaceCommon : public IWorkspace
 {
 public:


### PR DESCRIPTION
warnings under GCC and CLANG when I am building using MSys2  wxWidgets package via my custom build steps and other patches.