### PR TITLE
[cleanup] Clean up `ContextBase`'s hierarchy:

### DIFF
--- a/LiteEditor/ContextJavaScript.cpp
+++ b/LiteEditor/ContextJavaScript.cpp
@@ -177,8 +177,6 @@ wxMenu* ContextJavaScript::GetMenu() { return ContextBase::GetMenu(); }
 
 TagEntryPtr ContextJavaScript::GetTagAtCaret(bool scoped, bool impl) { return NULL; }
 
-void ContextJavaScript::GotoPreviousDefintion() {}
-
 bool ContextJavaScript::IsCommentOrString(long pos)
 {
     int style = GetCtrl().GetStyleAt(pos);
@@ -187,7 +185,10 @@ bool ContextJavaScript::IsCommentOrString(long pos)
 
 bool ContextJavaScript::IsDefaultContext() const { return false; }
 
-ContextBase* ContextJavaScript::NewInstance(clEditor* container) { return new ContextJavaScript(container); }
+std::shared_ptr<ContextBase> ContextJavaScript::NewInstance(clEditor* container)
+{
+    return std::make_shared<ContextJavaScript>(container);
+}
 
 void ContextJavaScript::OnCallTipClick(wxStyledTextEvent& event) {}
 
@@ -198,8 +199,6 @@ void ContextJavaScript::OnDbgDwellEnd(wxStyledTextEvent& event) {}
 void ContextJavaScript::OnDbgDwellStart(wxStyledTextEvent& event) {}
 
 void ContextJavaScript::OnDwellEnd(wxStyledTextEvent& event) {}
-
-void ContextJavaScript::OnDwellStart(wxStyledTextEvent& event) {}
 
 void ContextJavaScript::OnEnterHit() {}
 
@@ -249,7 +248,7 @@ void ContextJavaScript::SemicolonShift()
 
 void ContextJavaScript::SetActive() {}
 
-bool ContextJavaScript::IsComment(long pos)
+bool ContextJavaScript::IsComment(long pos) const
 {
     int style = GetCtrl().GetStyleAt(pos);
     return style == wxSTC_C_COMMENT || style == wxSTC_C_COMMENTDOC || style == wxSTC_C_COMMENTDOCKEYWORD ||

--- a/LiteEditor/ContextJavaScript.h
+++ b/LiteEditor/ContextJavaScript.h
@@ -31,40 +31,39 @@ class ContextJavaScript : public ContextBase
 {
 public:
     ContextJavaScript();
-    ContextJavaScript(clEditor* Editor);
-    virtual ~ContextJavaScript() = default;
+    explicit ContextJavaScript(clEditor* Editor);
+    ~ContextJavaScript() override = default;
 
 public:
-    virtual int GetActiveKeywordSet() const;
-    virtual int DoGetCalltipParamterIndex();
-    virtual wxMenu* GetMenu();
-    virtual void AddMenuDynamicContent(wxMenu* menu);
-    virtual void ApplySettings();
-    virtual void AutoIndent(const wxChar&);
-    virtual wxString CallTipContent();
-    virtual wxString GetCurrentScopeName();
-    virtual TagEntryPtr GetTagAtCaret(bool scoped, bool impl);
-    virtual void GotoPreviousDefintion();
-    virtual bool IsComment(long pos);
-    virtual bool IsCommentOrString(long pos);
-    virtual bool IsDefaultContext() const;
-    virtual ContextBase* NewInstance(clEditor* container);
-    virtual void OnCallTipClick(wxStyledTextEvent& event);
-    virtual void OnCalltipCancel();
-    virtual void OnDbgDwellEnd(wxStyledTextEvent& event);
-    virtual void OnDbgDwellStart(wxStyledTextEvent& event);
-    virtual void OnDwellEnd(wxStyledTextEvent& event);
-    virtual void OnDwellStart(wxStyledTextEvent& event);
-    virtual void OnEnterHit();
-    virtual void OnFileSaved();
-    virtual void OnKeyDown(wxKeyEvent& event);
-    virtual void OnSciUpdateUI(wxStyledTextEvent& event);
-    virtual void RemoveMenuDynamicContent(wxMenu* menu);
-    virtual void RetagFile();
-    virtual void SemicolonShift();
-    virtual void SetActive();
-    virtual bool IsAtBlockComment() const;
-    virtual bool IsAtLineComment() const;
+    int GetActiveKeywordSet() const override;
+    int DoGetCalltipParamterIndex() override;
+    wxMenu* GetMenu() override;
+    void AddMenuDynamicContent(wxMenu* menu) override;
+    void ApplySettings() override;
+    void AutoIndent(const wxChar&) override;
+    wxString CallTipContent() override;
+    wxString GetCurrentScopeName() override;
+    TagEntryPtr GetTagAtCaret(bool scoped, bool impl) override;
+    bool IsCommentOrString(long pos) override;
+    bool IsDefaultContext() const override;
+    std::shared_ptr<ContextBase> NewInstance(clEditor* container) override;
+    void OnCallTipClick(wxStyledTextEvent& event) override;
+    void OnCalltipCancel() override;
+    void OnDbgDwellEnd(wxStyledTextEvent& event) override;
+    void OnDbgDwellStart(wxStyledTextEvent& event) override;
+    void OnDwellEnd(wxStyledTextEvent& event) override;
+    void OnEnterHit() override;
+    void OnFileSaved() override;
+    void OnKeyDown(wxKeyEvent& event) override;
+    void OnSciUpdateUI(wxStyledTextEvent& event) override;
+    void RemoveMenuDynamicContent(wxMenu* menu) override;
+    void RetagFile() override;
+    void SemicolonShift() override;
+    void SetActive() override;
+    bool IsAtBlockComment() const override;
+    bool IsAtLineComment() const override;
+
+    bool IsComment(long pos) const;
 };
 
 #endif // CONTEXTJAVASCRIPT_H

--- a/LiteEditor/ContextPhp.cpp
+++ b/LiteEditor/ContextPhp.cpp
@@ -220,8 +220,6 @@ wxMenu* ContextPhp::GetMenu() { return ContextBase::GetMenu(); }
 
 TagEntryPtr ContextPhp::GetTagAtCaret(bool scoped, bool impl) { return NULL; }
 
-void ContextPhp::GotoPreviousDefintion() {}
-
 bool ContextPhp::IsCommentOrString(long pos)
 {
     int style = GetCtrl().GetStyleAt(pos);
@@ -236,7 +234,10 @@ bool ContextPhp::IsCommentOrString(long pos)
 
 bool ContextPhp::IsDefaultContext() const { return false; }
 
-ContextBase* ContextPhp::NewInstance(clEditor* container) { return new ContextPhp(container); }
+std::shared_ptr<ContextBase> ContextPhp::NewInstance(clEditor* container)
+{
+    return std::make_shared<ContextPhp>(container);
+}
 
 void ContextPhp::OnCallTipClick(wxStyledTextEvent& event) {}
 
@@ -247,8 +248,6 @@ void ContextPhp::OnDbgDwellEnd(wxStyledTextEvent& event) {}
 void ContextPhp::OnDbgDwellStart(wxStyledTextEvent& event) {}
 
 void ContextPhp::OnDwellEnd(wxStyledTextEvent& event) {}
-
-void ContextPhp::OnDwellStart(wxStyledTextEvent& event) {}
 
 void ContextPhp::OnEnterHit() {}
 
@@ -299,7 +298,7 @@ void ContextPhp::SemicolonShift()
 
 void ContextPhp::SetActive() {}
 
-bool ContextPhp::IsComment(long pos)
+bool ContextPhp::IsComment(long pos) const
 {
     int style = GetCtrl().GetStyleAt(pos);
     return style == wxSTC_H_COMMENT || style == wxSTC_H_XCCOMMENT || style == wxSTC_H_SGML_COMMENT ||

--- a/LiteEditor/ContextPhp.h
+++ b/LiteEditor/ContextPhp.h
@@ -32,43 +32,41 @@ class ContextPhp : public ContextGeneric
 {
 public:
     ContextPhp();
-    ContextPhp(clEditor *Editor);
-    virtual ~ContextPhp() = default;
+    explicit ContextPhp(clEditor *Editor);
+    ~ContextPhp() override = default;
 
 public:
-    bool IsStringTriggerCodeComplete(const wxString& str) const;
-    virtual int GetActiveKeywordSet() const;
-    virtual int  DoGetCalltipParamterIndex();
-    virtual wxMenu* GetMenu();
-    virtual void AddMenuDynamicContent(wxMenu* menu);
-    virtual void ApplySettings();
-    virtual void AutoIndent(const wxChar&);
-    virtual wxString CallTipContent();
-    virtual wxString GetCurrentScopeName();
-    virtual TagEntryPtr GetTagAtCaret(bool scoped, bool impl);
-    virtual void GotoPreviousDefintion();
-    virtual bool IsComment(long pos);
-    virtual bool IsCommentOrString(long pos);
-    virtual bool IsDefaultContext() const;
-    virtual ContextBase* NewInstance(clEditor* container);
-    virtual void OnCallTipClick(wxStyledTextEvent& event);
-    virtual void OnCalltipCancel();
-    virtual void OnDbgDwellEnd(wxStyledTextEvent& event);
-    virtual void OnDbgDwellStart(wxStyledTextEvent& event);
-    virtual void OnDwellEnd(wxStyledTextEvent& event);
-    virtual void OnDwellStart(wxStyledTextEvent& event);
-    virtual void OnEnterHit();
-    virtual void OnFileSaved();
-    virtual void OnKeyDown(wxKeyEvent& event);
-    virtual void OnSciUpdateUI(wxStyledTextEvent& event);
-    virtual void RemoveMenuDynamicContent(wxMenu* menu);
-    virtual void RetagFile();
-    virtual void SemicolonShift();
-    virtual void SetActive();
-    virtual bool IsAtBlockComment() const;
-    virtual bool IsAtLineComment() const;
-    void ProcessIdleActions();
-    
+    bool IsStringTriggerCodeComplete(const wxString& str) const override;
+    int GetActiveKeywordSet() const override;
+    int  DoGetCalltipParamterIndex() override;
+    wxMenu* GetMenu() override;
+    void AddMenuDynamicContent(wxMenu* menu) override;
+    void ApplySettings() override;
+    void AutoIndent(const wxChar&) override;
+    wxString CallTipContent() override;
+    wxString GetCurrentScopeName() override;
+    TagEntryPtr GetTagAtCaret(bool scoped, bool impl) override;
+    bool IsCommentOrString(long pos) override;
+    bool IsDefaultContext() const override;
+    std::shared_ptr<ContextBase> NewInstance(clEditor* container) override;
+    void OnCallTipClick(wxStyledTextEvent& event) override;
+    void OnCalltipCancel() override;
+    void OnDbgDwellEnd(wxStyledTextEvent& event) override;
+    void OnDbgDwellStart(wxStyledTextEvent& event) override;
+    void OnDwellEnd(wxStyledTextEvent& event) override;
+    void OnEnterHit() override;
+    void OnFileSaved() override;
+    void OnKeyDown(wxKeyEvent& event) override;
+    void OnSciUpdateUI(wxStyledTextEvent& event) override;
+    void RemoveMenuDynamicContent(wxMenu* menu) override;
+    void RetagFile() override;
+    void SemicolonShift() override;
+    void SetActive() override;
+    bool IsAtBlockComment() const override;
+    bool IsAtLineComment() const override;
+    void ProcessIdleActions() override;
+
+    bool IsComment(long pos) const;
 };
 
 #endif // CONTEXTPHP_H

--- a/LiteEditor/ContextPython.cpp
+++ b/LiteEditor/ContextPython.cpp
@@ -2,10 +2,8 @@
 
 #include "ColoursAndFontsManager.h"
 #include "cl_editor.h"
-#include "editor_config.h"
 #include "lexer_configuration.h"
 
-#include <wx/msgdlg.h>
 #include <wx/regex.h>
 #include <wx/tokenzr.h>
 #include <wx/xrc/xmlres.h>
@@ -55,7 +53,10 @@ void ContextPython::ApplySettings()
     DoApplySettings(lexPtr);
 }
 
-ContextBase* ContextPython::NewInstance(clEditor* container) { return new ContextPython(container); }
+std::shared_ptr<ContextBase> ContextPython::NewInstance(clEditor* container)
+{
+    return std::make_shared<ContextPython>(container);
+}
 
 void ContextPython::OnCommentSelection(wxCommandEvent& event)
 {

--- a/LiteEditor/ContextPython.hpp
+++ b/LiteEditor/ContextPython.hpp
@@ -3,7 +3,6 @@
 
 #include "generic_context.h"
 
-class clEditor;
 class ContextPython : public ContextGeneric
 {
 protected:
@@ -20,10 +19,10 @@ protected:
 
 public:
     ContextPython();
-    ContextPython(clEditor* container);
-    virtual ~ContextPython();
+    explicit ContextPython(clEditor* container);
+    ~ContextPython() override;
     void ApplySettings() override;
-    ContextBase* NewInstance(clEditor* container) override;
+    std::shared_ptr<ContextBase> NewInstance(clEditor* container) override;
     bool IsAtBlockComment() const override;
     bool IsAtLineComment() const override;
 };

--- a/LiteEditor/ContextRust.cpp
+++ b/LiteEditor/ContextRust.cpp
@@ -130,8 +130,6 @@ wxMenu* ContextRust::GetMenu() { return ContextBase::GetMenu(); }
 
 TagEntryPtr ContextRust::GetTagAtCaret(bool scoped, bool impl) { return NULL; }
 
-void ContextRust::GotoPreviousDefintion() {}
-
 bool ContextRust::IsCommentOrString(long pos)
 {
     static std::unordered_set<int> string_styles = { wxSTC_RUST_BYTECHARACTER, wxSTC_RUST_BYTESTRING,
@@ -143,7 +141,10 @@ bool ContextRust::IsCommentOrString(long pos)
 
 bool ContextRust::IsDefaultContext() const { return false; }
 
-ContextBase* ContextRust::NewInstance(clEditor* container) { return new ContextRust(container); }
+std::shared_ptr<ContextBase> ContextRust::NewInstance(clEditor* container)
+{
+    return std::make_shared<ContextRust>(container);
+}
 
 void ContextRust::OnCallTipClick(wxStyledTextEvent& event) { wxUnusedVar(event); }
 
@@ -154,8 +155,6 @@ void ContextRust::OnDbgDwellEnd(wxStyledTextEvent& event) { wxUnusedVar(event); 
 void ContextRust::OnDbgDwellStart(wxStyledTextEvent& event) { wxUnusedVar(event); }
 
 void ContextRust::OnDwellEnd(wxStyledTextEvent& event) { wxUnusedVar(event); }
-
-void ContextRust::OnDwellStart(wxStyledTextEvent& event) { wxUnusedVar(event); }
 
 void ContextRust::OnEnterHit() {}
 
@@ -200,7 +199,7 @@ void ContextRust::SemicolonShift()
 
 void ContextRust::SetActive() {}
 
-bool ContextRust::IsComment(long pos)
+bool ContextRust::IsComment(long pos) const
 {
     static std::unordered_set<int> comment_styles = { wxSTC_RUST_COMMENTBLOCK, wxSTC_RUST_COMMENTLINE,
                                                       wxSTC_RUST_COMMENTBLOCKDOC, wxSTC_RUST_COMMENTLINEDOC };

--- a/LiteEditor/ContextRust.hpp
+++ b/LiteEditor/ContextRust.hpp
@@ -8,46 +8,45 @@ class ContextRust : public ContextGeneric
 
 public:
     ContextRust();
-    ContextRust(clEditor* Editor);
-    virtual ~ContextRust();
+    explicit ContextRust(clEditor* Editor);
+    ~ContextRust() override;
 
 protected:
     void OnCommentSelection(wxCommandEvent& event);
     void OnCommentLine(wxCommandEvent& event);
 
 public:
-    bool IsStringTriggerCodeComplete(const wxString& str) const;
-    virtual int GetActiveKeywordSet() const;
-    virtual int DoGetCalltipParamterIndex();
-    virtual wxMenu* GetMenu();
-    virtual void AddMenuDynamicContent(wxMenu* menu);
-    virtual void ApplySettings();
-    virtual void AutoIndent(const wxChar&);
-    virtual wxString CallTipContent();
-    virtual wxString GetCurrentScopeName();
-    virtual TagEntryPtr GetTagAtCaret(bool scoped, bool impl);
-    virtual void GotoPreviousDefintion();
-    virtual bool IsComment(long pos);
-    virtual bool IsCommentOrString(long pos);
-    virtual bool IsDefaultContext() const;
-    virtual ContextBase* NewInstance(clEditor* container);
-    virtual void OnCallTipClick(wxStyledTextEvent& event);
-    virtual void OnCalltipCancel();
-    virtual void OnDbgDwellEnd(wxStyledTextEvent& event);
-    virtual void OnDbgDwellStart(wxStyledTextEvent& event);
-    virtual void OnDwellEnd(wxStyledTextEvent& event);
-    virtual void OnDwellStart(wxStyledTextEvent& event);
-    virtual void OnEnterHit();
-    virtual void OnFileSaved();
-    virtual void OnKeyDown(wxKeyEvent& event);
-    virtual void OnSciUpdateUI(wxStyledTextEvent& event);
-    virtual void RemoveMenuDynamicContent(wxMenu* menu);
-    virtual void RetagFile();
-    virtual void SemicolonShift();
-    virtual void SetActive();
-    virtual bool IsAtBlockComment() const;
-    virtual bool IsAtLineComment() const;
-    void ProcessIdleActions();
+    bool IsStringTriggerCodeComplete(const wxString& str) const override;
+    int GetActiveKeywordSet() const override;
+    int DoGetCalltipParamterIndex() override;
+    wxMenu* GetMenu() override;
+    void AddMenuDynamicContent(wxMenu* menu) override;
+    void ApplySettings() override;
+    void AutoIndent(const wxChar&) override;
+    wxString CallTipContent() override;
+    wxString GetCurrentScopeName() override;
+    TagEntryPtr GetTagAtCaret(bool scoped, bool impl) override;
+    bool IsCommentOrString(long pos) override;
+    bool IsDefaultContext() const override;
+    std::shared_ptr<ContextBase> NewInstance(clEditor* container) override;
+    void OnCallTipClick(wxStyledTextEvent& event) override;
+    void OnCalltipCancel() override;
+    void OnDbgDwellEnd(wxStyledTextEvent& event) override;
+    void OnDbgDwellStart(wxStyledTextEvent& event) override;
+    void OnDwellEnd(wxStyledTextEvent& event) override;
+    void OnEnterHit() override;
+    void OnFileSaved() override;
+    void OnKeyDown(wxKeyEvent& event) override;
+    void OnSciUpdateUI(wxStyledTextEvent& event) override;
+    void RemoveMenuDynamicContent(wxMenu* menu) override;
+    void RetagFile() override;
+    void SemicolonShift() override;
+    void SetActive() override;
+    bool IsAtBlockComment() const override;
+    bool IsAtLineComment() const override;
+    void ProcessIdleActions() override;
+
+    bool IsComment(long pos) const;
 };
 
 #endif // CONTEXTRUST_HPP

--- a/LiteEditor/context_base.h
+++ b/LiteEditor/context_base.h
@@ -30,9 +30,7 @@
 #include "macros.h"
 
 #include <memory>
-#include <set>
 #include <vector>
-#include <wx/filename.h>
 #include <wx/stc/stc.h>
 #include <wx/string.h>
 
@@ -77,10 +75,10 @@ protected:
 
 public:
     // ctor-dtor
-    ContextBase(clEditor* container);
-    ContextBase(const wxString& name);
+    explicit ContextBase(clEditor* container);
+    explicit ContextBase(const wxString& name);
 
-    virtual ~ContextBase() = default;
+    ~ContextBase() override = default;
 
     /**
      * @brief user typed '@' inside a block comment. Code complete possible keywords
@@ -110,7 +108,7 @@ public:
     const wxString& GetName() const { return m_name; }
 
     // every Context derived class must implement the following methods
-    virtual ContextBase* NewInstance(clEditor* container) = 0;
+    virtual std::shared_ptr<ContextBase> NewInstance(clEditor* container) = 0;
     virtual void ApplySettings() = 0;
 
     // functions with default implementation:

--- a/LiteEditor/context_cpp.cpp
+++ b/LiteEditor/context_cpp.cpp
@@ -26,11 +26,11 @@
 #include "context_cpp.h"
 
 #include "AddFunctionsImpDlg.h"
-#include "CTags.hpp"
 #include "CompletionHelper.hpp"
+#include "Cxx/FlexLexer.h"
+#include "Cxx/cpp_scanner.h"
 #include "Debugger/debuggermanager.h"
 #include "LSP/LSPManager.hpp"
-#include "SelectProjectsDlg.h"
 #include "addincludefiledlg.h"
 #include "clEditorStateLocker.h"
 #include "clFileSystemEvent.h"
@@ -40,7 +40,6 @@
 #include "codelite_events.h"
 #include "commentconfigdata.h"
 #include "ctags_manager.h"
-#include "drawingutils.h"
 #include "editor_config.h"
 #include "event_notifier.h"
 #include "file_logger.h"
@@ -49,21 +48,18 @@
 #include "fileview.h"
 #include "frame.h"
 #include "globals.h"
-#include "language.h"
 #include "macromanager.h"
 #include "manager.h"
 #include "movefuncimpldlg.h"
 #include "new_quick_watch_dlg.h"
-#include "pluginmanager.h"
 #include "precompiled_header.h"
 #include "resources/clXmlResource.hpp"
 #include "setters_getters_dlg.h"
+#include "variable.h"
 #include "workspacetab.h"
 
-#include <algorithm>
 #include <wx/choicdlg.h>
 #include <wx/file.h>
-#include <wx/progdlg.h>
 #include <wx/regex.h>
 #include <wx/tokenzr.h>
 #include <wx/xrc/xmlres.h>
@@ -181,7 +177,10 @@ ContextCpp::~ContextCpp()
     wxDELETE(m_rclickMenu);
 }
 
-ContextBase* ContextCpp::NewInstance(clEditor* container) { return new ContextCpp(container); }
+std::shared_ptr<ContextBase> ContextCpp::NewInstance(clEditor* container)
+{
+    return std::make_shared<ContextCpp>(container);
+}
 
 void ContextCpp::OnDwellEnd(wxStyledTextEvent& event)
 {
@@ -1680,7 +1679,7 @@ void ContextCpp::AutoAddComment()
     rCtrl.ChooseCaretX(); // set new column as "current" column
 }
 
-bool ContextCpp::IsComment(long pos)
+bool ContextCpp::IsComment(long pos) const
 {
     int style;
     style = GetCtrl().GetStyleAt(pos);

--- a/LiteEditor/context_cpp.h
+++ b/LiteEditor/context_cpp.h
@@ -26,7 +26,6 @@
 #define CONTEXT_CPP_H
 
 #include "LSP/LSPEvent.h"
-#include "Cxx/cpptoken.h"
 #include "cl_command_event.h"
 #include "context_base.h"
 #include "ctags_manager.h"
@@ -70,19 +69,18 @@ public:
      * @return
      */
     bool IsAtLineComment() const override;
-    ContextCpp(clEditor* container);
+    explicit ContextCpp(clEditor* container);
     bool IsDefaultContext() const override;
 
-    virtual ~ContextCpp();
+    ~ContextCpp() override;
     ContextCpp();
-    ContextBase* NewInstance(clEditor* container) override;
+    std::shared_ptr<ContextBase> NewInstance(clEditor* container) override;
     bool CompleteWord() override;
     bool CodeComplete(long pos = wxNOT_FOUND) override;
     bool GotoDefinition() override;
     wxString GetCurrentScopeName() override;
     void AutoIndent(const wxChar&) override;
     bool IsCommentOrString(long pos) override;
-    virtual bool IsComment(long pos);
     void AddMenuDynamicContent(wxMenu* menu) override;
     void RemoveMenuDynamicContent(wxMenu* menu) override;
     void ApplySettings() override;
@@ -92,6 +90,7 @@ public:
     void SemicolonShift() override;
     void ProcessIdleActions() override;
 
+    bool IsComment(long pos) const;
     // override swapfiles features
     virtual void SwapFiles(const wxFileName& fileName);
 

--- a/LiteEditor/context_diff.cpp
+++ b/LiteEditor/context_diff.cpp
@@ -22,12 +22,9 @@
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 #include "context_diff.h"
+
 #include "cl_editor.h"
 #include "editor_config.h"
-#include "frame.h"
-#include "manager.h"
-#include <wx/regex.h>
-#include <wx/xrc/xmlres.h>
 
 ContextDiff::ContextDiff()
     : ContextBase(wxT("Diff"))
@@ -41,7 +38,10 @@ ContextDiff::ContextDiff(clEditor* container)
     ApplySettings();
 }
 
-ContextBase* ContextDiff::NewInstance(clEditor* container) { return new ContextDiff(container); }
+std::shared_ptr<ContextBase> ContextDiff::NewInstance(clEditor* container)
+{
+    return std::make_shared<ContextDiff>(container);
+}
 
 void ContextDiff::ApplySettings()
 {

--- a/LiteEditor/context_diff.h
+++ b/LiteEditor/context_diff.h
@@ -31,11 +31,11 @@ class ContextDiff : public ContextBase
 {
 public:
     ContextDiff();
-    ContextDiff(clEditor* container);
-    virtual ~ContextDiff() = default;
+    explicit ContextDiff(clEditor* container);
+    ~ContextDiff() override = default;
 
-    virtual void ApplySettings();
-    virtual ContextBase* NewInstance(clEditor* container);
+    void ApplySettings() override;
+    std::shared_ptr<ContextBase> NewInstance(clEditor* container) override;
 };
 
 #endif // __contextdiff__

--- a/LiteEditor/context_html.cpp
+++ b/LiteEditor/context_html.cpp
@@ -198,8 +198,6 @@ TagEntryPtr ContextHtml::GetTagAtCaret(bool scoped, bool impl) { return NULL; }
 
 bool ContextHtml::GotoDefinition() { return false; }
 
-void ContextHtml::GotoPreviousDefintion() {}
-
 bool ContextHtml::IsCommentOrString(long pos)
 {
     int style = GetCtrl().GetStyleAt(pos);
@@ -214,7 +212,10 @@ bool ContextHtml::IsCommentOrString(long pos)
 
 bool ContextHtml::IsDefaultContext() const { return false; }
 
-ContextBase* ContextHtml::NewInstance(clEditor* container) { return new ContextHtml(container); }
+std::shared_ptr<ContextBase> ContextHtml::NewInstance(clEditor* container)
+{
+    return std::make_shared<ContextHtml>(container);
+}
 
 void ContextHtml::OnCallTipClick(wxStyledTextEvent& event) {}
 
@@ -225,8 +226,6 @@ void ContextHtml::OnDbgDwellEnd(wxStyledTextEvent& event) {}
 void ContextHtml::OnDbgDwellStart(wxStyledTextEvent& event) {}
 
 void ContextHtml::OnDwellEnd(wxStyledTextEvent& event) {}
-
-void ContextHtml::OnDwellStart(wxStyledTextEvent& event) {}
 
 void ContextHtml::OnEnterHit() {}
 
@@ -275,7 +274,7 @@ void ContextHtml::SemicolonShift()
 
 void ContextHtml::SetActive() {}
 
-bool ContextHtml::IsComment(long pos)
+bool ContextHtml::IsComment(long pos) const
 {
     int style = GetCtrl().GetStyleAt(pos);
     return style == wxSTC_H_COMMENT || style == wxSTC_H_XCCOMMENT || style == wxSTC_H_SGML_COMMENT ||

--- a/LiteEditor/context_html.h
+++ b/LiteEditor/context_html.h
@@ -32,42 +32,40 @@ class ContextHtml : public ContextBase
 {
 public:
     ContextHtml();
-    ContextHtml(clEditor *Editor);
-    virtual ~ContextHtml() = default;
+    explicit ContextHtml(clEditor *Editor);
+    ~ContextHtml() override = default;
 
 public:
-    virtual int GetActiveKeywordSet() const;
-    virtual int  DoGetCalltipParamterIndex();
-    virtual wxMenu* GetMenu();
-    virtual void AddMenuDynamicContent(wxMenu* menu);
-    virtual void ApplySettings();
-    virtual void AutoIndent(const wxChar&);
-    virtual wxString CallTipContent();
-    virtual wxString GetCurrentScopeName();
-    virtual TagEntryPtr GetTagAtCaret(bool scoped, bool impl);
-    virtual bool GotoDefinition();
-    virtual void GotoPreviousDefintion();
-    virtual bool IsComment(long pos);
-    virtual bool IsCommentOrString(long pos);
-    virtual bool IsDefaultContext() const;
-    virtual ContextBase* NewInstance(clEditor* container);
-    virtual void OnCallTipClick(wxStyledTextEvent& event);
-    virtual void OnCalltipCancel();
-    virtual void OnDbgDwellEnd(wxStyledTextEvent& event);
-    virtual void OnDbgDwellStart(wxStyledTextEvent& event);
-    virtual void OnDwellEnd(wxStyledTextEvent& event);
-    virtual void OnDwellStart(wxStyledTextEvent& event);
-    virtual void OnEnterHit();
-    virtual void OnFileSaved();
-    virtual void OnKeyDown(wxKeyEvent& event);
-    virtual void OnSciUpdateUI(wxStyledTextEvent& event);
-    virtual void RemoveMenuDynamicContent(wxMenu* menu);
-    virtual void RetagFile();
-    virtual void SemicolonShift();
-    virtual void SetActive();
-    virtual bool IsAtBlockComment() const;
-    virtual bool IsAtLineComment() const;
-    
+    int GetActiveKeywordSet() const override;
+    int DoGetCalltipParamterIndex() override;
+    wxMenu* GetMenu() override;
+    void AddMenuDynamicContent(wxMenu* menu) override;
+    void ApplySettings() override;
+    void AutoIndent(const wxChar&) override;
+    wxString CallTipContent() override;
+    wxString GetCurrentScopeName() override;
+    TagEntryPtr GetTagAtCaret(bool scoped, bool impl) override;
+    bool GotoDefinition() override;
+    bool IsCommentOrString(long pos) override;
+    bool IsDefaultContext() const override;
+    std::shared_ptr<ContextBase> NewInstance(clEditor* container) override;
+    void OnCallTipClick(wxStyledTextEvent& event) override;
+    void OnCalltipCancel() override;
+    void OnDbgDwellEnd(wxStyledTextEvent& event) override;
+    void OnDbgDwellStart(wxStyledTextEvent& event) override;
+    void OnDwellEnd(wxStyledTextEvent& event) override;
+    void OnEnterHit() override;
+    void OnFileSaved() override;
+    void OnKeyDown(wxKeyEvent& event) override;
+    void OnSciUpdateUI(wxStyledTextEvent& event) override;
+    void RemoveMenuDynamicContent(wxMenu* menu) override;
+    void RetagFile() override;
+    void SemicolonShift() override;
+    void SetActive() override;
+    bool IsAtBlockComment() const override;
+    bool IsAtLineComment() const override;
+
+    bool IsComment(long pos) const;
 };
 
 #endif // CONTEXTHTML_H

--- a/LiteEditor/context_manager.cpp
+++ b/LiteEditor/context_manager.cpp
@@ -33,13 +33,32 @@
 #include "context_cpp.h"
 #include "context_diff.h"
 #include "context_html.h"
-#include "editor_config.h"
 #include "generic_context.h"
 
-#include <wx/tokenzr.h>
-#include <wx/versioninfo.h>
+ContextManager::ContextManager()
+{
+    // register available contexts
+    m_contextPool = {{"c++", std::make_shared<ContextCpp>()},
+                     {"diff", std::make_shared<ContextDiff>()},
+                     {"html", std::make_shared<ContextHtml>()},
+                     {"php", std::make_shared<ContextPhp>()},
+                     {"javascript", std::make_shared<ContextJavaScript>()},
+                     {"python", std::make_shared<ContextPython>()},
+                     {"rust", std::make_shared<ContextRust>()}};
 
-ContextManager::ContextManager() { Initialize(); }
+    // load generic lexers
+    wxArrayString names = ColoursAndFontsManager::Get().GetAllLexersNames();
+    for (const auto& name : names) {
+        if (m_contextPool.count(name) == 0) {
+            m_contextPool.insert({name, std::make_shared<ContextGeneric>(name)});
+        }
+    }
+
+    // make sure there is a "fallback" lexer for unrecognized file types
+    if (m_contextPool.find("text") == m_contextPool.end()) {
+        m_contextPool[wxT("text")] = std::make_shared<ContextGeneric>(wxT("text"));
+    }
+}
 
 ContextBasePtr ContextManager::NewContext(clEditor* parent, const wxString& lexerName)
 {
@@ -48,10 +67,10 @@ ContextBasePtr ContextManager::NewContext(clEditor* parent, const wxString& lexe
     lex_name.MakeLower();
     auto iter = m_contextPool.find(lex_name);
     if (iter == m_contextPool.end()) {
-        return ContextBasePtr(m_contextPool["text"]->NewInstance(parent));
+        return m_contextPool["text"]->NewInstance(parent);
     }
 
-    return ContextBasePtr(iter->second->NewInstance((clEditor*)parent));
+    return iter->second->NewInstance(parent);
 }
 
 ContextBasePtr ContextManager::NewContextByFileName(clEditor* parent, const wxFileName& fileName)
@@ -62,32 +81,4 @@ ContextBasePtr ContextManager::NewContextByFileName(clEditor* parent, const wxFi
         return ContextManager::Get()->NewContext(parent, wxT("Text"));
     }
     return ContextManager::Get()->NewContext(parent, lexer->GetName());
-}
-
-void ContextManager::Initialize()
-{
-    // Populate the contexts available
-    m_contextPool.clear();
-
-    // register available contexts
-    m_contextPool["c++"] = std::make_shared<ContextCpp>();
-    m_contextPool["diff"] = std::make_shared<ContextDiff>();
-    m_contextPool["html"] = std::make_shared<ContextHtml>();
-    m_contextPool["php"] = std::make_shared<ContextPhp>();
-    m_contextPool["javascript"] = std::make_shared<ContextJavaScript>();
-    m_contextPool["python"] = std::make_shared<ContextPython>();
-    m_contextPool["rust"] = std::make_shared<ContextRust>();
-
-    // load generic lexers
-    wxArrayString names = ColoursAndFontsManager::Get().GetAllLexersNames();
-    for (const auto& name : names) {
-        if (m_contextPool.count(name) == 0) {
-            m_contextPool.insert({ name, std::make_shared<ContextGeneric>(name) });
-        }
-    }
-
-    // make sure there is a "fallback" lexer for unrecognized file types
-    if (m_contextPool.find("text") == m_contextPool.end()) {
-        m_contextPool[wxT("text")] = std::make_shared<ContextGeneric>(wxT("text"));
-    }
 }

--- a/LiteEditor/context_manager.h
+++ b/LiteEditor/context_manager.h
@@ -29,15 +29,12 @@
 #include "singleton.h"
 
 #include <unordered_map>
+#include <wx/filename.h>
 #include <wx/string.h>
-#include <wx/window.h>
-
-class ContextManager;
 
 class ContextManager : public Singleton<ContextManager>
 {
-    friend class Singleton<ContextManager>;
-    std::unordered_map<wxString, ContextBasePtr> m_contextPool;
+    friend Singleton<ContextManager>;
 
 public:
     /**
@@ -48,10 +45,12 @@ public:
      */
     ContextBasePtr NewContext(clEditor* parent, const wxString& lexerName);
     ContextBasePtr NewContextByFileName(clEditor* parent, const wxFileName& fileName);
-    void Initialize();
 
 private:
     ContextManager();
-    virtual ~ContextManager() = default;
+    ~ContextManager() override = default;
+
+private:
+    std::unordered_map<wxString, ContextBasePtr> m_contextPool;
 };
 #endif // CONTEXT_MANAGER_H

--- a/LiteEditor/generic_context.cpp
+++ b/LiteEditor/generic_context.cpp
@@ -28,7 +28,6 @@
 #include "clEditorColouriseLocker.h"
 #include "clEditorWordCharsLocker.h"
 #include "cl_editor.h"
-#include "editor_config.h"
 #include "file_logger.h"
 
 ContextGeneric::ContextGeneric(clEditor* container, const wxString& name)
@@ -38,7 +37,10 @@ ContextGeneric::ContextGeneric(clEditor* container, const wxString& name)
     ApplySettings();
 }
 
-ContextBase* ContextGeneric::NewInstance(clEditor* container) { return new ContextGeneric(container, GetName()); }
+std::shared_ptr<ContextBase> ContextGeneric::NewInstance(clEditor* container)
+{
+    return std::make_shared<ContextGeneric>(container, GetName());
+}
 
 void ContextGeneric::ApplySettings()
 {

--- a/LiteEditor/generic_context.h
+++ b/LiteEditor/generic_context.h
@@ -53,19 +53,19 @@ public:
         : ContextBase(wxT("Text"))
     {
     }
-    ContextGeneric(const wxString& name)
+    explicit ContextGeneric(const wxString& name)
         : ContextBase(name)
     {
     }
 
-    virtual ~ContextGeneric() = default;
-    virtual ContextBase* NewInstance(clEditor* container);
+    ~ContextGeneric() override = default;
+    std::shared_ptr<ContextBase> NewInstance(clEditor* container) override;
 
     //---------------------------------------
     // Operations
     //---------------------------------------
     virtual void ApplySettings();
-    
+
     void ProcessIdleActions();
 };
 #endif // CONTEXT_GENERIC_H


### PR DESCRIPTION
- Remove unused `GotoPreviousDefintion`/`OnDwellStart`
- replace raw `new` by `std::make_shared`
- add missing `explicit`
- add `override`
- move `ContextManager::Initialize()` content in constructor
- Add missing `const` for `IsComment`.