### PR TITLE
[cleanup] Clean MemCheck files:

### DIFF
--- a/MemCheck/imemcheckprocessor.h
+++ b/MemCheck/imemcheckprocessor.h
@@ -37,6 +37,9 @@
 
 #include "memcheckerror.h"
 
+#include <wx/arrstr.h>
+#include <wx/string.h>
+
 class MemCheckSettings;
 
 /**

--- a/MemCheck/memcheck.cpp
+++ b/MemCheck/memcheck.cpp
@@ -290,7 +290,7 @@ void MemCheckPlugin::OnWorkspaceClosed(clWorkspaceEvent& event)
     event.Skip();
 }
 
-bool MemCheckPlugin::IsReady(wxUpdateUIEvent& event)
+bool MemCheckPlugin::IsReady(wxUpdateUIEvent& event) const
 {
     bool ready = !m_mgr->IsBuildInProgress() && !m_terminal.IsRunning();
     int id = event.GetId();

--- a/MemCheck/memcheck.h
+++ b/MemCheck/memcheck.h
@@ -39,14 +39,12 @@
 #include "memcheckui.h"
 #include "plugin.h"
 
-#include <wx/process.h>
-
 class MemCheckOutputView;
 
 class MemCheckPlugin : public IPlugin
 {
 public:
-    MemCheckPlugin(IManager* manager);
+    explicit MemCheckPlugin(IManager* manager);
     ~MemCheckPlugin() override;
 
     //--------------------------------------------
@@ -58,9 +56,9 @@ public:
     void HookPopupMenu(wxMenu* menu, MenuType type) override;
     void UnPlug() override;
 
-    MemCheckSettings* const GetSettings() { return m_settings; };
+    MemCheckSettings* GetSettings() { return m_settings; };
 
-    virtual IMemCheckProcessor* GetProcessor() { return m_memcheckProcessor; }
+    IMemCheckProcessor* GetProcessor() { return m_memcheckProcessor; }
 
     /**
      * @brief true if test is not running and GUI can respond, otherwise if test is running user can't listing errors
@@ -68,7 +66,7 @@ public:
      * @param event
      * @return Plugin status.
      */
-    bool IsReady(wxUpdateUIEvent& event);
+    bool IsReady(wxUpdateUIEvent& event) const;
     /**
      * @brief stop the current running process using SIGTERM
      */
@@ -78,7 +76,6 @@ public:
      * @brief return true if a test is currently running
      * @return
      */
-    //    bool IsRunning() const { return m_process != NULL; }
     bool IsRunning() const { return m_terminal.IsRunning(); }
 
 protected:

--- a/MemCheck/memcheckerror.cpp
+++ b/MemCheck/memcheckerror.cpp
@@ -7,7 +7,9 @@
 
 #include "memcheckerror.h"
 
-#include "file_logger.h"
+#include "memcheckdefs.h"
+
+#include <wx/tokenzr.h>
 
 bool MemCheckErrorLocation::operator==(const MemCheckErrorLocation& other) const
 {

--- a/MemCheck/memcheckerror.h
+++ b/MemCheck/memcheckerror.h
@@ -36,11 +36,10 @@
 #ifndef _MEMCHECKERROR_H_
 #define _MEMCHECKERROR_H_
 
-#include "memcheckdefs.h"
-
+#include <iterator>
 #include <list>
-#include <wx/tokenzr.h>
-#include <wx/wx.h>
+#include <wx/clntdata.h>
+#include <wx/string.h>
 
 class MemCheckErrorLocation;
 class MemCheckError;

--- a/MemCheck/memchecklistctrlerrors.h
+++ b/MemCheck/memchecklistctrlerrors.h
@@ -58,12 +58,12 @@ public:
     }
     ~MemCheckListCtrlErrors() override = default;
 
-    virtual wxString OnGetItemText(long item, long column) const { return m_data->at(item)->label; }
+    wxString OnGetItemText(long item, long column) const override { return m_data->at(item)->label; }
 
     void SetData(std::vector<MemCheckErrorPtr>* data) { this->m_data = data; }
 
 protected:
-    std::vector<MemCheckErrorPtr>* m_data;
+    std::vector<MemCheckErrorPtr>* m_data = nullptr;
 };
 
 #endif

--- a/MemCheck/memcheckoutputview.cpp
+++ b/MemCheck/memcheckoutputview.cpp
@@ -7,9 +7,6 @@
 
 #include "memcheckoutputview.h"
 
-#include "dirsaver.h"
-#include "event_notifier.h"
-#include "file_logger.h"
 #include "memcheckdefs.h"
 #include "memchecksettings.h"
 #include "search_thread.h"

--- a/MemCheck/memcheckoutputview.h
+++ b/MemCheck/memcheckoutputview.h
@@ -33,59 +33,58 @@
 #ifndef _MEMCHECKOUTPUTVIEW_H_
 #define _MEMCHECKOUTPUTVIEW_H_
 
-#include "imemcheckprocessor.h"
+#include "memcheckerror.h"
 #include "memcheck.h"
 #include "memcheckui.h"
 
-#include <wx/tipwin.h>
 #include <wx/valnum.h>
 
 class MemCheckOutputView : public MemCheckOutputViewBase
 {
 public:
     MemCheckOutputView(wxWindow* parent, MemCheckPlugin* plugin, IManager* mgr);
-    virtual ~MemCheckOutputView();
+    ~MemCheckOutputView() override;
 
 protected:
-    virtual void OnClearOutputUpdateUI(wxUpdateUIEvent& event);
-    virtual void OnClearOutput(wxCommandEvent& event);
-    virtual void OnStop(wxCommandEvent& event);
-    virtual void OnStopUI(wxUpdateUIEvent& event);
-    virtual void OnListCtrlErrorsMouseLeave(wxMouseEvent& event);
-    virtual void OnListCtrlErrorsChar(wxKeyEvent& event);
-    virtual void OnListCtrlErrorsKeyDown(wxKeyEvent& event);
-    virtual void OnListCtrlErrorsKeyUp(wxKeyEvent& event);
-    virtual void OnListCtrlErrorsLeftDown(wxMouseEvent& event);
-    virtual void OnListCtrlErrorsLeftUp(wxMouseEvent& event);
-    virtual void OnListCtrlErrorsDeselected(wxListEvent& event);
-    virtual void OnListCtrlErrorsSelected(wxListEvent& event);
-    virtual void OnListCtrlErrorsActivated(wxListEvent& event);
-    virtual void OutputViewPageChanged(wxNotebookEvent& event);
-    virtual void OnSuppFileOpen(wxCommandEvent& event);
-    virtual void OnErrorsPanelUI(wxUpdateUIEvent& event);
-    virtual void OnSuppPanelUI(wxUpdateUIEvent& event);
-    virtual void OnListCtrlErrorsMouseMotion(wxMouseEvent& event);
-    virtual void OnListCtrlErrorsResize(wxSizeEvent& event);
-    virtual void OnPageSelect(wxCommandEvent& event);
-    virtual void OnClearFilter(wxCommandEvent& event);
-    virtual void OnPageFirst(wxCommandEvent& event);
-    virtual void OnPageLast(wxCommandEvent& event);
-    virtual void OnPageNext(wxCommandEvent& event);
-    virtual void OnPagePrev(wxCommandEvent& event);
-    virtual void OnSearchNonworkspace(wxCommandEvent& event);
-    virtual void OnOpenPlain(wxCommandEvent& event);
-    virtual void OnFilterErrors(wxCommandEvent& event);
-    virtual void OnSuppFileSelected(wxCommandEvent& event);
-    virtual void OnSuppressAll(wxCommandEvent& event);
-    virtual void OnSuppressSelected(wxCommandEvent& event);
-    virtual void OnSelectionChanged(wxDataViewEvent& event);
-    virtual void OnContextMenu(wxDataViewEvent& event);
-    virtual void OnMemCheckUI(wxUpdateUIEvent& event);
-    virtual void OnActivated(wxDataViewEvent& event);
-    virtual void OnJumpToNext(wxCommandEvent& event);
-    virtual void OnJumpToPrev(wxCommandEvent& event);
-    virtual void OnExpandAll(wxCommandEvent& event);
+    void OnClearOutputUpdateUI(wxUpdateUIEvent& event) override;
+    void OnClearOutput(wxCommandEvent& event) override;
+    void OnStop(wxCommandEvent& event) override;
+    void OnStopUI(wxUpdateUIEvent& event) override;
+    void OnListCtrlErrorsMouseLeave(wxMouseEvent& event) override;
+    void OnListCtrlErrorsChar(wxKeyEvent& event) override;
+    void OnListCtrlErrorsKeyDown(wxKeyEvent& event) override;
+    void OnListCtrlErrorsKeyUp(wxKeyEvent& event) override;
+    void OnListCtrlErrorsLeftDown(wxMouseEvent& event) override;
+    void OnListCtrlErrorsLeftUp(wxMouseEvent& event) override;
+    void OnListCtrlErrorsDeselected(wxListEvent& event) override;
+    void OnListCtrlErrorsSelected(wxListEvent& event) override;
+    void OnListCtrlErrorsActivated(wxListEvent& event) override;
+    void OutputViewPageChanged(wxNotebookEvent& event) override;
+    void OnSuppFileOpen(wxCommandEvent& event) override;
+    void OnErrorsPanelUI(wxUpdateUIEvent& event) override;
+    void OnSuppPanelUI(wxUpdateUIEvent& event) override;
+    void OnListCtrlErrorsMouseMotion(wxMouseEvent& event) override;
+    void OnListCtrlErrorsResize(wxSizeEvent& event) override;
+    void OnPageSelect(wxCommandEvent& event) override;
+    void OnClearFilter(wxCommandEvent& event) override;
+    void OnPageFirst(wxCommandEvent& event) override;
+    void OnPageLast(wxCommandEvent& event) override;
+    void OnPageNext(wxCommandEvent& event) override;
+    void OnPagePrev(wxCommandEvent& event) override;
+    void OnOpenPlain(wxCommandEvent& event) override;
+    void OnFilterErrors(wxCommandEvent& event) override;
+    void OnSuppFileSelected(wxCommandEvent& event) override;
+    void OnSuppressAll(wxCommandEvent& event) override;
+    void OnSuppressSelected(wxCommandEvent& event) override;
+    void OnSelectionChanged(wxDataViewEvent& event) override;
+    void OnContextMenu(wxDataViewEvent& event) override;
+    void OnMemCheckUI(wxUpdateUIEvent& event) override;
+    void OnActivated(wxDataViewEvent& event) override;
+    void OnJumpToNext(wxCommandEvent& event) override;
+    void OnJumpToPrev(wxCommandEvent& event) override;
+    void OnExpandAll(wxCommandEvent& event) override;
 
+    void OnSearchNonworkspace(wxCommandEvent& event);
     // common things for both notebooks
     MemCheckPlugin* m_plugin;
     IManager* m_mgr;

--- a/MemCheck/memchecksettings.h
+++ b/MemCheck/memchecksettings.h
@@ -64,10 +64,10 @@ class ValgrindSettings : public clConfigItem
 {
 public:
     ValgrindSettings();
-    virtual ~ValgrindSettings() {}
+    ~ValgrindSettings() override = default;
 
-    virtual void FromJSON(const JSONItem& json);
-    virtual JSONItem ToJSON() const;
+    void FromJSON(const JSONItem& json) override;
+    JSONItem ToJSON() const override;
 
 private:
     wxString m_binary;
@@ -117,10 +117,10 @@ class MemCheckSettings : public clConfigItem
 {
 public:
     MemCheckSettings();
-    virtual ~MemCheckSettings() {}
+    ~MemCheckSettings() override = default;
 
-    virtual void FromJSON(const JSONItem& json);
-    virtual JSONItem ToJSON() const;
+    void FromJSON(const JSONItem& json) override;
+    JSONItem ToJSON() const override;
 
 private:
     wxString m_engine;

--- a/MemCheck/memchecksettingsdialog.cpp
+++ b/MemCheck/memchecksettingsdialog.cpp
@@ -7,8 +7,6 @@
 
 #include "memchecksettingsdialog.h"
 
-#include "file_logger.h"
-#include "memcheckdefs.h"
 #include "memchecksettings.h"
 #include "windowattrmanager.h"
 

--- a/MemCheck/memchecksettingsdialog.h
+++ b/MemCheck/memchecksettingsdialog.h
@@ -40,24 +40,24 @@ class MemCheckSettingsDialog : public MemCheckSettingsDialogBase
 
 public:
     MemCheckSettingsDialog(wxWindow* parent, MemCheckSettings* settings);
-    virtual ~MemCheckSettingsDialog() = default;
+    ~MemCheckSettingsDialog() override = default;
 
 protected:
-    virtual void OnFilePickerValgrindOutputFileUI(wxUpdateUIEvent& event);
+    void OnFilePickerValgrindOutputFileUI(wxUpdateUIEvent& event) override;
 
     /**
      * @brief Shows popup menu with two functions: add new supp and remove supp
      * @param event
      */
-    virtual void OnSuppListRightDown(wxMouseEvent& event);
+    void OnSuppListRightDown(wxMouseEvent& event) override;
 
     MemCheckSettings* m_settings;
 
     void OnAddSupp(wxCommandEvent& event);
     void OnDelSupp(wxCommandEvent& event);
 
-    virtual void OnValgrindOutputFileChanged(wxFileDirPickerEvent& event);
-    virtual void ValgrindResetOptions(wxCommandEvent& event);
-    virtual void OnOK(wxCommandEvent& event);
+    void OnValgrindOutputFileChanged(wxFileDirPickerEvent& event) override;
+    void ValgrindResetOptions(wxCommandEvent& event) override;
+    void OnOK(wxCommandEvent& event) override;
 };
 #endif // _MEMCHECKSETTINGSDIALOG_H

--- a/MemCheck/valgrindprocessor.cpp
+++ b/MemCheck/valgrindprocessor.cpp
@@ -7,12 +7,10 @@
 
 #include "valgrindprocessor.h"
 
-#include "file_logger.h"
-#include "memcheckdefs.h"
 #include "memchecksettings.h"
 #include "workspace.h"
 
-#include <wx/stdpaths.h>
+#include <wx/app.h>
 #include <wx/textfile.h>
 
 ValgrindMemcheckProcessor::ValgrindMemcheckProcessor(MemCheckSettings* const settings)

--- a/MemCheck/valgrindprocessor.h
+++ b/MemCheck/valgrindprocessor.h
@@ -50,7 +50,7 @@ public:
      * @brief interface implementation, does nothing more than inherited ctor
      * @param settings
      */
-    ValgrindMemcheckProcessor(MemCheckSettings* const settings);
+    explicit ValgrindMemcheckProcessor(MemCheckSettings* settings);
 
     /**
      * @brief interface implementation
@@ -59,7 +59,7 @@ public:
      * Some files are specified in setting. Workspace specific supp file need to be named just before analyse run,
      * according to current opened workspace.
      */
-    virtual wxArrayString GetSuppressionFiles();
+    wxArrayString GetSuppressionFiles() override;
 
     /**
      * @brief interface implementation
@@ -68,7 +68,7 @@ public:
      *
      * Takes original command and prepend it with Valgrind command and its arguments.
      */
-    virtual void GetExecutionCommand(const wxString& originalCommand, wxString& command, wxString& command_args);
+    void GetExecutionCommand(const wxString& originalCommand, wxString& command, wxString& command_args) override;
 
     /**
      * @brief interface implementation
@@ -77,7 +77,7 @@ public:
      *
      * Loads Valgrind's xml log to wxXmlDocument, and goes trought nodes
      */
-    virtual bool Process(const wxString& outputLogFileName = wxEmptyString);
+    bool Process(const wxString& outputLogFileName = wxEmptyString) override;
 
 protected:
     /**


### PR DESCRIPTION
- Remove unneeded `#include`
- add missing `explicit`/`override`