### PR TITLE
Restore backup (for copyright plugin)

### DIFF
--- a/CodeLite/fileutils.cpp
+++ b/CodeLite/fileutils.cpp
@@ -95,6 +95,17 @@ const char ELF_STR[] = {0x7f, 'E', 'L', 'F'};
 #endif
 } // namespace
 
+bool FileUtils::Backup(const wxString& file_name)
+{
+    wxString backup_name(file_name);
+    backup_name << ".bak";
+    if (!wxCopyFile(file_name, backup_name, true)) {
+        clWARNING() << wxString::Format("Failed to backup file %s", file_name);
+        return false;
+    }
+    return true;
+}
+
 void FileUtils::OpenFileExplorer(const wxString& path)
 {
     // Wrap the path with quotes if needed

--- a/CodeLite/fileutils.cpp
+++ b/CodeLite/fileutils.cpp
@@ -95,15 +95,15 @@ const char ELF_STR[] = {0x7f, 'E', 'L', 'F'};
 #endif
 } // namespace
 
-bool FileUtils::Backup(const wxString& file_name)
+std::optional<wxFileName> FileUtils::Backup(const wxString& file_name)
 {
     wxString backup_name(file_name);
     backup_name << ".bak";
     if (!wxCopyFile(file_name, backup_name, true)) {
         clWARNING() << wxString::Format("Failed to backup file %s", file_name);
-        return false;
+        return std::nullopt;
     }
-    return true;
+    return backup_name;
 }
 
 void FileUtils::OpenFileExplorer(const wxString& path)

--- a/CodeLite/fileutils.h
+++ b/CodeLite/fileutils.h
@@ -62,7 +62,7 @@ public:
 
 public:
 
-    static bool Backup(const wxString& file_name);
+    static std::optional<wxFileName> Backup(const wxString& file_name);
 
     static bool ReadFileContent(const wxFileName& fn, wxString& data, const wxMBConv& conv = wxConvUTF8);
 

--- a/CodeLite/fileutils.h
+++ b/CodeLite/fileutils.h
@@ -61,6 +61,9 @@ public:
     };
 
 public:
+
+    static bool Backup(const wxString& file_name);
+
     static bool ReadFileContent(const wxFileName& fn, wxString& data, const wxMBConv& conv = wxConvUTF8);
 
     /**

--- a/Copyright/copyright.cpp
+++ b/Copyright/copyright.cpp
@@ -30,8 +30,10 @@
 #include "copyrights_options_dlg.h"
 #include "copyrights_proj_sel_dlg.h"
 #include "copyrightsconfigdata.h"
+#include "editor_config.h"
 #include "event_notifier.h"
 #include "file_logger.h"
+#include "fileutils.h"
 #include "globals.h"
 #include "macromanager.h"
 #include "progress_dialog.h"
@@ -40,12 +42,8 @@
 
 #include <vector>
 #include <wx/app.h>
-#include <wx/ffile.h>
-#include <wx/filefn.h>
-#include <wx/log.h>
 #include <wx/menu.h>
 #include <wx/msgdlg.h>
-#include <wx/progdlg.h>
 #include <wx/tokenzr.h>
 #include <wx/xrc/xmlres.h>
 
@@ -353,7 +351,11 @@ void Copyright::MassUpdate(const std::vector<wxFileName>& filtered_files, const 
                 }
 
                 file_content.Prepend(_content);
-                WriteFileWithBackup(fn.GetFullPath(), file_content, data.GetBackupFiles());
+                if (data.GetBackupFiles() && !FileUtils::Backup(fn.GetFullPath())) {
+                    continue;
+                }
+                wxCSConv fontEncConv(EditorConfigST::Get()->GetOptions()->GetFileFontEncoding());
+                FileUtils::WriteFileContent(fn.GetFullPath(), file_content, fontEncConv);
             }
         }
     }

--- a/DatabaseExplorer/ClassGenerateDialog.cpp
+++ b/DatabaseExplorer/ClassGenerateDialog.cpp
@@ -27,8 +27,9 @@
 
 #include "cl_command_event.h"
 #include "codelite_events.h"
+#include "editor_config.h"
 #include "event_notifier.h"
-#include "globals.h"
+#include "fileutils.h"
 
 #include <wx/tokenzr.h>
 #include <wx/xrc/xmlres.h>
@@ -107,8 +108,9 @@ bool ClassGenerateDialog::GenerateClass(Table* pTab, const wxString& path)
     FormatFile(hFile, fnHeaderFileName);
     FormatFile(cFile, fnCppFileName);
 
-    ::WriteFileWithBackup(fnCppFileName.GetFullPath(), cFile, false);
-    ::WriteFileWithBackup(fnHeaderFileName.GetFullPath(), hFile, false);
+    wxCSConv fontEncConv(EditorConfigST::Get()->GetOptions()->GetFileFontEncoding());
+    FileUtils::WriteFileContent(fnCppFileName.GetFullPath(), cFile, fontEncConv);
+    FileUtils::WriteFileContent(fnHeaderFileName.GetFullPath(), hFile, fontEncConv);
 
     // add files to the workspace
     wxArrayString arrString;

--- a/LiteEditor/batchbuilddlg.cpp
+++ b/LiteEditor/batchbuilddlg.cpp
@@ -23,11 +23,14 @@
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-#include <wx/tokenzr.h>
-#include "globals.h"
+#include "batchbuilddlg.h"
+
+#include "editor_config.h"
+#include "fileutils.h"
 #include "manager.h"
 #include "workspace.h"
-#include "batchbuilddlg.h"
+
+#include <wx/tokenzr.h>
 
 BatchBuildDlg::BatchBuildDlg( wxWindow* parent )
     : BatchBuildBaseDlg( parent )
@@ -274,6 +277,6 @@ void BatchBuildDlg::DoSaveBatchBuildOrder()
             content << m_checkListConfigurations->GetString(i) << wxT("\n");
         }
     }
-
-    WriteFileWithBackup(fn.GetFullPath(), content, false);
+    wxCSConv fontEncConv(EditorConfigST::Get()->GetOptions()->GetFileFontEncoding());
+    FileUtils::WriteFileContent(fn.GetFullPath(), content, fontEncConv);
 }

--- a/LiteEditor/replaceinfilespanel.cpp
+++ b/LiteEditor/replaceinfilespanel.cpp
@@ -169,7 +169,8 @@ void ReplaceInFilesPanel::DoSaveResults(wxStyledTextCtrl* sci, MatchInfo_t::iter
     bool ok = true;
     if (dynamic_cast<clEditor*>(sci) == NULL) {
         // it's a temp editor, check if we have any changes to save
-        if (sci->GetModify() && !WriteFileWithBackup(begin->second.GetFileName(), sci->GetText(), false)) {
+        wxCSConv fontEncConv(EditorConfigST::Get()->GetOptions()->GetFileFontEncoding());
+        if (sci->GetModify() && !FileUtils::WriteFileContent(begin->second.GetFileName(), sci->GetText(), fontEncConv)) {
             wxMessageBox(_("Failed to save file:\n") + begin->second.GetFileName(),
                          _("CodeLite - Replace"),
                          wxICON_ERROR | wxOK);

--- a/Plugin/globals.cpp
+++ b/Plugin/globals.cpp
@@ -22,6 +22,8 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
+#include "precompiled_header.h"
+
 #include "globals.h"
 
 #include "Debugger/debuggermanager.h"
@@ -39,7 +41,6 @@
 #include "imanager.h"
 #include "macros.h"
 #include "md5/wxmd5.h"
-#include "precompiled_header.h"
 #include "procutils.h"
 #include "workspace.h"
 
@@ -289,13 +290,6 @@ bool CompareFileWithString(const wxString& filePath, const wxString& str)
     wxString diskMD5 = wxMD5::GetDigest(content);
     wxString mem_MD5 = wxMD5::GetDigest(str);
     return diskMD5 == mem_MD5;
-}
-
-bool WriteFileWithBackup(const wxString& file_name, const wxString& content, bool backup)
-{
-    wxUnusedVar(backup);
-    wxCSConv fontEncConv(EditorConfigST::Get()->GetOptions()->GetFileFontEncoding());
-    return FileUtils::WriteFileContent(file_name, content, fontEncConv);
 }
 
 bool CopyToClipboard(const wxString& text)

--- a/Plugin/globals.h
+++ b/Plugin/globals.h
@@ -144,15 +144,6 @@ WXDLLIMPEXP_SDK bool CompareFileWithString(const wxString& filePath, const wxStr
 WXDLLIMPEXP_SDK bool IsValidCppIdentifier(const wxString& id);
 
 /**
- * \brief write file content with optional backup
- * \param file_name
- * \param content
- * \param backup
- * \return true on success, false otherwise
- */
-WXDLLIMPEXP_SDK bool WriteFileWithBackup(const wxString& file_name, const wxString& content, bool backup);
-
-/**
  * \brief copy text to the clipboard
  * \return true on success false otherwise
  */

--- a/QmakePlugin/qmakeplugin.cpp
+++ b/QmakePlugin/qmakeplugin.cpp
@@ -462,7 +462,7 @@ void QMakePlugin::OnNewQmakeBasedProject(wxCommandEvent& event)
                 wxSetWorkingDirectory(name);
             }
 
-            if (!WriteFileWithBackup(name + wxT(".project"), content, false)) {
+            if (!FileUtils::WriteFileContent(name + wxT(".project"), content)) {
                 wxMessageBox(wxString::Format(
                                  _("Failed to create .project file '%s'"), wxString(name + wxT(".project")).c_str()),
                              wxT("CodeLite"),

--- a/git/gitFileDiffDlg.cpp
+++ b/git/gitFileDiffDlg.cpp
@@ -25,8 +25,9 @@
 
 #include "gitFileDiffDlg.h"
 
+#include "editor_config.h"
+#include "fileutils.h"
 #include "gitCommitEditor.h"
-#include "globals.h"
 #include "windowattrmanager.h"
 
 #include <wx/filedlg.h>
@@ -51,7 +52,8 @@ void GitFileDiffDlg::OnSaveAsPatch(wxCommandEvent& event)
     wxString path = ::wxFileSelector(
         _("Save as"), "", "untitled", "patch", wxFileSelectorDefaultWildcardStr, wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
     if (!path.IsEmpty()) {
-        ::WriteFileWithBackup(path, m_editor->GetText(), false);
+        wxCSConv fontEncConv(EditorConfigST::Get()->GetOptions()->GetFileFontEncoding());
+        FileUtils::WriteFileContent(path, m_editor->GetText(), fontEncConv);
         ::wxMessageBox("Diff written to:\n" + path, "CodeLite");
         // Close the dialog
         CallAfter(&GitFileDiffDlg::EndModal, wxID_CLOSE);

--- a/wxformbuilder/wxformbuilder.cpp
+++ b/wxformbuilder/wxformbuilder.cpp
@@ -262,7 +262,7 @@ void wxFormBuilder::DoCreateWxFormBuilderProject(const wxFBItemInfo& data)
         content.Replace(wxT("$(Title)"), data.title);
         content.Replace(wxT("$(ClassName)"), data.className);
 
-        if (!WriteFileWithBackup(fbpFile.GetFullPath().c_str(), content, false)) {
+        if (!FileUtils::WriteFileContent(fbpFile.GetFullPath(), content)) {
             wxMessageBox(wxString::Format(_("Failed to write file '%s'"), fbpFile.GetFullPath().c_str()),
                          wxT("CodeLite"),
                          wxOK | wxCENTER | wxICON_WARNING);


### PR DESCRIPTION
[cleanup] Remove `WriteFileWithBackup` which ignore backup.

If backup of copyright should be removed instead, check box option should be removed too.