### PR TITLE
Fix CTRL+TAB assertion failure

### DIFF
--- a/LiteEditor/mainbook.cpp
+++ b/LiteEditor/mainbook.cpp
@@ -1309,7 +1309,7 @@ bool MainBook::DoSelectPage(wxWindow* win)
     } else {
         wxCommandEvent event(wxEVT_ACTIVE_EDITOR_CHANGED);
         event.SetString(FileUtils::RealPath(editor->GetFileName().GetFullPath()));
-        EventNotifier::Get()->AddPendingEvent(event);
+        EventNotifier::Get()->ProcessEvent(event);
     }
     return true;
 }
@@ -1678,11 +1678,10 @@ void MainBook::ShowNavigationDialog()
         return;
     }
 
-    NotebookNavigationDlg* dlg = new NotebookNavigationDlg(EventNotifier::Get()->TopFrame(), m_book);
-    if (dlg->ShowModal() == wxID_OK && dlg->GetSelection() != wxNOT_FOUND) {
-        m_book->SetSelection(dlg->GetSelection());
+    NotebookNavigationDlg dlg(EventNotifier::Get()->TopFrame(), m_book);
+    if (dlg.ShowModal() == wxID_OK && dlg.GetSelection() != wxNOT_FOUND) {
+        m_book->SetSelection(dlg.GetSelection());
     }
-    wxDELETE(dlg);
 }
 
 void MainBook::MovePage(bool movePageRight)


### PR DESCRIPTION
* Change `AddPendingEvent` to `ProcessEvent` for `wxEVT_ACTIVE_EDITOR_CHANGED` to ensure immediate, synchronous processing of the editor change event. It fixes a CTRL-TAB assertion failure on wxGTK (wx3.2).

* Refactor `NotebookNavigationDlg` instantiation from heap allocation to stack allocation.