### PR TITLE
(bugfix) Toggle folder expand/collapse on double-click in file trees

### DIFF
--- a/Plugin/clFileViwerTreeCtrl.cpp
+++ b/Plugin/clFileViwerTreeCtrl.cpp
@@ -24,15 +24,24 @@ clFileViewerTreeCtrl::clFileViewerTreeCtrl(
 
 void clFileViewerTreeCtrl::OnLeftDown(wxMouseEvent& event)
 {
+    wxDataViewItem item;
+    wxDataViewColumn* column = nullptr;
+    HitTest(event.GetPosition(), item, column);
+    if (item.IsOk()) {
+        // Remember pre-click expand state for activate/double-click handling.
+        m_lastClickItem = item;
+        m_lastClickWasExpanded = IsExpanded(item);
+    } else {
+        m_lastClickItem = wxDataViewItem();
+        m_lastClickWasExpanded = false;
+    }
+
     if (event.CmdDown() || event.ShiftDown() || event.AltDown()) {
         // let modifier-driven range/toggle selection go through the native control
         event.Skip();
         return;
     }
 
-    wxDataViewItem item;
-    wxDataViewColumn* column = nullptr;
-    HitTest(event.GetPosition(), item, column);
     if (!item.IsOk()) {
         event.Skip();
         return;
@@ -95,9 +104,12 @@ bool clFileViewerTreeCtrl::ShouldComeBefore(clTreeCtrlData* a, clTreeCtrlData* b
     return a->GetName().CmpNoCase(b->GetName()) < 0;
 }
 
-wxDataViewItem clFileViewerTreeCtrl::InsertSorted(
-    const wxDataViewItem& parent, const wxString& text, int icon, int expandedIcon, bool isContainer,
-    wxClientData* data)
+wxDataViewItem clFileViewerTreeCtrl::InsertSorted(const wxDataViewItem& parent,
+                                                  const wxString& text,
+                                                  int icon,
+                                                  int expandedIcon,
+                                                  bool isContainer,
+                                                  wxClientData* data)
 {
     clTreeCtrlData* newData = static_cast<clTreeCtrlData*>(data);
     int count = GetChildCount(parent);

--- a/Plugin/clFileViwerTreeCtrl.cpp
+++ b/Plugin/clFileViwerTreeCtrl.cpp
@@ -20,44 +20,10 @@ clFileViewerTreeCtrl::clFileViewerTreeCtrl(
     // out of this tree, so pre-empt the native handling for this specific case:
     // detect it ourselves and consume the event before it reaches the native control.
     Bind(wxEVT_LEFT_DOWN, &clFileViewerTreeCtrl::OnLeftDown, this);
-    // Right-click must update selection/current item before the context menu runs;
-    // otherwise GTK may only move the visual cursor while commands still use the
-    // previous selection (e.g. "Open Shell").
-    Bind(wxEVT_RIGHT_DOWN, &clFileViewerTreeCtrl::OnRightDown, this);
     // Double-click on a folder row toggles expand/collapse (whole row, not only the arrow).
     Bind(wxEVT_LEFT_DCLICK, &clFileViewerTreeCtrl::OnLeftDClick, this);
     // Left/Right arrows collapse/expand the current folder.
     Bind(wxEVT_KEY_DOWN, &clFileViewerTreeCtrl::OnKeyDown, this);
-}
-
-void clFileViewerTreeCtrl::SelectItemForContext(const wxDataViewItem& item)
-{
-    if (!item.IsOk()) {
-        return;
-    }
-
-    // Standard tree UX: right-click outside the selection selects only that item.
-    // Right-click inside an existing multi-selection keeps the multi-selection.
-    if (!IsSelected(item)) {
-        UnselectAll();
-        Select(item);
-    }
-    SetCurrentItem(item);
-
-    wxDataViewEvent selectionEvent(wxEVT_DATAVIEW_SELECTION_CHANGED, this, item);
-    ProcessWindowEvent(selectionEvent);
-    SetFocus();
-}
-
-void clFileViewerTreeCtrl::OnRightDown(wxMouseEvent& event)
-{
-    wxDataViewItem item;
-    wxDataViewColumn* column = nullptr;
-    HitTest(event.GetPosition(), item, column);
-    if (item.IsOk()) {
-        SelectItemForContext(item);
-    }
-    event.Skip();
 }
 
 void clFileViewerTreeCtrl::OnLeftDClick(wxMouseEvent& event)

--- a/Plugin/clFileViwerTreeCtrl.cpp
+++ b/Plugin/clFileViwerTreeCtrl.cpp
@@ -1,5 +1,17 @@
 #include "clFileViwerTreeCtrl.h"
 
+#include <wx/settings.h>
+#include <wx/time.h>
+
+namespace
+{
+int DoubleClickIntervalMs()
+{
+    int msec = wxSystemSettings::GetMetric(wxSYS_DCLICK_MSEC);
+    return msec > 0 ? msec : 400;
+}
+} // namespace
+
 clFileViewerTreeCtrl::clFileViewerTreeCtrl(
     wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style)
     : wxDataViewTreeCtrl(parent, id, pos, size, style)
@@ -20,6 +32,40 @@ clFileViewerTreeCtrl::clFileViewerTreeCtrl(
     // out of this tree, so pre-empt the native handling for this specific case:
     // detect it ourselves and consume the event before it reaches the native control.
     Bind(wxEVT_LEFT_DOWN, &clFileViewerTreeCtrl::OnLeftDown, this);
+    // Right-click must update selection/current item before the context menu runs;
+    // otherwise GTK may only move the visual cursor while commands still use the
+    // previous selection (e.g. "Open Shell").
+    Bind(wxEVT_RIGHT_DOWN, &clFileViewerTreeCtrl::OnRightDown, this);
+}
+
+void clFileViewerTreeCtrl::SelectItemForContext(const wxDataViewItem& item)
+{
+    if (!item.IsOk()) {
+        return;
+    }
+
+    // Standard tree UX: right-click outside the selection selects only that item.
+    // Right-click inside an existing multi-selection keeps the multi-selection.
+    if (!IsSelected(item)) {
+        UnselectAll();
+        Select(item);
+    }
+    SetCurrentItem(item);
+
+    wxDataViewEvent selectionEvent(wxEVT_DATAVIEW_SELECTION_CHANGED, this, item);
+    ProcessWindowEvent(selectionEvent);
+    SetFocus();
+}
+
+void clFileViewerTreeCtrl::OnRightDown(wxMouseEvent& event)
+{
+    wxDataViewItem item;
+    wxDataViewColumn* column = nullptr;
+    HitTest(event.GetPosition(), item, column);
+    if (item.IsOk()) {
+        SelectItemForContext(item);
+    }
+    event.Skip();
 }
 
 void clFileViewerTreeCtrl::OnLeftDown(wxMouseEvent& event)
@@ -27,13 +73,22 @@ void clFileViewerTreeCtrl::OnLeftDown(wxMouseEvent& event)
     wxDataViewItem item;
     wxDataViewColumn* column = nullptr;
     HitTest(event.GetPosition(), item, column);
+
     if (item.IsOk()) {
-        // Remember pre-click expand state for activate/double-click handling.
-        m_lastClickItem = item;
-        m_lastClickWasExpanded = IsExpanded(item);
+        // Capture expand state only on the first click of a double-click sequence.
+        // The second LEFT_DOWN of a double-click must keep the original snapshot;
+        // otherwise activate can see a mid-sequence state and "skip" a toggle.
+        const wxLongLong now = wxGetLocalTimeMillis();
+        const bool newSequence =
+            !m_lastClickValid || item != m_lastClickItem || (now - m_lastClickTime) > DoubleClickIntervalMs();
+        if (newSequence) {
+            m_lastClickItem = item;
+            m_lastClickWasExpanded = IsExpanded(item);
+            m_lastClickValid = true;
+            m_lastClickTime = now;
+        }
     } else {
-        m_lastClickItem = wxDataViewItem();
-        m_lastClickWasExpanded = false;
+        ClearLastClickSnapshot();
     }
 
     if (event.CmdDown() || event.ShiftDown() || event.AltDown()) {

--- a/Plugin/clFileViwerTreeCtrl.cpp
+++ b/Plugin/clFileViwerTreeCtrl.cpp
@@ -1,17 +1,5 @@
 #include "clFileViwerTreeCtrl.h"
 
-#include <wx/settings.h>
-#include <wx/time.h>
-
-namespace
-{
-int DoubleClickIntervalMs()
-{
-    int msec = wxSystemSettings::GetMetric(wxSYS_DCLICK_MSEC);
-    return msec > 0 ? msec : 400;
-}
-} // namespace
-
 clFileViewerTreeCtrl::clFileViewerTreeCtrl(
     wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style)
     : wxDataViewTreeCtrl(parent, id, pos, size, style)
@@ -36,6 +24,10 @@ clFileViewerTreeCtrl::clFileViewerTreeCtrl(
     // otherwise GTK may only move the visual cursor while commands still use the
     // previous selection (e.g. "Open Shell").
     Bind(wxEVT_RIGHT_DOWN, &clFileViewerTreeCtrl::OnRightDown, this);
+    // Double-click on a folder row toggles expand/collapse (whole row, not only the arrow).
+    Bind(wxEVT_LEFT_DCLICK, &clFileViewerTreeCtrl::OnLeftDClick, this);
+    // Left/Right arrows collapse/expand the current folder.
+    Bind(wxEVT_KEY_DOWN, &clFileViewerTreeCtrl::OnKeyDown, this);
 }
 
 void clFileViewerTreeCtrl::SelectItemForContext(const wxDataViewItem& item)
@@ -68,35 +60,71 @@ void clFileViewerTreeCtrl::OnRightDown(wxMouseEvent& event)
     event.Skip();
 }
 
-void clFileViewerTreeCtrl::OnLeftDown(wxMouseEvent& event)
+void clFileViewerTreeCtrl::OnLeftDClick(wxMouseEvent& event)
 {
     wxDataViewItem item;
     wxDataViewColumn* column = nullptr;
     HitTest(event.GetPosition(), item, column);
 
-    if (item.IsOk()) {
-        // Capture expand state only on the first click of a double-click sequence.
-        // The second LEFT_DOWN of a double-click must keep the original snapshot;
-        // otherwise activate can see a mid-sequence state and "skip" a toggle.
-        const wxLongLong now = wxGetLocalTimeMillis();
-        const bool newSequence =
-            !m_lastClickValid || item != m_lastClickItem || (now - m_lastClickTime) > DoubleClickIntervalMs();
-        if (newSequence) {
-            m_lastClickItem = item;
-            m_lastClickWasExpanded = IsExpanded(item);
-            m_lastClickValid = true;
-            m_lastClickTime = now;
+    clTreeCtrlData* cd = item.IsOk() ? GetItemData(item) : nullptr;
+    if (cd && cd->IsFolder()) {
+        if (IsExpanded(item)) {
+            Collapse(item);
+        } else {
+            Expand(item);
         }
-    } else {
-        ClearLastClickSnapshot();
+        return;
+    }
+    event.Skip();
+}
+
+void clFileViewerTreeCtrl::OnKeyDown(wxKeyEvent& event)
+{
+    const int key = event.GetKeyCode();
+    if (key != WXK_LEFT && key != WXK_RIGHT) {
+        event.Skip();
+        return;
     }
 
+    wxDataViewItem item = GetCurrentItem();
+    if (!item.IsOk()) {
+        event.Skip();
+        return;
+    }
+
+    if (key == WXK_RIGHT) {
+        // Expand when collapsed; if already expanded, let the native control
+        // move the cursor to the first child (if any).
+        clTreeCtrlData* cd = GetItemData(item);
+        if (cd && cd->IsFolder() && !IsExpanded(item)) {
+            Expand(item);
+            return;
+        }
+        event.Skip();
+        return;
+    }
+
+    // WXK_LEFT: collapse when expanded; if already collapsed, let native
+    // move the cursor to the parent (standard tree navigation).
+    clTreeCtrlData* cd = GetItemData(item);
+    if (cd && cd->IsFolder() && IsExpanded(item)) {
+        Collapse(item);
+        return;
+    }
+    event.Skip();
+}
+
+void clFileViewerTreeCtrl::OnLeftDown(wxMouseEvent& event)
+{
     if (event.CmdDown() || event.ShiftDown() || event.AltDown()) {
         // let modifier-driven range/toggle selection go through the native control
         event.Skip();
         return;
     }
 
+    wxDataViewItem item;
+    wxDataViewColumn* column = nullptr;
+    HitTest(event.GetPosition(), item, column);
     if (!item.IsOk()) {
         event.Skip();
         return;

--- a/Plugin/clFileViwerTreeCtrl.h
+++ b/Plugin/clFileViwerTreeCtrl.h
@@ -132,14 +132,6 @@ class WXDLLIMPEXP_SDK clFileViewerTreeCtrl : public wxDataViewTreeCtrl
     // Holds the index used for locating top level folders.
     clTreeCtrlData m_rootData{clTreeCtrlData::kRoot};
 
-    // Expand-state snapshot for the first left-down of a (double-)click sequence.
-    // The second left-down of a double-click must not overwrite this, and the
-    // snapshot is invalidated after activate handling so the next sequence is fresh.
-    wxDataViewItem m_lastClickItem;
-    bool m_lastClickWasExpanded = false;
-    bool m_lastClickValid = false;
-    wxLongLong m_lastClickTime{0};
-
     bool ShouldComeBefore(clTreeCtrlData* a, clTreeCtrlData* b) const;
     wxDataViewItem InsertSorted(const wxDataViewItem& parent,
                                 const wxString& text,
@@ -149,6 +141,8 @@ class WXDLLIMPEXP_SDK clFileViewerTreeCtrl : public wxDataViewTreeCtrl
                                 wxClientData* data);
     void OnLeftDown(wxMouseEvent& event);
     void OnRightDown(wxMouseEvent& event);
+    void OnLeftDClick(wxMouseEvent& event);
+    void OnKeyDown(wxKeyEvent& event);
 
 public:
     clFileViewerTreeCtrl(wxWindow* parent,
@@ -165,31 +159,6 @@ public:
      * inside an existing multi-selection keeps the multi-selection.
      */
     void SelectItemForContext(const wxDataViewItem& item);
-
-    /**
-     * @brief true if a left-down snapshot is available for activate handling
-     */
-    bool HasLastClickSnapshot() const { return m_lastClickValid; }
-
-    /**
-     * @brief item under the pointer at the first left-down of the current sequence
-     */
-    const wxDataViewItem& GetLastClickItem() const { return m_lastClickItem; }
-
-    /**
-     * @brief whether GetLastClickItem() was expanded at that first left-down
-     */
-    bool GetLastClickWasExpanded() const { return m_lastClickWasExpanded; }
-
-    /**
-     * @brief drop the left-down snapshot after activate has consumed it
-     */
-    void ClearLastClickSnapshot()
-    {
-        m_lastClickValid = false;
-        m_lastClickItem = wxDataViewItem();
-        m_lastClickWasExpanded = false;
-    }
 
     /**
      * @brief the (invisible) root item. Top level folders are direct children of this item

--- a/Plugin/clFileViwerTreeCtrl.h
+++ b/Plugin/clFileViwerTreeCtrl.h
@@ -140,7 +140,6 @@ class WXDLLIMPEXP_SDK clFileViewerTreeCtrl : public wxDataViewTreeCtrl
                                 bool isContainer,
                                 wxClientData* data);
     void OnLeftDown(wxMouseEvent& event);
-    void OnRightDown(wxMouseEvent& event);
     void OnLeftDClick(wxMouseEvent& event);
     void OnKeyDown(wxKeyEvent& event);
 
@@ -151,14 +150,6 @@ public:
                          const wxSize& size = wxDefaultSize,
                          long style = wxDV_MULTIPLE | wxDV_ROW_LINES | wxDV_NO_HEADER | wxBORDER_STATIC);
     virtual ~clFileViewerTreeCtrl() = default;
-
-    /**
-     * @brief select / set-current the item for context-menu commands
-     *
-     * Right-click outside the selection selects only that item. Right-click
-     * inside an existing multi-selection keeps the multi-selection.
-     */
-    void SelectItemForContext(const wxDataViewItem& item);
 
     /**
      * @brief the (invisible) root item. Top level folders are direct children of this item

--- a/Plugin/clFileViwerTreeCtrl.h
+++ b/Plugin/clFileViwerTreeCtrl.h
@@ -130,7 +130,13 @@ class WXDLLIMPEXP_SDK clFileViewerTreeCtrl : public wxDataViewTreeCtrl
 {
     // Client data for the (invisible) root item, which has no wxDataViewItem of its own.
     // Holds the index used for locating top level folders.
-    clTreeCtrlData m_rootData{ clTreeCtrlData::kRoot };
+    clTreeCtrlData m_rootData{clTreeCtrlData::kRoot};
+
+    // Snapshot of expand state at the most recent left-button press. Used so
+    // double-click / activate can toggle relative to the pre-click state even
+    // if the native control already expanded/collapsed the row.
+    wxDataViewItem m_lastClickItem;
+    bool m_lastClickWasExpanded = false;
 
     bool ShouldComeBefore(clTreeCtrlData* a, clTreeCtrlData* b) const;
     wxDataViewItem InsertSorted(const wxDataViewItem& parent,
@@ -148,6 +154,16 @@ public:
                          const wxSize& size = wxDefaultSize,
                          long style = wxDV_MULTIPLE | wxDV_ROW_LINES | wxDV_NO_HEADER | wxBORDER_STATIC);
     virtual ~clFileViewerTreeCtrl() = default;
+
+    /**
+     * @brief item under the pointer at the last left-down, if any
+     */
+    const wxDataViewItem& GetLastClickItem() const { return m_lastClickItem; }
+
+    /**
+     * @brief whether GetLastClickItem() was expanded at that left-down
+     */
+    bool GetLastClickWasExpanded() const { return m_lastClickWasExpanded; }
 
     /**
      * @brief the (invisible) root item. Top level folders are direct children of this item

--- a/Plugin/clFileViwerTreeCtrl.h
+++ b/Plugin/clFileViwerTreeCtrl.h
@@ -132,11 +132,13 @@ class WXDLLIMPEXP_SDK clFileViewerTreeCtrl : public wxDataViewTreeCtrl
     // Holds the index used for locating top level folders.
     clTreeCtrlData m_rootData{clTreeCtrlData::kRoot};
 
-    // Snapshot of expand state at the most recent left-button press. Used so
-    // double-click / activate can toggle relative to the pre-click state even
-    // if the native control already expanded/collapsed the row.
+    // Expand-state snapshot for the first left-down of a (double-)click sequence.
+    // The second left-down of a double-click must not overwrite this, and the
+    // snapshot is invalidated after activate handling so the next sequence is fresh.
     wxDataViewItem m_lastClickItem;
     bool m_lastClickWasExpanded = false;
+    bool m_lastClickValid = false;
+    wxLongLong m_lastClickTime{0};
 
     bool ShouldComeBefore(clTreeCtrlData* a, clTreeCtrlData* b) const;
     wxDataViewItem InsertSorted(const wxDataViewItem& parent,
@@ -146,6 +148,7 @@ class WXDLLIMPEXP_SDK clFileViewerTreeCtrl : public wxDataViewTreeCtrl
                                 bool isContainer,
                                 wxClientData* data);
     void OnLeftDown(wxMouseEvent& event);
+    void OnRightDown(wxMouseEvent& event);
 
 public:
     clFileViewerTreeCtrl(wxWindow* parent,
@@ -156,14 +159,37 @@ public:
     virtual ~clFileViewerTreeCtrl() = default;
 
     /**
-     * @brief item under the pointer at the last left-down, if any
+     * @brief select / set-current the item for context-menu commands
+     *
+     * Right-click outside the selection selects only that item. Right-click
+     * inside an existing multi-selection keeps the multi-selection.
+     */
+    void SelectItemForContext(const wxDataViewItem& item);
+
+    /**
+     * @brief true if a left-down snapshot is available for activate handling
+     */
+    bool HasLastClickSnapshot() const { return m_lastClickValid; }
+
+    /**
+     * @brief item under the pointer at the first left-down of the current sequence
      */
     const wxDataViewItem& GetLastClickItem() const { return m_lastClickItem; }
 
     /**
-     * @brief whether GetLastClickItem() was expanded at that left-down
+     * @brief whether GetLastClickItem() was expanded at that first left-down
      */
     bool GetLastClickWasExpanded() const { return m_lastClickWasExpanded; }
+
+    /**
+     * @brief drop the left-down snapshot after activate has consumed it
+     */
+    void ClearLastClickSnapshot()
+    {
+        m_lastClickValid = false;
+        m_lastClickItem = wxDataViewItem();
+        m_lastClickWasExpanded = false;
+    }
 
     /**
      * @brief the (invisible) root item. Top level folders are direct children of this item

--- a/Plugin/clTreeCtrlPanel.cpp
+++ b/Plugin/clTreeCtrlPanel.cpp
@@ -229,30 +229,13 @@ void clTreeCtrlPanel::OnItemActivated(wxDataViewEvent& event)
 {
     event.Skip();
 
-    // Double-click (or keyboard activate) on a folder toggles expand/collapse
-    // for the whole row, not only when the expander arrow is used.
-    // Use expand state from the *first* left-down of the double-click sequence
-    // (not the second), so a native expand/collapse mid-sequence cannot invert
-    // the intended toggle. Clear the snapshot afterwards so the next sequence
-    // starts clean and rapid double-clicks do not "stick" on expand.
-    wxDataViewItem item = event.GetItem();
-    clTreeCtrlData* cd = GetItemData(item);
+    // Folders: expand/collapse is handled by LEFT_DCLICK and Left/Right keys on
+    // the tree itself. Activation only opens files.
+    clTreeCtrlData* cd = GetItemData(event.GetItem());
     if (cd && cd->IsFolder()) {
-        bool wasExpanded = GetTreeCtrl()->IsExpanded(item);
-        if (GetTreeCtrl()->HasLastClickSnapshot() && GetTreeCtrl()->GetLastClickItem() == item) {
-            wasExpanded = GetTreeCtrl()->GetLastClickWasExpanded();
-        }
-        GetTreeCtrl()->ClearLastClickSnapshot();
-
-        if (wasExpanded) {
-            GetTreeCtrl()->Collapse(item);
-        } else {
-            GetTreeCtrl()->Expand(item);
-        }
         return;
     }
 
-    GetTreeCtrl()->ClearLastClickSnapshot();
     wxCommandEvent dummy;
     OnOpenFile(dummy);
 }

--- a/Plugin/clTreeCtrlPanel.cpp
+++ b/Plugin/clTreeCtrlPanel.cpp
@@ -123,13 +123,23 @@ clTreeCtrlPanel::~clTreeCtrlPanel()
 
 void clTreeCtrlPanel::OnContextMenu(wxDataViewEvent& event)
 {
+    // Use the DataView context-menu event (not wxEVT_RIGHT_DOWN) so trackpad /
+    // gesture context menus also update the selection correctly.
     wxDataViewItem item = event.GetItem();
     CHECK_ITEM_RET(item);
 
-    // Make sure the right-clicked row is the selection/current item before any
-    // menu command reads GetCurrentItem()/GetSelections(). On GTK the visual
-    // cursor can move without updating the selection.
-    GetTreeCtrl()->SelectItemForContext(item);
+    // Always select the item under the cursor as the single selection/current
+    // item so GetCurrentItem() (Open Shell, Open Containing Folder, …) uses it.
+    // Do this before PopupMenu, and show the menu synchronously: CallAfter would
+    // open it while the mouse button may still be down, so the menu vanishes on
+    // release.
+    SelectItem(item);
+    DoContextMenu(item);
+}
+
+void clTreeCtrlPanel::DoContextMenu(const wxDataViewItem& item)
+{
+    CHECK_ITEM_RET(item);
 
     clTreeCtrlData* cd = GetItemData(item);
     if (cd && cd->IsFolder()) {
@@ -564,6 +574,7 @@ void clTreeCtrlPanel::SelectItem(const wxDataViewItem& item)
     }
 
     GetTreeCtrl()->Select(item);
+    GetTreeCtrl()->SetCurrentItem(item);
     GetTreeCtrl()->EnsureVisible(item);
 }
 

--- a/Plugin/clTreeCtrlPanel.cpp
+++ b/Plugin/clTreeCtrlPanel.cpp
@@ -126,6 +126,11 @@ void clTreeCtrlPanel::OnContextMenu(wxDataViewEvent& event)
     wxDataViewItem item = event.GetItem();
     CHECK_ITEM_RET(item);
 
+    // Make sure the right-clicked row is the selection/current item before any
+    // menu command reads GetCurrentItem()/GetSelections(). On GTK the visual
+    // cursor can move without updating the selection.
+    GetTreeCtrl()->SelectItemForContext(item);
+
     clTreeCtrlData* cd = GetItemData(item);
     if (cd && cd->IsFolder()) {
         // Prepare a folder context menu
@@ -226,15 +231,19 @@ void clTreeCtrlPanel::OnItemActivated(wxDataViewEvent& event)
 
     // Double-click (or keyboard activate) on a folder toggles expand/collapse
     // for the whole row, not only when the expander arrow is used.
-    // Use expand state from the initial left-down of the click sequence so that
-    // if the native control already toggled, we still end at the intended state.
+    // Use expand state from the *first* left-down of the double-click sequence
+    // (not the second), so a native expand/collapse mid-sequence cannot invert
+    // the intended toggle. Clear the snapshot afterwards so the next sequence
+    // starts clean and rapid double-clicks do not "stick" on expand.
     wxDataViewItem item = event.GetItem();
     clTreeCtrlData* cd = GetItemData(item);
     if (cd && cd->IsFolder()) {
         bool wasExpanded = GetTreeCtrl()->IsExpanded(item);
-        if (GetTreeCtrl()->GetLastClickItem() == item) {
+        if (GetTreeCtrl()->HasLastClickSnapshot() && GetTreeCtrl()->GetLastClickItem() == item) {
             wasExpanded = GetTreeCtrl()->GetLastClickWasExpanded();
         }
+        GetTreeCtrl()->ClearLastClickSnapshot();
+
         if (wasExpanded) {
             GetTreeCtrl()->Collapse(item);
         } else {
@@ -243,6 +252,7 @@ void clTreeCtrlPanel::OnItemActivated(wxDataViewEvent& event)
         return;
     }
 
+    GetTreeCtrl()->ClearLastClickSnapshot();
     wxCommandEvent dummy;
     OnOpenFile(dummy);
 }

--- a/Plugin/clTreeCtrlPanel.cpp
+++ b/Plugin/clTreeCtrlPanel.cpp
@@ -223,6 +223,26 @@ void clTreeCtrlPanel::OnContextMenu(wxDataViewEvent& event)
 void clTreeCtrlPanel::OnItemActivated(wxDataViewEvent& event)
 {
     event.Skip();
+
+    // Double-click (or keyboard activate) on a folder toggles expand/collapse
+    // for the whole row, not only when the expander arrow is used.
+    // Use expand state from the initial left-down of the click sequence so that
+    // if the native control already toggled, we still end at the intended state.
+    wxDataViewItem item = event.GetItem();
+    clTreeCtrlData* cd = GetItemData(item);
+    if (cd && cd->IsFolder()) {
+        bool wasExpanded = GetTreeCtrl()->IsExpanded(item);
+        if (GetTreeCtrl()->GetLastClickItem() == item) {
+            wasExpanded = GetTreeCtrl()->GetLastClickWasExpanded();
+        }
+        if (wasExpanded) {
+            GetTreeCtrl()->Collapse(item);
+        } else {
+            GetTreeCtrl()->Expand(item);
+        }
+        return;
+    }
+
     wxCommandEvent dummy;
     OnOpenFile(dummy);
 }

--- a/Plugin/clTreeCtrlPanel.h
+++ b/Plugin/clTreeCtrlPanel.h
@@ -87,7 +87,9 @@ public:
      * @param excludeFilePatterns
      */
     void SetExcludeFilePatterns(const wxString& excludeFilePatterns)
-    { this->m_excludeFilePatterns = excludeFilePatterns; }
+    {
+        this->m_excludeFilePatterns = excludeFilePatterns;
+    }
 
     const wxString& GetExcludeFilePatterns() const { return m_excludeFilePatterns; }
 
@@ -168,6 +170,7 @@ protected:
     virtual void OnFindInFilesShowing(clFindInFilesEvent& event);
     virtual void OnInitDone(wxCommandEvent& event);
     virtual void OnContextMenu(wxDataViewEvent& event);
+    void DoContextMenu(const wxDataViewItem& item);
     virtual void OnItemActivated(wxDataViewEvent& event);
     virtual void OnItemExpanding(wxDataViewEvent& event);
     virtual void OnCloseFolder(wxCommandEvent& event);


### PR DESCRIPTION
Filesystem workspace and other clTreeCtrlPanel views previously only expanded or collapsed folders via the expander arrow. Double-clicking a folder row now toggles expand state, while files still open on activate.