### PR TITLE
Remove Plugin dependency from wxcgen:

### DIFF
--- a/CodeLite/StringUtils.cpp
+++ b/CodeLite/StringUtils.cpp
@@ -3,6 +3,7 @@
 #include "macros.h"
 
 #include <vector>
+#include <wx/regex.h>
 #include <wx/stc/stc.h>
 #include <wx/tokenzr.h>
 
@@ -982,6 +983,50 @@ wxString StringUtils::BuildCommandFromArray(std::span<const wxString> commands)
     }
     if (!result.empty()) {
         result.RemoveLast();
+    }
+    return result;
+}
+
+wxString StringUtils::ReplaceVariable(const wxString& inString,
+                                      const wxString& variableName,
+                                      const wxString& replaceWith,
+                                      bool bIgnoreCase)
+{
+    size_t flags = wxRE_DEFAULT;
+    if (bIgnoreCase) {
+        flags |= wxRE_ICASE;
+    }
+
+    wxString strRe1;
+    wxString strRe2;
+    wxString strRe3;
+    wxString strRe4;
+
+    strRe1 << "\\$\\((" << variableName << ")\\)";
+    strRe2 << "\\$\\{(" << variableName << ")\\}";
+    strRe3 << "\\$(" << variableName << ")";
+    strRe4 << "%(" << variableName << ")%";
+
+    wxRegEx reOne(strRe1, flags);   // $(variable)
+    wxRegEx reTwo(strRe2, flags);   // ${variable}
+    wxRegEx reThree(strRe3, flags); // $variable
+    wxRegEx reFour(strRe4, flags);  // %variable%
+
+    wxString result = inString;
+    if (reOne.Matches(result)) {
+        reOne.ReplaceAll(&result, replaceWith);
+    }
+
+    if (reTwo.Matches(result)) {
+        reTwo.ReplaceAll(&result, replaceWith);
+    }
+
+    if (reThree.Matches(result)) {
+        reThree.ReplaceAll(&result, replaceWith);
+    }
+
+    if (reFour.Matches(result)) {
+        reFour.ReplaceAll(&result, replaceWith);
     }
     return result;
 }

--- a/CodeLite/StringUtils.h
+++ b/CodeLite/StringUtils.h
@@ -309,5 +309,19 @@ public:
      * @note This function is recursive when the input already has surrounding quotes.
      */
     static wxString EscapeAndWrapWithDoubleQuotes(const wxString& input);
+
+    /**
+     * @brief search for variableName and replace all its occurrence with 'replaceWith'
+     * This function supports the following formats:
+     * $variableName
+     * ${variableName}
+     * $(variableName)
+     * %variableName%
+     */
+    static wxString ReplaceVariable(const wxString& inString,
+                                    const wxString& variableName,
+                                    const wxString& replaceWith,
+                                    bool bIgnoreCase = false);
 };
+
 inline wxString BoolToString(bool b) { return b ? wxT("yes") : wxT("no"); }

--- a/LiteEditor/cl_editor.cpp
+++ b/LiteEditor/cl_editor.cpp
@@ -69,7 +69,6 @@
 #include "imanager.h"
 #include "lexer_configuration.h"
 #include "localworkspace.h"
-#include "macromanager.h"
 #include "manager.h"
 #include "menumanager.h"
 #include "new_quick_watch_dlg.h"
@@ -3987,7 +3986,7 @@ void clEditor::OnDbgCustomWatch(wxCommandEvent& event)
 
         // Replace $(Variable) with the actual string
         wxString command = iter->second;
-        command = MacroManager::Instance()->Replace(command, wxT("variable"), word, true);
+        command = StringUtils::ReplaceVariable(command, wxT("variable"), word, true);
 
         clMainFrame::Get()->GetDebuggerPane()->GetWatchesTable()->AddExpression(command);
         clMainFrame::Get()->GetDebuggerPane()->SelectTab(wxGetTranslation(DebuggerPane::WATCHES));

--- a/LiteEditor/manager.cpp
+++ b/LiteEditor/manager.cpp
@@ -37,6 +37,7 @@
 #include "Keyboard/clKeyboardManager.h"
 #include "NewProjectDialog.h"
 #include "Scripting/CodeLiteLUA.hpp"
+#include "StringUtils.h"
 #include "SideBar.hpp"
 #include "WorkspaceImporter/WSImporter.h"
 #include "app.h"
@@ -2446,7 +2447,7 @@ void Manager::UpdateTypeResolved(const wxString& expr, const wxString& type_name
             if (cmd.GetName() == expression_type) {
                 // prepare the string to be evaluated
                 command = cmd.GetCommand();
-                command = MacroManager::Instance()->Replace(command, wxT("variable"), expr, true);
+                command = StringUtils::ReplaceVariable(command, wxT("variable"), expr, true);
 
                 dbg_command = cmd.GetDbgCommand();
 

--- a/Plugin/Debugger/debuggersettings.cpp
+++ b/Plugin/Debugger/debuggersettings.cpp
@@ -24,7 +24,7 @@
 //////////////////////////////////////////////////////////////////////////////
 #include "debuggersettings.h"
 
-#include "macromanager.h"
+#include "StringUtils.h"
 
 void DebuggerCmdData::DeSerialize(Archive& arch)
 {
@@ -119,7 +119,7 @@ wxString DebuggerPreDefinedTypes::GetPreDefinedTypeForTypename(const wxString& e
             // Create variable object for this variable
             // and display the content
             wxString expression = dcd.GetCommand();
-            expression = MacroManager::Instance()->Replace(expression, wxT("variable"), name, true);
+            expression = StringUtils::ReplaceVariable(expression, wxT("variable"), name, true);
             return expression;
         }
     }

--- a/Plugin/macromanager.cpp
+++ b/Plugin/macromanager.cpp
@@ -51,50 +51,6 @@ wxString MacroManager::Expand(const wxString& expression,
                               const wxString& confToBuild)
 { return DoExpand(expression, manager, project, true, confToBuild); }
 
-wxString MacroManager::Replace(const wxString& inString,
-                               const wxString& variableName,
-                               const wxString& replaceWith,
-                               bool bIgnoreCase)
-{
-    size_t flags = wxRE_DEFAULT;
-    if (bIgnoreCase) {
-        flags |= wxRE_ICASE;
-    }
-
-    wxString strRe1;
-    wxString strRe2;
-    wxString strRe3;
-    wxString strRe4;
-
-    strRe1 << "\\$\\((" << variableName << ")\\)";
-    strRe2 << "\\$\\{(" << variableName << ")\\}";
-    strRe3 << "\\$(" << variableName << ")";
-    strRe4 << "%(" << variableName << ")%";
-
-    wxRegEx reOne(strRe1, flags);   // $(variable)
-    wxRegEx reTwo(strRe2, flags);   // ${variable}
-    wxRegEx reThree(strRe3, flags); // $variable
-    wxRegEx reFour(strRe4, flags);  // %variable%
-
-    wxString result = inString;
-    if (reOne.Matches(result)) {
-        reOne.ReplaceAll(&result, replaceWith);
-    }
-
-    if (reTwo.Matches(result)) {
-        reTwo.ReplaceAll(&result, replaceWith);
-    }
-
-    if (reThree.Matches(result)) {
-        reThree.ReplaceAll(&result, replaceWith);
-    }
-
-    if (reFour.Matches(result)) {
-        reFour.ReplaceAll(&result, replaceWith);
-    }
-    return result;
-}
-
 bool MacroManager::FindVariable(const wxString& inString, wxString& name, wxString& fullname)
 {
     size_t flags = wxRE_DEFAULT | wxRE_ICASE;

--- a/wxcrafter/CMakeLists.txt
+++ b/wxcrafter/CMakeLists.txt
@@ -212,10 +212,10 @@ endif()
 add_library(wxCrafterCommon STATIC ${COMMON_SRCS})
 set_target_properties(wxCrafterCommon PROPERTIES POSITION_INDEPENDENT_CODE ON)
 # Link the CodeLite internal libs so the static lib picks up their INTERFACE
-# include directories (JSON.h, plugin.h, wxsqlite3, etc.). Static libs don't
+# include directories (JSON.h, etc.). Static libs don't
 # actually link against other libs at archive time, but CMake will propagate
 # include dirs and compile features.
-target_link_libraries(wxCrafterCommon PUBLIC libcodelite plugin)
+target_link_libraries(wxCrafterCommon PUBLIC libcodelite)
 if(USE_PCH)
   target_precompile_headers(wxCrafterCommon REUSE_FROM PCH)
 endif()

--- a/wxcrafter/controls/custom_control_wrapper.cpp
+++ b/wxcrafter/controls/custom_control_wrapper.cpp
@@ -1,8 +1,8 @@
 #include "custom_control_wrapper.h"
 
 #include "Properties/category_property.h"
+#include "StringUtils.h"
 #include "file_logger.h"
-#include "macromanager.h"
 #include "wxc_settings.h"
 #include "xml/xmlutils.h"
 
@@ -50,9 +50,9 @@ wxString CustomControlWrapper::CppCtorCode() const
     }
 
     // Replace $name with the actual control c++ name
-    cppCode = MacroManager::Instance()->Replace(cppCode, wxT("name"), GetName(), true);
-    cppCode = MacroManager::Instance()->Replace(cppCode, wxT("parent"), GetWindowParent(), true);
-    cppCode = MacroManager::Instance()->Replace(cppCode, wxT("id"), GetId(), true);
+    cppCode = StringUtils::ReplaceVariable(cppCode, wxT("name"), GetName(), true);
+    cppCode = StringUtils::ReplaceVariable(cppCode, wxT("parent"), GetWindowParent(), true);
+    cppCode = StringUtils::ReplaceVariable(cppCode, wxT("id"), GetId(), true);
     return cppCode;
 }
 

--- a/wxcrafter/src/wxc_widget.cpp
+++ b/wxcrafter/src/wxc_widget.cpp
@@ -1,9 +1,9 @@
 #include "wxc_widget.h"
+
 #include "ActivityIndicatorWrapper.h"
 #include "AnimationCtrlWrapper.h"
 #include "AuiToolBarTopLevel.h"
 #include "BitmapComboxWrapper.h"
-#include "EventsEditorDlg.h"
 #include "Importer/import_from_wxFB.h"
 #include "Properties/bool_property.h"
 #include "Properties/category_property.h"
@@ -77,7 +77,6 @@
 #include "gauge_wrapper.h"
 #include "generic_dir_ctrl_wrapper.h"
 #include "gl_canvas_wrapper.h"
-#include "globals.h"
 #include "grid_bag_sizer_wrapper.h"
 #include "grid_sizer_wrapper.h"
 #include "html_window_wrapper.h"

--- a/wxcrafter/src/wxcrafter_plugin.cpp
+++ b/wxcrafter/src/wxcrafter_plugin.cpp
@@ -86,6 +86,20 @@ void NotifyFileSaved(const wxFileName& fn)
 }
 #endif
 
+wxStringSet_t GetProjectFiles(const wxString& projectName)
+{
+    ProjectPtr p = clCxxWorkspaceST::Get()->GetProject(projectName);
+    if (!p) {
+        return {};
+    }
+    const Project::FilesMap_t& filesMap = p->GetFiles();
+    wxStringSet_t files;
+    files.reserve(filesMap.size());
+    for (const auto& [filename, _] : filesMap) {
+        files.insert(filename);
+    }
+}
+
 void SetStatusMessage(const wxString& msg)
 {
     wxFrame* topFrame = EventNotifier::Get()->TopFrame();
@@ -813,8 +827,7 @@ void wxCrafterPlugin::DoGenerateCode(const NewFormDetails& fd)
         vdFullPath << projectName;
 
         // Check if already got a file with this name in the project
-        wxStringSet_t files;
-        wxCrafter::GetProjectFiles(project->GetName(), files);
+        wxStringSet_t files = GetProjectFiles(project->GetName());
 
         if (!files.count(wxcpFile.GetFullPath())) {
 
@@ -1348,13 +1361,12 @@ void wxCrafterPlugin::OnReGenerateForProject(wxCommandEvent& e)
 {
     wxArrayString wxcpFiles;
     if (clGetManager()->GetWorkspace() && clGetManager()->GetWorkspace()->IsOpen()) {
-        wxStringSet_t all_files;
         wxArrayString projects;
         ProjectPtr activeProject = clGetManager()->GetSelectedProject();
         if (!activeProject) {
             return;
         }
-        wxCrafter::GetProjectFiles(activeProject->GetName(), all_files);
+        wxStringSet_t all_files = GetProjectFiles(activeProject->GetName());
 
         // Filter out and keep only wxcp files
         for (const wxString& file : all_files) {

--- a/wxcrafter/src/wxgui_helpers.cpp
+++ b/wxcrafter/src/wxgui_helpers.cpp
@@ -2,13 +2,11 @@
 
 #include "JSON.h"
 #include "macros.h"
-#include "map"
-#include "project.h"
-#include "workspace.h"
 #include "wxc_bitmap_code_generator.h"
 #include "wxc_project_metadata.h"
 #include "xml/xmlutils.h"
 
+#include <map>
 #include <wx/app.h>
 #include <wx/arrstr.h>
 #include <wx/ffile.h>
@@ -1286,19 +1284,6 @@ void wxCrafter::WrapInIfBlock(const wxString& condname, wxString& codeblock)
     bottomBlock << "#endif // " << condname << "\n";
 
     codeblock.Prepend(topBlock).Append(bottomBlock);
-}
-
-void wxCrafter::GetProjectFiles(const wxString& projectName, wxStringSet_t& files)
-{
-    ProjectPtr p = clCxxWorkspaceST::Get()->GetProject(projectName);
-    if (!p) {
-        return;
-    }
-    const Project::FilesMap_t& filesMap = p->GetFiles();
-    files.reserve(filesMap.size());
-    for (const auto& p : filesMap) {
-        files.insert(p.first);
-    }
 }
 
 static wxWindow* sTopFrame = NULL;

--- a/wxcrafter/src/wxgui_helpers.h
+++ b/wxcrafter/src/wxgui_helpers.h
@@ -207,11 +207,6 @@ wxShowEffect ShowEffectFromString(const wxString& effect);
 void WrapInIfBlock(const wxString& condname, wxString& codeblock);
 
 /**
- * @brief return the workspace files as set
- */
-void GetProjectFiles(const wxString& projectName, wxStringSet_t& files);
-
-/**
  * @brief return the top frame
  */
 wxWindow* TopFrame();

--- a/wxcrafter/wxcgen/main.cpp
+++ b/wxcrafter/wxcgen/main.cpp
@@ -3,7 +3,6 @@
 // directly through the widget model, bypassing GUICraftMainPanel entirely.
 
 #include "JSON.h"
-#include "editor_config.h"
 #include "file_logger.h"
 #include "fileutils.h"
 #include "top_level_win_wrapper.h"
@@ -22,6 +21,7 @@
 #include <wx/sstream.h>
 #include <wx/stdpaths.h>
 #include <wx/string.h>
+#include <wx/wxcrtvararg.h>
 #include <wx/xml/xml.h>
 
 static const wxCmdLineEntryDesc s_cmdDesc[] = {
@@ -200,22 +200,12 @@ int wxcgenApp::OnRun()
     }
 
     // Ensure the user data dir exists before anything tries to write into
-    // it (FileLogger / EditorConfig both expect it).
+    // it (FileLogger expect it).
     wxFileName user_data_dir{wxStandardPaths::Get().GetUserDataDir(), wxEmptyString};
     user_data_dir.AppendDir("wxcrafter");
     user_data_dir.Mkdir(wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
 
     FileLogger::OpenLog("wxcgen.log", FileLogger::System);
-
-#ifdef __WXGTK__
-    wxString installPrefix = INSTALL_PREFIX;
-    wxStandardPaths::Get().SetInstallPrefix(installPrefix);
-    EditorConfigST::Get()->SetInstallDir(wxString() << INSTALL_PREFIX << "/share/wxcrafter");
-#elif defined(__WXMSW__)
-    EditorConfigST::Get()->SetInstallDir(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath());
-#endif
-    EditorConfigST::Get()->Init("", "2.0.2");
-    EditorConfigST::Get()->Load();
 
     int rc = 0;
     for (size_t i = 0; i < parser.GetParamCount(); i++) {


### PR DESCRIPTION
- Move `MacroManager::Replace` (Plugin) to `StringUtils::ReplaceVariable` (CodeLite).
- Move `wxCrafter::GetProjectFiles` from wxgui_helpers.cpp (wxCrafterCommon) into wxcrafter_plugin.cpp (SharedGui)
- Remove `EditorConfig` from wxcgen