### PR TITLE
[Fix] Add missing `return` from 7a57f10e5086fb9cfc46e880bfa1ebe70a53dba8

### DIFF
--- a/wxcrafter/src/wxcrafter_plugin.cpp
+++ b/wxcrafter/src/wxcrafter_plugin.cpp
@@ -98,6 +98,7 @@ wxStringSet_t GetProjectFiles(const wxString& projectName)
     for (const auto& [filename, _] : filesMap) {
         files.insert(filename);
     }
+    return files;
 }
 
 void SetStatusMessage(const wxString& msg)


### PR DESCRIPTION
closes https://github.com/eranif/codelite/issues/4040