### PR TITLE
[cleanup] Clean Outline files:

### DIFF
--- a/Outline/outline.cpp
+++ b/Outline/outline.cpp
@@ -25,27 +25,6 @@
 
 #include "outline.h"
 
-#include "cl_command_event.h"
-#include "codelite_events.h"
-#include "ctags_manager.h"
-#include "detachedpanesinfo.h"
-#include "event_notifier.h"
-#include "fileextmanager.h"
-#include "iconfigtool.h"
-#include "macros.h"
-#include "workspace.h"
-
-#include <set>
-#include <wx/app.h>
-#include <wx/busyinfo.h>
-#include <wx/log.h>
-#include <wx/menu.h>
-#include <wx/settings.h>
-#include <wx/tokenzr.h>
-#include <wx/utils.h>
-#include <wx/wupdlock.h>
-#include <wx/xrc/xmlres.h>
-
 //--------------------------------------------
 // Plugin Interface
 //--------------------------------------------

--- a/Outline/outline.h
+++ b/Outline/outline.h
@@ -26,20 +26,8 @@
 #ifndef __SymbolView__
 #define __SymbolView__
 
-#include "clTabTogglerHelper.h"
-#include "cl_command_event.h"
-#include "dockablepane.h"
-#include "globals.h"
 #include "outline_tab.h"
 #include "plugin.h"
-#include "windowstack.h"
-
-#include <map>
-#include <queue>
-#include <wx/choice.h>
-#include <wx/imaglist.h>
-#include <wx/splitter.h>
-#include <wx/treectrl.h>
 
 class SymbolViewPlugin : public IPlugin
 {
@@ -50,7 +38,7 @@ public:
     //--------------------------------------------
     // Constructors/Destructors
     //--------------------------------------------
-    SymbolViewPlugin(IManager* manager);
+    explicit SymbolViewPlugin(IManager* manager);
     ~SymbolViewPlugin() override = default;
 
     //--------------------------------------------

--- a/Outline/outline_tab.cpp
+++ b/Outline/outline_tab.cpp
@@ -6,7 +6,6 @@
 #include "clSideBarCtrl.hpp"
 #include "codelite_events.h"
 #include "event_notifier.h"
-#include "file_logger.h"
 #include "globals.h"
 #include "imanager.h"
 #include "macros.h"

--- a/Outline/outline_tab.h
+++ b/Outline/outline_tab.h
@@ -21,10 +21,10 @@ private:
     void ClearView();
 
 public:
-    OutlineTab(wxWindow* parent);
-    virtual ~OutlineTab();
+    explicit OutlineTab(wxWindow* parent);
+    ~OutlineTab() override;
 
 protected:
-    virtual void OnItemSelected(wxDataViewEvent& event);
+    void OnItemSelected(wxDataViewEvent& event) override;
 };
 #endif // OUTLINETAB_H


### PR DESCRIPTION
- Remove unneeded `#include`
- add missing `explicit`/`override`