### PR TITLE
[Fix] Fix bug introduced by Json nlohmann (#3902)

### DIFF
--- a/CodeLite/JSON.cpp
+++ b/CodeLite/JSON.cpp
@@ -317,15 +317,22 @@ std::unordered_map<std::string_view, JSONItem> JSONItem::GetAsMap() const
 
 wxStringMap_t JSONItem::toStringMap(const wxStringMap_t& default_map) const
 {
-    if (!m_json || !isArray()) {
+    if (!m_json || (!isArray() && !isObject())) {
         return default_map;
     }
     wxStringMap_t res;
-
-    for (int i = 0; i < arraySize(); ++i) {
-        wxString key = arrayItem(i).namedObject("key").toString();
-        wxString val = arrayItem(i).namedObject("value").toString();
-        res.emplace(key, val);
+    if (isArray()) {
+        for (int i = 0; i < arraySize(); ++i) {
+            wxString key = arrayItem(i).namedObject("key").toString();
+            wxString val = arrayItem(i).namedObject("value").toString();
+            res.emplace(key, val);
+        }
+    } else {
+        for (auto& [key, child] : m_json->items()) {
+            if (child.is_string()) {
+                res.emplace(key, wxString::FromUTF8(child.get<std::string>()));
+            }
+        }
     }
     return res;
 }

--- a/CodeLite/json_utils.h
+++ b/CodeLite/json_utils.h
@@ -57,11 +57,25 @@ inline wxSize ToSize(const nlohmann::json& json)
 
 inline wxStringMap_t ToStringMap(const nlohmann::json& json)
 {
-    wxStringMap_t res;
-    for (const auto& [key, item] : json.items()) {
-        res[wxString::FromUTF8(key)] = wxString::FromUTF8(item);
+    if (json.is_object()) {
+        wxStringMap_t res;
+        for (const auto& [key, item] : json.items()) {
+            res[wxString::FromUTF8(key)] = wxString::FromUTF8(item);
+        }
+        return res;
+    } else if (json.is_array()) {
+        wxStringMap_t res;
+        for (const auto& child : json) {
+            if (!child.is_object() || !child.contains("key") || !child.contains("value")) {
+                continue;
+            }
+            res[wxString::FromUTF8(child["key"].get<std::string>())] =
+                wxString::FromUTF8(child["value"].get<std::string>());
+        }
+        return res;
+    } else {
+        return {};
     }
-    return res;
 }
 
 inline std::string ToJsonValue(const wxSize& sz) { return std::to_string(sz.x) + "," + std::to_string(sz.y); }

--- a/Tests/CodeliteTest/JsonTests.cpp
+++ b/Tests/CodeliteTest/JsonTests.cpp
@@ -361,6 +361,7 @@ TEST_CASE("toStringMap") {
     root.toElement().addProperty("map", map);
 
     CHECK(map == root.toElement()["map"].toStringMap());
+    CHECK(map == JSONItem{JsonUtils::ToJson(map)}.toStringMap());
 }
 
 TEST_CASE("GetAsVector") {

--- a/Tests/CodeliteTest/json_utilsTests.cpp
+++ b/Tests/CodeliteTest/json_utilsTests.cpp
@@ -12,4 +12,5 @@ TEST_CASE("wxStringMap_t")
 {
     const wxStringMap_t map = {{"hello", "world"}, {"key", "value"}};
     CHECK(map == JsonUtils::ToStringMap(JsonUtils::ToJson(map)));
+    CHECK(map == JsonUtils::ToStringMap(nlohmann::json{nlohmann::json{{"key", "hello"}, {"value", "world"}}, nlohmann::json{{"key", "key"}, {"value", "value"}}}));
 }


### PR DESCRIPTION
`wxStringMap_t` was serialized as `[{"key": "key1", "value": "value1"}, {"key": "key2", "value": "value2"}]`, and I wrongly changed that `{"key1": "value1", "key2": "value2"}`. I change deserialization to support both.