### PR TITLE
[cleanup] Continue migration to `nlohmann::json`: `ToJSON` of `LSP` returns `nlohmann::json`

### DIFF
--- a/CodeLite/LSP/CodeActionRequest.cpp
+++ b/CodeLite/LSP/CodeActionRequest.cpp
@@ -12,7 +12,7 @@ LSP::CodeActionRequest::CodeActionRequest(const LSP::TextDocumentIdentifier& tex
     m_params->As<CodeActionParams>()->SetTextDocument(textDocument);
     m_params->As<CodeActionParams>()->SetRange(range);
     m_params->As<CodeActionParams>()->SetDiagnostics(diags);
-    LSP_DEBUG() << ToJSON().format(true) << endl;
+    LSP_DEBUG() << wxString::FromUTF8(ToJSON().dump(2)) << endl;
 }
 
 std::optional<LSPEvent> LSP::CodeActionRequest::OnResponse(const LSP::ResponseMessage& response, wxEvtHandler* owner)

--- a/CodeLite/LSP/CompletionItem.cpp
+++ b/CodeLite/LSP/CompletionItem.cpp
@@ -1,6 +1,6 @@
 #include "CompletionItem.h"
 
-JSONItem LSP::CompletionItem::ToJSON() const { return JSONItem(nullptr); }
+nlohmann::json LSP::CompletionItem::ToJSON() const { return nullptr; }
 
 void LSP::CompletionItem::FromJSON(const JSONItem& json)
 {

--- a/CodeLite/LSP/CompletionItem.h
+++ b/CodeLite/LSP/CompletionItem.h
@@ -65,7 +65,7 @@ public:
 public:
     CompletionItem() = default;
     ~CompletionItem() override = default;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     void FromJSON(const JSONItem& json) override;
     void SetDetail(const wxString& detail) { this->m_detail = detail; }
     void SetDocumentation(const MarkupContent& documentation) { this->m_documentation = documentation; }

--- a/CodeLite/LSP/InitializeRequest.cpp
+++ b/CodeLite/LSP/InitializeRequest.cpp
@@ -8,76 +8,51 @@ LSP::InitializeRequest::InitializeRequest(bool withTokenTypes, const wxString& r
     m_rootUri = rootUri;
 }
 
-JSONItem LSP::InitializeRequest::ToJSON() const
+nlohmann::json LSP::InitializeRequest::ToJSON() const
 {
-    JSONItem json = Request::ToJSON();
+    auto json = Request::ToJSON();
 
     // add the 'params'
-    JSONItem params = JSONItem::createObject();
-    params.addProperty("processId", GetProcessId());
+    nlohmann::json params = nlohmann::json::object();
+    params["processId"] = GetProcessId();
     if (!GetRootUri().IsEmpty()) {
-        params.addProperty("rootUri", LSP::FileNameToURI(GetRootUri()));
+        params["rootUri"] = LSP::FileNameToURI(GetRootUri()).ToStdString(wxConvUTF8);
     }
 
     if (!m_initOptions.empty()) {
         // Parse the JSON string and set it as the 'initializationOptions
-        JSON initializationOptions(m_initOptions);
-        if (initializationOptions.isOk()) {
-            params.addProperty(wxString("initializationOptions"), std::move(initializationOptions));
+        auto initializationOptions =
+            nlohmann::ordered_json::parse(m_initOptions.mb_str(wxConvUTF8).data(), nullptr, false);
+        if (!initializationOptions.is_discarded()) {
+            params["initializationOptions"] = std::move(initializationOptions);
         }
     }
 
-    auto capabilities = params.AddObject("capabilities");
-    auto windowCapabilities = capabilities.AddObject("window");
-    windowCapabilities.addProperty("workDoneProgress", true);
+    auto& capabilities = params["capabilities"] = nlohmann::json::object();
+    capabilities["window"] = nlohmann::json{{"workDoneProgress", true}};
 
-    auto textDocumentCapabilities = capabilities.AddObject("textDocument");
-    auto docFormat =
-        textDocumentCapabilities.AddObject("completion").AddObject("completionItem").AddArray("documentationFormat");
-    docFormat.arrayAppend("plaintext");
-    auto hoverFormat = textDocumentCapabilities.AddObject("hover").AddArray("contentFormat");
-    hoverFormat.arrayAppend("markdown");
-    hoverFormat.arrayAppend("plaintext");
+    auto& textDocumentCapabilities = capabilities["textDocument"];
+    textDocumentCapabilities["completion"]["completionItem"]["documentationFormat"] = std::array{"plaintext"};
+    textDocumentCapabilities["hover"]["contentFormat"] = {"markdown", "plaintext"};
 
     if (m_withTokenTypes) {
-        auto sematicTokens = textDocumentCapabilities.AddObject("semanticTokens");
-        auto tokenTypes = sematicTokens.AddArray("tokenTypes");
-        tokenTypes.arrayAppend("type");
-        tokenTypes.arrayAppend("class");
-        tokenTypes.arrayAppend("enum");
-        tokenTypes.arrayAppend("interface");
-        tokenTypes.arrayAppend("struct");
-        tokenTypes.arrayAppend("typeParameter");
-        tokenTypes.arrayAppend("parameter");
-        tokenTypes.arrayAppend("variable");
-        tokenTypes.arrayAppend("property");
-        tokenTypes.arrayAppend("enumMember");
-        tokenTypes.arrayAppend("event");
-        tokenTypes.arrayAppend("function");
-        tokenTypes.arrayAppend("method");
-        tokenTypes.arrayAppend("macro");
-        tokenTypes.arrayAppend("keyword");
-        tokenTypes.arrayAppend("modifier");
-        tokenTypes.arrayAppend("comment");
-        tokenTypes.arrayAppend("string");
-        tokenTypes.arrayAppend("number");
-        tokenTypes.arrayAppend("regexp");
-        tokenTypes.arrayAppend("operator");
-
-        auto tokenModifiers = sematicTokens.AddArray("tokenModifiers");
-        tokenModifiers.arrayAppend("declaration");
-        tokenModifiers.arrayAppend("definition");
-        tokenModifiers.arrayAppend("readonly");
-        tokenModifiers.arrayAppend("static");
-        tokenModifiers.arrayAppend("deprecated");
-        tokenModifiers.arrayAppend("abstract");
-        tokenModifiers.arrayAppend("async");
-        tokenModifiers.arrayAppend("modification");
-        tokenModifiers.arrayAppend("documentation");
-        tokenModifiers.arrayAppend("defaultLibrary");
+        textDocumentCapabilities["semanticTokens"]["tokenTypes"] = {
+            "type",     "class",    "enum",       "interface", "struct",   "typeParameter", "parameter",
+            "variable", "property", "enumMember", "event",     "function", "method",        "macro",
+            "keyword",  "modifier", "comment",    "string",    "number",   "regexp",        "operator"};
+        textDocumentCapabilities["semanticTokens"]["tokenModifiers"] = {"declaration",
+                                                                        "definition",
+                                                                        "readonly",
+                                                                        "static",
+                                                                        "deprecated",
+                                                                        "abstract",
+                                                                        "async",
+                                                                        "modification",
+                                                                        "documentation",
+                                                                        "defaultLibrary"};
     }
 
-    json.addProperty("params", params);
+    json["params"] = std::move(params);
     return json;
 }
 

--- a/CodeLite/LSP/InitializeRequest.h
+++ b/CodeLite/LSP/InitializeRequest.h
@@ -27,7 +27,7 @@ public:
     }
     int GetProcessId() const { return m_processId; }
     const wxString& GetRootUri() const { return m_rootUri; }
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     std::optional<LSPEvent> OnResponse(const LSP::ResponseMessage& response, wxEvtHandler* owner) override;
     bool IsPositionDependentRequest() const override { return false; }
     void SetInitOptions(const wxString& initOptions) { this->m_initOptions = initOptions; }

--- a/CodeLite/LSP/InitializedNotification.cpp
+++ b/CodeLite/LSP/InitializedNotification.cpp
@@ -3,7 +3,7 @@
 namespace LSP
 {
 struct InitializedParams : public Params {
-    JSONItem ToJSON() const override { return nlohmann::json::object(); }
+    nlohmann::json ToJSON() const override { return nlohmann::json::object(); }
 
     void FromJSON(const JSONItem& json) override { wxUnusedVar(json); };
 };

--- a/CodeLite/LSP/JSONObject.h
+++ b/CodeLite/LSP/JSONObject.h
@@ -14,7 +14,7 @@ class WXDLLIMPEXP_CL Serializable
 public:
     Serializable() = default;
     virtual ~Serializable() = default;
-    virtual JSONItem ToJSON() const = 0;
+    virtual nlohmann::json ToJSON() const = 0;
     virtual void FromJSON(const JSONItem& json) = 0;
 
     bool operator==(const Serializable&) const = default;

--- a/CodeLite/LSP/Message.cpp
+++ b/CodeLite/LSP/Message.cpp
@@ -38,7 +38,7 @@ int ReadHeaders(const std::string& message, std::unordered_map<std::string, std:
 
 } // namespace
 
-JSONItem LSP::Message::ToJSON() const { return nlohmann::json{{"jsonrpc", m_jsonrpc.ToStdString(wxConvUTF8)}}; }
+nlohmann::json LSP::Message::ToJSON() const { return nlohmann::json{{"jsonrpc", m_jsonrpc.ToStdString(wxConvUTF8)}}; }
 
 void LSP::Message::FromJSON(const JSONItem& json) { m_jsonrpc = json.namedObject("jsonrpc").toString(); }
 

--- a/CodeLite/LSP/Message.h
+++ b/CodeLite/LSP/Message.h
@@ -20,7 +20,7 @@ public:
 public:
     Message() = default;
     ~Message() override = default;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     void FromJSON(const JSONItem& json) override;
 
     /**

--- a/CodeLite/LSP/MessageWithParams.cpp
+++ b/CodeLite/LSP/MessageWithParams.cpp
@@ -6,12 +6,12 @@
 #include <sstream>
 #include <wx/string.h>
 
-JSONItem LSP::MessageWithParams::ToJSON() const
+nlohmann::json LSP::MessageWithParams::ToJSON() const
 {
-    JSONItem json = Message::ToJSON();
-    json.addProperty("method", GetMethod());
+    auto json = Message::ToJSON();
+    json["method"] = GetMethod().ToStdString(wxConvUTF8);
     if (m_params) {
-        json.addProperty("params", m_params->ToJSON());
+        json["params"] = m_params->ToJSON();
     }
     return json;
 }

--- a/CodeLite/LSP/MessageWithParams.h
+++ b/CodeLite/LSP/MessageWithParams.h
@@ -25,7 +25,7 @@ protected:
 public:
     MessageWithParams() = default;
     ~MessageWithParams() override = default;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     void FromJSON(const JSONItem& json) override;
     std::string ToString() const override;
 

--- a/CodeLite/LSP/RenameRequest.cpp
+++ b/CodeLite/LSP/RenameRequest.cpp
@@ -37,7 +37,7 @@ std::optional<LSPEvent> LSP::RenameRequest::OnResponse(const LSP::ResponseMessag
         for (const auto& [filepath, changes] : modifications) {
             LSP_DEBUG() << "  " << filepath << modifications.size() << "changes:" << endl;
             for (const auto& change : changes) {
-                LSP_DEBUG() << "    " << change.ToJSON().format(false) << endl;
+                LSP_DEBUG() << "    " << wxString::FromUTF8(change.ToJSON().dump(0)) << endl;
             }
         }
     }

--- a/CodeLite/LSP/Request.cpp
+++ b/CodeLite/LSP/Request.cpp
@@ -5,10 +5,10 @@ LSP::Request::Request()
 {
 }
 
-JSONItem LSP::Request::ToJSON() const
+nlohmann::json LSP::Request::ToJSON() const
 {
-    JSONItem json = MessageWithParams::ToJSON();
-    json.addProperty("id", GetId());
+    auto json = MessageWithParams::ToJSON();
+    json["id"] = GetId();
     return json;
 }
 

--- a/CodeLite/LSP/Request.h
+++ b/CodeLite/LSP/Request.h
@@ -22,7 +22,7 @@ public:
     void SetId(int id) { this->m_id = id; }
     int GetId() const { return m_id; }
 
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     void FromJSON(const JSONItem& json) override;
 
     /**

--- a/CodeLite/LSP/ResponseError.cpp
+++ b/CodeLite/LSP/ResponseError.cpp
@@ -22,4 +22,4 @@ void LSP::ResponseError::FromJSON(const JSONItem& json)
 
 std::string LSP::ResponseError::ToString() const { return ""; }
 
-JSONItem LSP::ResponseError::ToJSON() const { return JSONItem(nullptr); }
+nlohmann::json LSP::ResponseError::ToJSON() const { return nullptr; }

--- a/CodeLite/LSP/ResponseError.h
+++ b/CodeLite/LSP/ResponseError.h
@@ -32,7 +32,7 @@ public:
     ResponseError() = default;
     ~ResponseError() override = default;
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     std::string ToString() const override;
     void SetErrorCode(int errorCode) { this->m_errorCode = errorCode; }
     void SetMessage(const wxString& message) { this->m_message = message; }

--- a/CodeLite/LSP/ResponseMessage.cpp
+++ b/CodeLite/LSP/ResponseMessage.cpp
@@ -18,7 +18,7 @@ std::string LSP::ResponseMessage::ToString() const
 }
 
 // we don't really serialise response messages
-JSONItem LSP::ResponseMessage::ToJSON() const { return JSONItem(nullptr); }
+nlohmann::json LSP::ResponseMessage::ToJSON() const { return nullptr; }
 
 void LSP::ResponseMessage::FromJSON(const JSONItem& json)
 {

--- a/CodeLite/LSP/ResponseMessage.h
+++ b/CodeLite/LSP/ResponseMessage.h
@@ -15,7 +15,7 @@ class WXDLLIMPEXP_CL ResponseMessage : public LSP::Message
 public:
     ResponseMessage(std::unique_ptr<JSON>&& json);
     ~ResponseMessage() override = default;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     void FromJSON(const JSONItem& json) override;
 
     std::string ToString() const override;

--- a/CodeLite/LSP/WorkspaceExecuteCommand.cpp
+++ b/CodeLite/LSP/WorkspaceExecuteCommand.cpp
@@ -7,7 +7,7 @@ WorkspaceExecuteCommand::WorkspaceExecuteCommand(const wxString& filepath, const
 {
     SetMethod("workspace/executeCommand");
     m_params.reset(new ExecuteCommandParams(command.GetCommand(), command.GetArguments()));
-    LSP_DEBUG() << ToJSON().format(true) << endl;
+    LSP_DEBUG() << wxString::FromUTF8(ToJSON().dump(2)) << endl;
 }
 
 std::optional<LSPEvent> WorkspaceExecuteCommand::OnResponse(const LSP::ResponseMessage& response, wxEvtHandler* owner)

--- a/CodeLite/LSP/WorkspaceSymbolRequest.cpp
+++ b/CodeLite/LSP/WorkspaceSymbolRequest.cpp
@@ -34,7 +34,7 @@ public:
 
     void FromJSON(const JSONItem& json) override { m_query = json["query"].toString(); }
 
-    JSONItem ToJSON() const override { return nlohmann::json{{"query", m_query.ToStdString(wxConvUTF8)}}; }
+    nlohmann::json ToJSON() const override { return nlohmann::json{{"query", m_query.ToStdString(wxConvUTF8)}}; }
 
     void SetQuery(const wxString& query) { this->m_query = query; }
     const wxString& GetQuery() const { return this->m_query; }

--- a/CodeLite/LSP/basic_types.cpp
+++ b/CodeLite/LSP/basic_types.cpp
@@ -39,7 +39,7 @@ void TextDocumentIdentifier::FromJSON(const JSONItem& json)
     URI::FromString(json.namedObject("uri").toString(), &m_filename);
 }
 
-JSONItem TextDocumentIdentifier::ToJSON() const
+nlohmann::json TextDocumentIdentifier::ToJSON() const
 { return nlohmann::json{{"uri", GetPathAsURI().ToStdString(wxConvUTF8)}}; }
 
 //===----------------------------------------------------------------------------------
@@ -51,10 +51,10 @@ void VersionedTextDocumentIdentifier::FromJSON(const JSONItem& json)
     m_version = json.namedObject("version").toInt(m_version);
 }
 
-JSONItem VersionedTextDocumentIdentifier::ToJSON() const
+nlohmann::json VersionedTextDocumentIdentifier::ToJSON() const
 {
-    JSONItem json = TextDocumentIdentifier::ToJSON();
-    json.addProperty("version", m_version);
+    auto json = TextDocumentIdentifier::ToJSON();
+    json["version"] = m_version;
     return json;
 }
 
@@ -67,7 +67,7 @@ void Position::FromJSON(const JSONItem& json)
     m_character = json.namedObject("character").toInt(wxNOT_FOUND);
 }
 
-JSONItem Position::ToJSON() const { return nlohmann::json{{"line", m_line}, {"character", m_character}}; }
+nlohmann::json Position::ToJSON() const { return nlohmann::json{{"line", m_line}, {"character", m_character}}; }
 
 //===----------------------------------------------------------------------------------
 // TextDocumentItem
@@ -81,7 +81,7 @@ void TextDocumentItem::FromJSON(const JSONItem& json)
     m_text = json.namedObject("text").toString();
 }
 
-JSONItem TextDocumentItem::ToJSON() const
+nlohmann::json TextDocumentItem::ToJSON() const
 {
     return nlohmann::json{{"uri", GetPathAsURI().ToStdString(wxConvUTF8)},
                           {"languageId", GetLanguageId().ToStdString(wxConvUTF8)},
@@ -99,13 +99,13 @@ void TextDocumentContentChangeEvent::FromJSON(const JSONItem& json)
     }
 }
 
-JSONItem TextDocumentContentChangeEvent::ToJSON() const
+nlohmann::json TextDocumentContentChangeEvent::ToJSON() const
 {
-    JSONItem json = JSONItem::createObject();
+    nlohmann::json json = {{"text", m_text.ToStdString(wxConvUTF8)}};
+
     if (m_range.IsOk()) {
-        json.addProperty("range", m_range.ToJSON());
+        json["range"] = m_range.ToJSON();
     }
-    json.addProperty("text", m_text);
     return json;
 }
 
@@ -115,13 +115,7 @@ void Range::FromJSON(const JSONItem& json)
     m_end.FromJSON(json["end"]);
 }
 
-JSONItem Range::ToJSON() const
-{
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("start", m_start.ToJSON());
-    json.addProperty("end", m_end.ToJSON());
-    return json;
-}
+nlohmann::json Range::ToJSON() const { return nlohmann::json{{"start", m_start.ToJSON()}, {"end", m_end.ToJSON()}}; }
 
 void Location::FromJSON(const JSONItem& json)
 {
@@ -131,14 +125,12 @@ void Location::FromJSON(const JSONItem& json)
     m_name = json["name"].toString();
 }
 
-JSONItem Location::ToJSON() const
+nlohmann::json Location::ToJSON() const
 {
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("uri", GetPathAsURI());
-    json.addProperty("range", m_range.ToJSON());
-    json.addProperty("pattern", m_pattern);
-    json.addProperty("name", m_name);
-    return json;
+    return nlohmann::json{{"uri", GetPathAsURI().ToStdString(wxConvUTF8)},
+                          {"range", m_range.ToJSON()},
+                          {"pattern", m_pattern.ToStdString(wxConvUTF8)},
+                          {"name", m_name.ToStdString(wxConvUTF8)}};
 }
 
 void TextEdit::FromJSON(const JSONItem& json)
@@ -147,13 +139,8 @@ void TextEdit::FromJSON(const JSONItem& json)
     m_newText = json.namedObject("newText").toString();
 }
 
-JSONItem TextEdit::ToJSON() const
-{
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("newText", m_newText);
-    json.addProperty("range", m_range.ToJSON());
-    return json;
-}
+nlohmann::json TextEdit::ToJSON() const
+{ return nlohmann::json{{"newText", m_newText.ToStdString(wxConvUTF8)}, {"range", m_range.ToJSON()}}; }
 
 void ParameterInformation::FromJSON(const JSONItem& json)
 {
@@ -161,7 +148,7 @@ void ParameterInformation::FromJSON(const JSONItem& json)
     m_documentation = json.namedObject("documentation").toString();
 }
 
-JSONItem ParameterInformation::ToJSON() const
+nlohmann::json ParameterInformation::ToJSON() const
 {
     return nlohmann::json{
         {"label", m_label.ToStdString(wxConvUTF8)}, {"documentation", m_documentation.ToStdString(wxConvUTF8)}};
@@ -186,17 +173,16 @@ void SignatureInformation::FromJSON(const JSONItem& json)
     }
 }
 
-JSONItem SignatureInformation::ToJSON() const
+nlohmann::json SignatureInformation::ToJSON() const
 {
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("label", m_label);
-    json.addProperty("documentation", m_documentation);
+    nlohmann::json json = {
+        {"label", m_label.ToStdString(wxConvUTF8)}, {"documentation", m_documentation.ToStdString(wxConvUTF8)}};
     if (!m_parameters.empty()) {
-        JSONItem params = JSONItem::createArray();
+        nlohmann::json params = nlohmann::json::array();
         for (const auto& paramInfo : m_parameters) {
-            params.arrayAppend(paramInfo.ToJSON());
+            params.push_back(paramInfo.ToJSON());
         }
-        json.addProperty("parameters", params);
+        json["parameters"] = std::move(params);
     }
     return json;
 }
@@ -217,17 +203,15 @@ void SignatureHelp::FromJSON(const JSONItem& json)
     m_activeParameter = json.namedObject("activeParameter").toInt(0);
 }
 
-JSONItem SignatureHelp::ToJSON() const
+nlohmann::json SignatureHelp::ToJSON() const
 {
-    JSONItem json = JSONItem::createObject();
-    JSONItem signatures = JSONItem::createArray();
+    nlohmann::json signatures = nlohmann::json::array();
     for (const SignatureInformation& si : m_signatures) {
-        signatures.arrayAppend(si.ToJSON());
+        signatures.push_back(si.ToJSON());
     }
-    json.addProperty("signatures", signatures);
-    json.addProperty("activeSignature", m_activeSignature);
-    json.addProperty("activeParameter", m_activeParameter);
-    return json;
+    return nlohmann::json{{"signatures", std::move(signatures)},
+                          {"activeSignature", m_activeSignature},
+                          {"activeParameter", m_activeParameter}};
 }
 
 void MarkupContent::FromJSON(const JSONItem& json)
@@ -236,7 +220,7 @@ void MarkupContent::FromJSON(const JSONItem& json)
     m_value = json.namedObject("value").toString();
 }
 
-JSONItem MarkupContent::ToJSON() const
+nlohmann::json MarkupContent::ToJSON() const
 { return nlohmann::json{{"kind", m_kind.ToStdString(wxConvUTF8)}, {"value", m_value.ToStdString(wxConvUTF8)}}; }
 
 void Hover::FromJSON(const JSONItem& json)
@@ -245,13 +229,8 @@ void Hover::FromJSON(const JSONItem& json)
     m_range.FromJSON(json.namedObject("range"));
 }
 
-JSONItem Hover::ToJSON() const
-{
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("contents", m_contents.ToJSON());
-    json.addProperty("range", m_range.ToJSON());
-    return json;
-}
+nlohmann::json Hover::ToJSON() const
+{ return nlohmann::json{{"contents", m_contents.ToJSON()}, {"range", m_range.ToJSON()}}; }
 
 ///===------------------------------------------------------------------------
 /// Diagnostic
@@ -263,13 +242,11 @@ void Diagnostic::FromJSON(const JSONItem& json)
     m_severity = json.namedObject("severity").fromNumber(DiagnosticSeverity::Error);
 }
 
-JSONItem Diagnostic::ToJSON() const
+nlohmann::json Diagnostic::ToJSON() const
 {
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("range", m_range.ToJSON());
-    json.addProperty("message", GetMessage());
-    json.addProperty("severity", (int)m_severity);
-    return json;
+    return nlohmann::json{{"range", m_range.ToJSON()},
+                          {"message", GetMessage().ToStdString(wxConvUTF8)},
+                          {"severity", static_cast<int>(m_severity)}};
 }
 
 TextDocumentContentChangeEvent& TextDocumentContentChangeEvent::SetText(const wxString& text)
@@ -305,10 +282,10 @@ void DocumentSymbol::FromJSON(const JSONItem& json)
     }
 }
 
-JSONItem DocumentSymbol::ToJSON() const
+nlohmann::json DocumentSymbol::ToJSON() const
 {
     wxASSERT_MSG(false, "DocumentSymbol::ToJSON(): is not implemented");
-    return JSONItem(nullptr);
+    return nullptr;
 }
 
 //===----------------------------------------------------------------------------------
@@ -334,14 +311,12 @@ void SymbolInformation::FromJSON(const JSONItem& json)
     }
 }
 
-JSONItem SymbolInformation::ToJSON() const
+nlohmann::json SymbolInformation::ToJSON() const
 {
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("kind", (int)kind);
-    json.addProperty("containerName", containerName);
-    json.addProperty("location", location.ToJSON());
-    json.addProperty("name", name);
-    return json;
+    return nlohmann::json{{"kind", static_cast<int>(kind)},
+                          {"containerName", containerName.ToStdString(wxConvUTF8)},
+                          {"location", location.ToJSON()},
+                          {"name", name.ToStdString(wxConvUTF8)}};
 }
 
 SymbolInformation SymbolInformation::From(const CTags::SymbolInfo& ctags_symbol_info)
@@ -425,7 +400,7 @@ void Command::FromJSON(const JSONItem& json)
 }
 
 // unimplemented
-JSONItem Command::ToJSON() const { return {}; }
+nlohmann::json Command::ToJSON() const { return nullptr; }
 
 std::unordered_map<wxString, std::vector<LSP::TextEdit>> ParseWorkspaceEdit(const JSONItem& result)
 {

--- a/CodeLite/LSP/basic_types.h
+++ b/CodeLite/LSP/basic_types.h
@@ -62,6 +62,7 @@ private:
 public:
     URI() = default;
     ~URI() = default;
+    bool operator==(const URI&) const = default;
 
     static void FromString(const wxString& str, URI* o);
 
@@ -79,7 +80,7 @@ class WXDLLIMPEXP_CL Position : public Serializable
 
 public:
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     Position(int line, int col)
         : m_line(line)
@@ -116,7 +117,7 @@ class WXDLLIMPEXP_CL Range : public Serializable
 
 public:
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     Range(const Position& start, const Position& end)
         : m_start(start)
@@ -124,7 +125,10 @@ public:
     {
     }
     Range() = default;
-    virtual ~Range() = default;
+    ~Range() override = default;
+
+    bool operator==(const Range&) const = default;
+
     Range& SetEnd(const Position& end)
     {
         this->m_end = end;
@@ -149,7 +153,7 @@ class WXDLLIMPEXP_CL TextDocumentContentChangeEvent : public Serializable
     Range m_range; // Optional
 
 public:
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     void FromJSON(const JSONItem& json) override;
 
     TextDocumentContentChangeEvent() = default;
@@ -157,7 +161,10 @@ public:
         : m_text(text)
     {
     }
-    virtual ~TextDocumentContentChangeEvent() = default;
+    ~TextDocumentContentChangeEvent() override = default;
+
+    bool operator==(const TextDocumentContentChangeEvent&) const = default;
+
     TextDocumentContentChangeEvent& SetText(const wxString& text);
     const wxString& GetText() const { return m_text; }
     const Range& GetRange() const { return m_range; }
@@ -172,13 +179,15 @@ class WXDLLIMPEXP_CL TextDocumentIdentifier : public Serializable
     URI m_filename;
 
 public:
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     void FromJSON(const JSONItem& json) override;
 
     TextDocumentIdentifier() = default;
     TextDocumentIdentifier(const wxString& filename) { URI::FromString(filename, &m_filename); }
 
-    virtual ~TextDocumentIdentifier() = default;
+    ~TextDocumentIdentifier() override = default;
+    bool operator==(const TextDocumentIdentifier&) const = default;
+
     TextDocumentIdentifier& SetFilename(const wxString& filename)
     {
         URI::FromString(filename, &m_filename);
@@ -196,7 +205,7 @@ class WXDLLIMPEXP_CL VersionedTextDocumentIdentifier : public TextDocumentIdenti
     int m_version = 1;
 
 public:
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     void FromJSON(const JSONItem& json) override;
 
     VersionedTextDocumentIdentifier() = default;
@@ -204,7 +213,9 @@ public:
         : m_version(version)
     {
     }
-    virtual ~VersionedTextDocumentIdentifier() = default;
+    ~VersionedTextDocumentIdentifier() override = default;
+    bool operator==(const VersionedTextDocumentIdentifier&) const = default;
+
     VersionedTextDocumentIdentifier& SetVersion(int version)
     {
         this->m_version = version;
@@ -225,8 +236,10 @@ class WXDLLIMPEXP_CL TextEdit : public LSP::Serializable
 public:
     TextEdit() = default;
     ~TextEdit() override = default;
+    bool operator==(const TextEdit&) const = default;
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
+
     void SetNewText(const wxString& newText) { this->m_newText = newText; }
     void SetRange(const Range& range) { this->m_range = range; }
     const wxString& GetNewText() const { return m_newText; }
@@ -243,16 +256,15 @@ class WXDLLIMPEXP_CL Location : public Serializable
 
 public:
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     Location(const wxString& uri, const Range& range)
         : m_range(range)
-    {
-        URI::FromString(uri, &m_uri);
-    }
+    { URI::FromString(uri, &m_uri); }
 
     Location() = default;
-    virtual ~Location() = default;
+    ~Location() override = default;
+    bool operator==(const Location&) const = default;
     Location& SetRange(const Range& range)
     {
         this->m_range = range;
@@ -285,24 +297,24 @@ class WXDLLIMPEXP_CL TextDocumentItem : public Serializable
 
 public:
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     TextDocumentItem(const wxString& uri, const wxString& langId, const wxString& text, int version = 1)
         : m_languageId(langId)
         , m_text(text)
         , m_version(version)
-    {
-        URI::FromString(uri, &m_uri);
-    }
+    { URI::FromString(uri, &m_uri); }
 
     TextDocumentItem() = default;
-    virtual ~TextDocumentItem() = default;
+    ~TextDocumentItem() override = default;
+    bool operator==(const TextDocumentItem&) const = default;
+
     TextDocumentItem& SetLanguageId(const wxString& languageId)
     {
         this->m_languageId = languageId;
         return *this;
     }
-    TextDocumentItem& SetText(const std::string& text)
+    TextDocumentItem& SetText(const wxString& text)
     {
         this->m_text = text;
         return *this;
@@ -332,7 +344,8 @@ class WXDLLIMPEXP_CL ParameterInformation : public LSP::Serializable
 
 public:
     ParameterInformation() = default;
-    virtual ~ParameterInformation() = default;
+    ~ParameterInformation() override = default;
+    bool operator==(const ParameterInformation&) const = default;
     ParameterInformation& SetDocumentation(const wxString& documentation)
     {
         this->m_documentation = documentation;
@@ -346,7 +359,7 @@ public:
     const wxString& GetDocumentation() const { return m_documentation; }
     const wxString& GetLabel() const { return m_label; }
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     using Vec_t = std::vector<ParameterInformation>;
 };
@@ -362,7 +375,8 @@ public:
 
 public:
     SignatureInformation() = default;
-    virtual ~SignatureInformation() = default;
+    ~SignatureInformation() override = default;
+    bool operator==(const SignatureInformation&) const = default;
     SignatureInformation& SetParameters(const ParameterInformation::Vec_t& parameters)
     {
         this->m_parameters = parameters;
@@ -382,7 +396,7 @@ public:
     const wxString& GetDocumentation() const { return m_documentation; }
     const wxString& GetLabel() const { return m_label; }
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 };
 
 class WXDLLIMPEXP_CL SignatureHelp : public LSP::Serializable
@@ -393,7 +407,8 @@ class WXDLLIMPEXP_CL SignatureHelp : public LSP::Serializable
 
 public:
     SignatureHelp() = default;
-    virtual ~SignatureHelp() = default;
+    ~SignatureHelp() override = default;
+    bool operator==(const SignatureHelp&) const = default;
 
     SignatureHelp& SetActiveParameter(int activeParameter)
     {
@@ -414,7 +429,7 @@ public:
     int GetActiveSignature() const { return m_activeSignature; }
     const SignatureInformation::Vec_t& GetSignatures() const { return m_signatures; }
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 };
 
 class WXDLLIMPEXP_CL MarkupContent : public LSP::Serializable
@@ -424,7 +439,9 @@ class WXDLLIMPEXP_CL MarkupContent : public LSP::Serializable
 
 public:
     MarkupContent() = default;
-    virtual ~MarkupContent() = default;
+    ~MarkupContent() override = default;
+    bool operator==(const MarkupContent&) const = default;
+
     MarkupContent& SetKind(const wxString& kind)
     {
         this->m_kind = kind;
@@ -438,7 +455,7 @@ public:
     }
     const wxString& GetValue() const { return m_value; }
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 };
 
 class WXDLLIMPEXP_CL Hover : public LSP::Serializable
@@ -448,7 +465,9 @@ class WXDLLIMPEXP_CL Hover : public LSP::Serializable
 
 public:
     Hover() = default;
-    virtual ~Hover() = default;
+    ~Hover() override = default;
+    bool operator==(const Hover&) const = default;
+
     Hover& SetContents(const MarkupContent& contents)
     {
         this->m_contents = contents;
@@ -462,7 +481,7 @@ public:
     }
     const Range& GetRange() const { return m_range; }
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 };
 
 enum DiagnosticSeverity {
@@ -492,7 +511,7 @@ class WXDLLIMPEXP_CL Diagnostic : public Serializable
 
 public:
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     Diagnostic(const Range& range, const wxString& message)
         : m_range(range)
@@ -500,7 +519,9 @@ public:
     {
     }
     Diagnostic() = default;
-    virtual ~Diagnostic() = default;
+    ~Diagnostic() override = default;
+    bool operator==(const Diagnostic&) const = default;
+
     Diagnostic& SetRange(const Range& range)
     {
         this->m_range = range;
@@ -525,10 +546,11 @@ class WXDLLIMPEXP_CL Command : public Serializable
 
 public:
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const;
 
     Command() = default;
-    virtual ~Command() = default;
+    ~Command() override = default;
+    bool operator==(const Command&) const = default;
 
     void SetTitle(const wxString& title) { this->m_title = title; }
     void SetCommand(const wxString& command) { this->m_command = command; }
@@ -577,10 +599,11 @@ class WXDLLIMPEXP_CL DocumentSymbol : public Serializable
 
 public:
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     DocumentSymbol() = default;
-    virtual ~DocumentSymbol() = default;
+    ~DocumentSymbol() override = default;
+    bool operator==(const DocumentSymbol&) const = default;
 
     void SetChildren(const std::vector<DocumentSymbol>& children) { this->children = children; }
     void SetDetail(const wxString& detail) { this->detail = detail; }
@@ -631,10 +654,11 @@ class WXDLLIMPEXP_CL SymbolInformation : public Serializable
 
 public:
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     SymbolInformation() = default;
-    virtual ~SymbolInformation() = default;
+    ~SymbolInformation() override = default;
+    bool operator==(const SymbolInformation&) const = default;
 
     void SetContainerName(const wxString& containerName) { this->containerName = containerName; }
     void SetKind(const eSymbolKind& kind) { this->kind = kind; }

--- a/CodeLite/LSP/json_rpc_params.cpp
+++ b/CodeLite/LSP/json_rpc_params.cpp
@@ -12,13 +12,8 @@ void TextDocumentPositionParams::FromJSON(const JSONItem& json)
     m_position.FromJSON(json["position"]);
 }
 
-JSONItem TextDocumentPositionParams::ToJSON() const
-{
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("textDocument", m_textDocument.ToJSON());
-    json.addProperty("position", m_position.ToJSON());
-    return json;
-}
+nlohmann::json TextDocumentPositionParams::ToJSON() const
+{ return nlohmann::json{{"textDocument", m_textDocument.ToJSON()}, {"position", m_position.ToJSON()}}; }
 
 //===----------------------------------------------
 // SemanticTokensParams
@@ -26,12 +21,8 @@ JSONItem TextDocumentPositionParams::ToJSON() const
 
 void SemanticTokensParams::FromJSON(const JSONItem& json) { m_textDocument.FromJSON(json["textDocument"]); }
 
-JSONItem SemanticTokensParams::ToJSON() const
-{
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("textDocument", m_textDocument.ToJSON());
-    return json;
-}
+nlohmann::json SemanticTokensParams::ToJSON() const
+{ return nlohmann::json{{"textDocument", m_textDocument.ToJSON()}}; }
 
 //===----------------------------------------------------------------------------------
 // DidOpenTextDocumentParams
@@ -39,12 +30,8 @@ JSONItem SemanticTokensParams::ToJSON() const
 
 void DidOpenTextDocumentParams::FromJSON(const JSONItem& json) { m_textDocument.FromJSON(json["textDocument"]); }
 
-JSONItem DidOpenTextDocumentParams::ToJSON() const
-{
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("textDocument", m_textDocument.ToJSON());
-    return json;
-}
+nlohmann::json DidOpenTextDocumentParams::ToJSON() const
+{ return nlohmann::json{{"textDocument", m_textDocument.ToJSON()}}; }
 
 //===----------------------------------------------------------------------------------
 // DidCloseTextDocumentParams
@@ -52,12 +39,8 @@ JSONItem DidOpenTextDocumentParams::ToJSON() const
 
 void DidCloseTextDocumentParams::FromJSON(const JSONItem& json) { m_textDocument.FromJSON(json["textDocument"]); }
 
-JSONItem DidCloseTextDocumentParams::ToJSON() const
-{
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("textDocument", m_textDocument.ToJSON());
-    return json;
-}
+nlohmann::json DidCloseTextDocumentParams::ToJSON() const
+{ return nlohmann::json{{"textDocument", m_textDocument.ToJSON()}}; }
 
 //===----------------------------------------------------------------------------------
 // DidChangeTextDocumentParams
@@ -78,16 +61,13 @@ void DidChangeTextDocumentParams::FromJSON(const JSONItem& json)
     }
 }
 
-JSONItem DidChangeTextDocumentParams::ToJSON() const
+nlohmann::json DidChangeTextDocumentParams::ToJSON() const
 {
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("textDocument", m_textDocument.ToJSON());
-    JSONItem arr = JSONItem::createArray();
+    nlohmann::json arr = nlohmann::json::array();
     for (const auto& contentChange : m_contentChanges) {
-        arr.arrayAppend(contentChange.ToJSON());
+        arr.push_back(contentChange.ToJSON());
     }
-    json.addProperty("contentChanges", arr);
-    return json;
+    return nlohmann::json{{"textDocument", m_textDocument.ToJSON()}, {"contentChanges", std::move(arr)}};
 }
 
 //===----------------------------------------------------------------------------------
@@ -100,13 +80,8 @@ void DidSaveTextDocumentParams::FromJSON(const JSONItem& json)
     m_text = json["text"].toString();
 }
 
-JSONItem DidSaveTextDocumentParams::ToJSON() const
-{
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("textDocument", m_textDocument.ToJSON());
-    json.addProperty("text", m_text);
-    return json;
-}
+nlohmann::json DidSaveTextDocumentParams::ToJSON() const
+{ return nlohmann::json{{"textDocument", m_textDocument.ToJSON()}, {"text", m_text.ToStdString(wxConvUTF8)}}; }
 
 //===----------------------------------------------------------------------------------
 // CompletionParams
@@ -114,11 +89,7 @@ JSONItem DidSaveTextDocumentParams::ToJSON() const
 
 void CompletionParams::FromJSON(const JSONItem& json) { TextDocumentPositionParams::FromJSON(json); }
 
-JSONItem CompletionParams::ToJSON() const
-{
-    JSONItem json = TextDocumentPositionParams::ToJSON();
-    return json;
-}
+nlohmann::json CompletionParams::ToJSON() const { return TextDocumentPositionParams::ToJSON(); }
 
 //===----------------------------------------------------------------------------------
 // CodeActionParams
@@ -131,15 +102,14 @@ ExecuteCommandParams::ExecuteCommandParams(const wxString& command, const wxStri
 
 void ExecuteCommandParams::FromJSON(const JSONItem& json) { wxUnusedVar(json); }
 
-JSONItem ExecuteCommandParams::ToJSON() const
+nlohmann::json ExecuteCommandParams::ToJSON() const
 {
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("command", m_command);
-    // parse the "arguments"
-    // and add them
-    JSON root{m_arguments};
-    if (root.isOk()) {
-        json.addProperty("arguments", std::move(root));
+    nlohmann::json json = {{"command", m_command.ToStdString(wxConvUTF8)}};
+
+    // parse the "arguments" and add them
+    auto argument_json = nlohmann::ordered_json::parse(m_arguments.ToStdString(wxConvUTF8), nullptr, false);
+    if (!argument_json.is_discarded()) {
+        json["arguments"] = std::move(argument_json);
     }
     return json;
 }
@@ -150,19 +120,15 @@ JSONItem ExecuteCommandParams::ToJSON() const
 
 void CodeActionParams::FromJSON(const JSONItem& json) { wxUnusedVar(json); }
 
-JSONItem CodeActionParams::ToJSON() const
+nlohmann::json CodeActionParams::ToJSON() const
 {
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("textDocument", m_textDocument.ToJSON());
-    json.addProperty("range", m_range.ToJSON());
-
-    // add empty context
-    auto context = json.AddObject("context");
-    auto diags_arr = context.AddArray("diagnostics"); // empty array
+    auto diags_arr = nlohmann::json::array();
     for (const auto& diag : m_diagnostics) {
-        diags_arr.arrayAppend(diag.ToJSON());
+        diags_arr.push_back(diag.ToJSON());
     }
-    return json;
+    return nlohmann::json{{"textDocument", m_textDocument.ToJSON()},
+                          {"range", m_range.ToJSON()},
+                          {"context", {"diagnostics", std::move(diags_arr)}}};
 }
 
 //===----------------------------------------------------------------------------------
@@ -171,12 +137,8 @@ JSONItem CodeActionParams::ToJSON() const
 
 void DocumentSymbolParams::FromJSON(const JSONItem& json) { m_textDocument.FromJSON(json["textDocument"]); }
 
-JSONItem DocumentSymbolParams::ToJSON() const
-{
-    JSONItem json = JSONItem::createObject();
-    json.addProperty("textDocument", m_textDocument.ToJSON());
-    return json;
-}
+nlohmann::json DocumentSymbolParams::ToJSON() const
+{ return nlohmann::json{{"textDocument", m_textDocument.ToJSON()}}; }
 
 ReferenceParams::ReferenceParams(bool includeDeclaration)
     : m_includeDeclaration(includeDeclaration)
@@ -189,20 +151,19 @@ void ReferenceParams::FromJSON(const JSONItem& json)
     m_includeDeclaration = json["context"]["includeDeclaration"].toBool(m_includeDeclaration);
 }
 
-JSONItem ReferenceParams::ToJSON() const
+nlohmann::json ReferenceParams::ToJSON() const
 {
-    JSONItem json = TextDocumentPositionParams::ToJSON();
-    auto context = json.AddObject("context");
-    context.addProperty("includeDeclaration", m_includeDeclaration);
+    auto json = TextDocumentPositionParams::ToJSON();
+    json["context"]["includeDeclaration"] = m_includeDeclaration;
     return json;
 }
 
 void RenameParams::FromJSON(const JSONItem& json) { wxUnusedVar(json); }
 
-JSONItem RenameParams::ToJSON() const
+nlohmann::json RenameParams::ToJSON() const
 {
-    JSONItem json = TextDocumentPositionParams::ToJSON();
-    json.addProperty("newName", m_newName);
+    auto json = TextDocumentPositionParams::ToJSON();
+    json["newName"] = m_newName.ToStdString(wxConvUTF8);
     return json;
 }
 

--- a/CodeLite/LSP/json_rpc_params.h
+++ b/CodeLite/LSP/json_rpc_params.h
@@ -22,6 +22,7 @@ public:
 public:
     Params() = default;
     virtual ~Params() = default;
+    bool operator==(const Params&) const = default;
     template <typename T>
     T* As() const
     {
@@ -41,8 +42,10 @@ public:
     TextDocumentPositionParams() = default;
     ~TextDocumentPositionParams() override = default;
 
+    bool operator==(const TextDocumentPositionParams&) const = default;
+
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     void SetPosition(const Position& position) { this->m_position = position; }
     void SetTextDocument(const TextDocumentIdentifier& textDocument) { this->m_textDocument = textDocument; }
@@ -65,9 +68,10 @@ class WXDLLIMPEXP_CL RenameParams : public TextDocumentPositionParams
 public:
     RenameParams() = default;
     ~RenameParams() override = default;
+    bool operator==(const RenameParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     void SetNewName(const wxString& newName) { this->m_newName = newName; }
     const wxString& GetNewName() const { return m_newName; }
 };
@@ -82,9 +86,10 @@ class WXDLLIMPEXP_CL ReferenceParams : public TextDocumentPositionParams
 public:
     ReferenceParams(bool includeDeclaration);
     ~ReferenceParams() override = default;
+    bool operator==(const ReferenceParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     void SetIncludeDeclaration(bool includeDeclaration) { this->m_includeDeclaration = includeDeclaration; }
     bool IsIncludeDeclaration() const { return m_includeDeclaration; }
 };
@@ -99,9 +104,10 @@ class WXDLLIMPEXP_CL SemanticTokensParams : public Params
 public:
     SemanticTokensParams() = default;
     ~SemanticTokensParams() override = default;
+    bool operator==(const SemanticTokensParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     void SetTextDocument(const TextDocumentIdentifier& textDocument) { this->m_textDocument = textDocument; }
     const TextDocumentIdentifier& GetTextDocument() const { return m_textDocument; }
@@ -124,9 +130,10 @@ class WXDLLIMPEXP_CL DocumentSymbolParams : public Params
 public:
     DocumentSymbolParams() = default;
     ~DocumentSymbolParams() override = default;
+    bool operator==(const DocumentSymbolParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     void SetTextDocument(const TextDocumentIdentifier& textDocument) { this->m_textDocument = textDocument; }
     const TextDocumentIdentifier& GetTextDocument() const { return m_textDocument; }
@@ -140,9 +147,10 @@ class WXDLLIMPEXP_CL CompletionParams : public TextDocumentPositionParams
 public:
     CompletionParams() = default;
     ~CompletionParams() override = default;
+    bool operator==(const CompletionParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 };
 
 //===----------------------------------------------------------------------------------
@@ -156,9 +164,10 @@ class WXDLLIMPEXP_CL ExecuteCommandParams : public Params
 public:
     ExecuteCommandParams(const wxString& command, const wxString& arguments);
     ~ExecuteCommandParams() = default;
+    bool operator==(const ExecuteCommandParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 };
 
 //===----------------------------------------------------------------------------------
@@ -173,9 +182,10 @@ class WXDLLIMPEXP_CL CodeActionParams : public Params
 public:
     CodeActionParams() = default;
     virtual ~CodeActionParams() = default;
+    bool operator==(const CodeActionParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     void SetTextDocument(const TextDocumentIdentifier& textDocument) { this->m_textDocument = textDocument; }
     const TextDocumentIdentifier& GetTextDocument() const { return m_textDocument; }
@@ -197,9 +207,10 @@ class WXDLLIMPEXP_CL DidOpenTextDocumentParams : public Params
 public:
     DidOpenTextDocumentParams() = default;
     ~DidOpenTextDocumentParams() override = default;
+    bool operator==(const DidOpenTextDocumentParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
 
     DidOpenTextDocumentParams& SetTextDocument(const TextDocumentItem& textDocument)
     {
@@ -219,9 +230,10 @@ class WXDLLIMPEXP_CL DidCloseTextDocumentParams : public Params
 public:
     DidCloseTextDocumentParams() = default;
     ~DidCloseTextDocumentParams() override = default;
+    bool operator==(const DidCloseTextDocumentParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     DidCloseTextDocumentParams& SetTextDocument(const TextDocumentIdentifier& textDocument)
     {
         this->m_textDocument = textDocument;
@@ -241,9 +253,10 @@ class WXDLLIMPEXP_CL DidChangeTextDocumentParams : public Params
 public:
     DidChangeTextDocumentParams() = default;
     ~DidChangeTextDocumentParams() override = default;
+    bool operator==(const DidChangeTextDocumentParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     DidChangeTextDocumentParams& SetContentChanges(const std::vector<TextDocumentContentChangeEvent>& contentChanges)
     {
         this->m_contentChanges = contentChanges;
@@ -269,9 +282,10 @@ class WXDLLIMPEXP_CL DidSaveTextDocumentParams : public Params
 public:
     DidSaveTextDocumentParams() = default;
     ~DidSaveTextDocumentParams() override = default;
+    bool operator==(const DidSaveTextDocumentParams&) const = default;
 
     void FromJSON(const JSONItem& json) override;
-    JSONItem ToJSON() const override;
+    nlohmann::json ToJSON() const override;
     DidSaveTextDocumentParams& SetTextDocument(const TextDocumentIdentifier& textDocument)
     {
         this->m_textDocument = textDocument;

--- a/CodeLite/LSP/json_rpc_results.h
+++ b/CodeLite/LSP/json_rpc_results.h
@@ -25,7 +25,7 @@ public:
     {
         return dynamic_cast<T*>(const_cast<Result*>(this));
     }
-    JSONItem ToJSON() const override { return JSONItem(nullptr); }
+    nlohmann::json ToJSON() const override { return nullptr; }
 };
 
 //===----------------------------------------------------------------------------------
@@ -38,7 +38,7 @@ class WXDLLIMPEXP_CL ResultString : public Result
 public:
     ResultString(const wxString& text) {}
     virtual ~ResultString() = default;
-    void FromJSON(const JSONItem& json);
+    void FromJSON(const JSONItem& json) override;
     ResultString& SetText(const wxString& text)
     {
         this->m_text = text;
@@ -57,7 +57,7 @@ class WXDLLIMPEXP_CL ResultNumber : public Result
 public:
     ResultNumber(const wxString& text) {}
     virtual ~ResultNumber() = default;
-    void FromJSON(const JSONItem& json);
+    void FromJSON(const JSONItem& json) override;
     ResultNumber& SetNumber(int number)
     {
         this->m_number = number;
@@ -76,7 +76,7 @@ class WXDLLIMPEXP_CL ResultBoolean : public Result
 public:
     ResultBoolean(const wxString& text) {}
     virtual ~ResultBoolean() = default;
-    void FromJSON(const JSONItem& json);
+    void FromJSON(const JSONItem& json) override;
 
     ResultBoolean& SetValue(bool value)
     {

--- a/Plugin/LSP/LSPManager.cpp
+++ b/Plugin/LSP/LSPManager.cpp
@@ -492,7 +492,7 @@ void Manager::OnSymbolFound(LSPEvent& event)
             editor->SelectRangeAfter(location.GetRange());
         }
         BrowseRecord current_location{location};
-        clDEBUG() << "location:" << location.ToJSON().format() << endl;
+        clDEBUG() << "location:" << wxString::FromUTF8(location.ToJSON().dump(2)) << endl;
         clDEBUG() << "Calling StoreCurrentLocation with:" << current_location << endl;
         NavMgr::Get()->StoreCurrentLocation(from, current_location);
     };

--- a/Tests/CodeliteTest/CMakeLists.txt
+++ b/Tests/CodeliteTest/CMakeLists.txt
@@ -3,7 +3,7 @@ project("CodeliteTest")
 # wxWidgets include (this will do all the magic to configure everything)
 include("${wxWidgets_USE_FILE}")
 
-file(GLOB UNIT_TESTS_SRC "*.cpp")
+file(GLOB_RECURSE UNIT_TESTS_SRC "*.cpp")
 add_executable(CodeliteTest ${UNIT_TESTS_SRC})
 
 target_link_libraries(CodeliteTest ${LINKER_OPTIONS} doctest libcodelite plugin)

--- a/Tests/CodeliteTest/LSP/basic_typesTest.cpp
+++ b/Tests/CodeliteTest/LSP/basic_typesTest.cpp
@@ -1,0 +1,328 @@
+#include "LSP/basic_types.h"
+
+#include <doctest.h>
+
+TEST_CASE("LSP::Position")
+{
+    const LSP::Position expected = {1, 2};
+    LSP::Position actual;
+
+    REQUIRE(actual != expected);
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::Range")
+{
+    const LSP::Range expected = {{1, 2}, {3, 4}};
+    LSP::Range actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetStart() != expected.GetStart());
+    REQUIRE(actual.GetEnd() != expected.GetEnd());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::TextDocumentContentChangeEvent")
+{
+    LSP::TextDocumentContentChangeEvent expected;
+    expected.SetRange({{1, 2}, {3, 4}});
+    expected.SetText(wxString::FromUTF8("\u4321"));
+    LSP::TextDocumentContentChangeEvent actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetRange() != expected.GetRange());
+    REQUIRE(actual.GetText() != expected.GetText());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::TextDocumentIdentifier")
+{
+    const LSP::TextDocumentIdentifier expected(wxString::FromUTF8("/absolute/path\u4321"));
+    LSP::TextDocumentIdentifier actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetPath() != expected.GetPath());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::VersionedTextDocumentIdentifier")
+{
+    LSP::VersionedTextDocumentIdentifier expected;
+    expected.SetFilename(wxString::FromUTF8("/absolute/path\u4321"));
+    expected.SetVersion(42);
+    LSP::VersionedTextDocumentIdentifier actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetPath() != expected.GetPath());
+    REQUIRE(actual.GetVersion() != expected.GetVersion());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::TextEdit")
+{
+    LSP::TextEdit expected;
+    expected.SetNewText(wxString::FromUTF8("\u4321"));
+    expected.SetRange({{1, 2}, {3, 4}});
+    LSP::TextEdit actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetNewText() != expected.GetNewText());
+    REQUIRE(actual.GetRange() != expected.GetRange());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::Location")
+{
+    LSP::Location expected;
+    expected.SetName(wxString::FromUTF8("\u4321"));
+    expected.SetPath(wxString::FromUTF8("/absolute/path\u4321"));
+    expected.SetPattern(wxString::FromUTF8("\u1324"));
+    expected.SetRange({{1, 2}, {3, 4}});
+    LSP::Location actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetName() != expected.GetName());
+    REQUIRE(actual.GetPath() != expected.GetPath());
+    REQUIRE(actual.GetPattern() != expected.GetPattern());
+    REQUIRE(actual.GetRange() != expected.GetRange());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::TextDocumentItem")
+{
+    LSP::TextDocumentItem expected;
+    expected.SetLanguageId(wxString::FromUTF8("\u4321"));
+    expected.SetText(wxString::FromUTF8("\u5432"));
+    expected.SetUri(wxString::FromUTF8("/absolute/path\u4321"));
+    expected.SetVersion(42);
+    LSP::TextDocumentItem actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetLanguageId() != expected.GetLanguageId());
+    REQUIRE(actual.GetPath() != expected.GetPath());
+    REQUIRE(actual.GetText() != expected.GetText());
+    REQUIRE(actual.GetVersion() != expected.GetVersion());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::ParameterInformation")
+{
+    LSP::ParameterInformation expected;
+    expected.SetDocumentation(wxString::FromUTF8("\u4321"));
+    expected.SetLabel(wxString::FromUTF8("\u5432"));
+    LSP::ParameterInformation actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetDocumentation() != expected.GetDocumentation());
+    REQUIRE(actual.GetLabel() != expected.GetLabel());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::SignatureInformation")
+{
+    LSP::SignatureInformation expected;
+    expected.SetDocumentation(wxString::FromUTF8("\u4321"));
+    expected.SetLabel(wxString::FromUTF8("\u5432"));
+    expected.SetParameters({LSP::ParameterInformation{}.SetDocumentation("doc").SetLabel("label")});
+    LSP::SignatureInformation actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetDocumentation() != expected.GetDocumentation());
+    REQUIRE(actual.GetLabel() != expected.GetLabel());
+    REQUIRE(actual.GetParameters() != expected.GetParameters());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::SignatureHelp")
+{
+    LSP::SignatureHelp expected;
+    expected.SetActiveParameter(1);
+    expected.SetActiveSignature(2);
+    expected.SetSignatures(
+        {LSP::SignatureInformation()
+             .SetDocumentation("SigDoc")
+             .SetLabel("SigLabel")
+             .SetParameters({LSP::ParameterInformation{}.SetDocumentation("doc").SetLabel("label")})});
+    LSP::SignatureHelp actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetActiveParameter() != expected.GetActiveParameter());
+    REQUIRE(actual.GetActiveSignature() != expected.GetActiveSignature());
+    REQUIRE(actual.GetSignatures() != expected.GetSignatures());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::MarkupContent")
+{
+    LSP::MarkupContent expected;
+    expected.SetKind(wxString::FromUTF8("\u4321"));
+    expected.SetValue(wxString::FromUTF8("\u5432"));
+    LSP::MarkupContent actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetKind() != expected.GetKind());
+    REQUIRE(actual.GetValue() != expected.GetValue());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::Hover")
+{
+    LSP::Hover expected;
+    expected.SetContents(LSP::MarkupContent{}.SetKind("king").SetValue("value"));
+    expected.SetRange({{1, 2}, {3, 4}});
+    LSP::Hover actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetContents() != expected.GetContents());
+    REQUIRE(actual.GetRange() != expected.GetRange());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::Diagnostic")
+{
+    LSP::Diagnostic expected;
+    expected.SetMessage(wxString::FromUTF8("\u4321"));
+    expected.SetRange({{1, 2}, {3, 4}});
+    expected.SetSeverity(LSP::DiagnosticSeverity::Hint);
+    LSP::Diagnostic actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetMessage() != expected.GetMessage());
+    REQUIRE(actual.GetRange() != expected.GetRange());
+    REQUIRE(actual.GetSeverity() != expected.GetSeverity());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+#if 0 // Unimplemented Command::ToJSON()
+TEST_CASE("LSP::Command")
+{
+    LSP::Command expected;
+    expected.SetArguments(wxString::FromUTF8("\u4321"));
+    expected.SetCommand(wxString::FromUTF8("\u5432"));
+    expected.SetTitle(wxString::FromUTF8("\u1324"));
+    LSP::Command actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetArguments() != expected.GetArguments());
+    REQUIRE(actual.GetCommand() != expected.GetCommand());
+    REQUIRE(actual.GetTitle() != expected.GetTitle());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+#endif
+#if 0 // Unimplemented LSP::DocumentSymbol::ToJSON()
+TEST_CASE("LSP::DocumentSymbol")
+{
+    LSP::DocumentSymbol child;
+    child.SetDetail("Detail");
+    child.SetKind(LSP::eSymbolKind::kSK_Field);
+    child.SetName("name");
+    child.SetRange({{11, 22}, {81, 91}});
+    child.SetSelectionRange({{32, 42}, {62, 72}});
+
+    LSP::DocumentSymbol expected;
+    expected.SetChildren({child});
+    expected.SetDetail(wxString::FromUTF8("\u4321"));
+    expected.SetKind(LSP::eSymbolKind::kSK_Constructor);
+    expected.SetName(wxString::FromUTF8("\u1324"));
+    expected.SetRange({{1, 2}, {8, 9}});
+    expected.SetSelectionRange({{3, 4}, {6, 7}});
+    LSP::DocumentSymbol actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetChildren() != expected.GetChildren());
+    REQUIRE(actual.GetDetail() != expected.GetDetail());
+    REQUIRE(actual.GetKind() != expected.GetKind());
+    REQUIRE(actual.GetRange() != expected.GetRange());
+    REQUIRE(actual.GetSelectionRange() != expected.GetSelectionRange());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+#endif
+
+TEST_CASE("LSP::SymbolInformation")
+{
+    LSP::SymbolInformation expected;
+    expected.SetContainerName(wxString::FromUTF8("\u4321"));
+    expected.SetKind(LSP::eSymbolKind::kSK_Constructor);
+    expected.SetLocation(LSP::Location{}.SetPath("/my/path/").SetRange({{1, 2}, {3, 4}}));
+    expected.SetName(wxString::FromUTF8("\u1324"));
+    LSP::SymbolInformation actual;
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetContainerName() != expected.GetContainerName());
+    REQUIRE(actual.GetKind() != expected.GetKind());
+    REQUIRE(actual.GetLocation() != expected.GetLocation());
+    REQUIRE(actual.GetName() != expected.GetName());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::Progress")
+{
+    const auto expected_kind = LSP::ProgressKind::report;
+    const auto expected_kind_string = "report";
+    const auto expected_message = "\u4321";
+    const double expected_percentage = 4.2;
+    const auto expected_token = "\u5432";
+    const nlohmann::json json = {
+        {"params",
+         {{"token", expected_token},
+          {"value",
+           {{"kind", expected_kind_string}, {"message", expected_message}, {"percentage", expected_percentage}}}}}};
+
+    const LSP::Progress actual = LSP::Progress::FromJSON(json).value_or(LSP::Progress{});
+
+    CHECK(actual.m_kind == expected_kind);
+    CHECK(actual.m_message == wxString::FromUTF8(expected_message));
+    CHECK(actual.m_percentage == expected_percentage);
+    CHECK(actual.m_token == wxString::FromUTF8(expected_token));
+}

--- a/Tests/CodeliteTest/LSP/json_rpc_paramsTests.cpp
+++ b/Tests/CodeliteTest/LSP/json_rpc_paramsTests.cpp
@@ -1,0 +1,194 @@
+#include "LSP/json_rpc_params.h"
+
+#include <doctest.h>
+
+TEST_CASE("LSP::TextDocumentPositionParams")
+{
+    LSP::TextDocumentPositionParams expected;
+    LSP::TextDocumentPositionParams actual;
+    expected.SetPosition({1, 2});
+    expected.SetTextDocument(LSP::TextDocumentIdentifier("/path/filename"));
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetPosition() != expected.GetPosition());
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+#if 0 // Unimplemented LSP::RenameParams::FromJSON()
+TEST_CASE("LSP::RenameParams")
+{
+    LSP::RenameParams expected;
+    LSP::RenameParams actual;
+    expected.SetNewName(wxString::FromUTF8("\u4321"));
+    expected.SetPosition({1, 2});
+    expected.SetTextDocument(LSP::TextDocumentIdentifier("/path/filename"));
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetNewName() != expected.GetNewName());
+    REQUIRE(actual.GetPosition() != expected.GetPosition());
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+
+    actual.(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+#endif
+
+TEST_CASE("LSP::ReferenceParams")
+{
+    LSP::ReferenceParams expected(false);
+    LSP::ReferenceParams actual(true);
+    expected.SetIncludeDeclaration(false);
+    expected.SetPosition({1, 2});
+    expected.SetTextDocument(LSP::TextDocumentIdentifier("/path/filename"));
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetPosition() != expected.GetPosition());
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+    REQUIRE(actual.IsIncludeDeclaration() != expected.IsIncludeDeclaration());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::SemanticTokensParams")
+{
+    LSP::SemanticTokensParams expected;
+    LSP::SemanticTokensParams actual;
+    expected.SetTextDocument(LSP::TextDocumentIdentifier("/path/filename"));
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::DocumentSymbolParams")
+{
+    LSP::DocumentSymbolParams expected;
+    LSP::DocumentSymbolParams actual;
+    expected.SetTextDocument(LSP::TextDocumentIdentifier("/path/filename"));
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::CompletionParams")
+{
+    LSP::CompletionParams expected;
+    LSP::CompletionParams actual;
+    expected.SetPosition({1, 2});
+    expected.SetTextDocument(LSP::TextDocumentIdentifier("/path/filename"));
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetPosition() != expected.GetPosition());
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+#if 0 // Unimplemented LSP::ExecuteCommandParams::FromJSON()
+TEST_CASE("LSP::ExecuteCommandParams")
+{
+    const LSP::ExecuteCommandParams expected(wxString::FromUTF8("command\u4321"), wxString::FromUTF8("arg\u4321"));
+    LSP::ExecuteCommandParams actual("", "");
+
+    REQUIRE(actual != expected);
+    // No getters
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+#endif
+#if 0 // Unimplemented LSP::CodeActionParams::FromJSON()
+TEST_CASE("LSP::CodeActionParams")
+{
+    LSP::CodeActionParams expected;
+    LSP::CodeActionParams actual;
+    expected.SetDiagnostics({LSP::Diagnostic{}
+                                 .SetMessage("message")
+                                 .SetRange({{1, 2}, {3, 4}})});
+    expected.SetRange({{2, 4}, {3, 5}});
+    expected.SetTextDocument(LSP::TextDocumentIdentifier{"filename"});
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetDiagnostics() != expected.GetDiagnostics());
+    REQUIRE(actual.GetRange() != expected.GetRange());
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+#endif
+TEST_CASE("LSP::DidOpenTextDocumentParams")
+{
+    LSP::DidOpenTextDocumentParams expected;
+    LSP::DidOpenTextDocumentParams actual;
+    expected.SetTextDocument(LSP::TextDocumentItem{"/uri", "langId", "text", 42});
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::DidCloseTextDocumentParams")
+{
+    LSP::DidCloseTextDocumentParams expected;
+    LSP::DidCloseTextDocumentParams actual;
+    expected.SetTextDocument(LSP::TextDocumentIdentifier{"/path/filename"});
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::DidChangeTextDocumentParams")
+{
+    LSP::DidChangeTextDocumentParams expected;
+    LSP::DidChangeTextDocumentParams actual;
+    expected.SetContentChanges({LSP::TextDocumentContentChangeEvent{}.SetText("text")});
+    expected.SetTextDocument(static_cast<LSP::VersionedTextDocumentIdentifier&>(
+        LSP::VersionedTextDocumentIdentifier{42}.SetFilename("/path/filename")));
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetContentChanges() != expected.GetContentChanges());
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}
+
+TEST_CASE("LSP::DidSaveTextDocumentParams")
+{
+    LSP::DidSaveTextDocumentParams expected;
+    LSP::DidSaveTextDocumentParams actual;
+    expected.SetText(wxString::FromUTF8("text\u4321"));
+    expected.SetTextDocument(LSP::TextDocumentIdentifier{"/path/filename"});
+
+    REQUIRE(actual != expected);
+    REQUIRE(actual.GetText() != expected.GetText());
+    REQUIRE(actual.GetTextDocument() != expected.GetTextDocument());
+
+    actual.FromJSON(expected.ToJSON());
+
+    CHECK(actual == expected);
+}


### PR DESCRIPTION

Fix `TextDocumentItem::SetText`.