### PR TITLE
Restore events lost in DiffSideBySidePanel base.

### DIFF
--- a/Plugin/Diff/DiffSideBySidePanel.cpp
+++ b/Plugin/Diff/DiffSideBySidePanel.cpp
@@ -1051,7 +1051,7 @@ void DiffSideBySidePanel::OnShowOverviewBarClicked(wxCommandEvent& event)
 
 void DiffSideBySidePanel::OnShowOverviewBarUI(wxUpdateUIEvent& event) { event.Check(m_config.IsOverviewBarShown()); }
 
-void DiffSideBySidePanel::OnPaneloverviewEraseBackground(wxEraseEvent& event)
+void DiffSideBySidePanel::OnPanelOverviewEraseBackground(wxEraseEvent& event)
 {
     if (!m_config.IsOverviewBarShown()) {
         return;
@@ -1143,7 +1143,7 @@ void DiffSideBySidePanel::OnPaneloverviewEraseBackground(wxEraseEvent& event)
     }
 }
 
-void DiffSideBySidePanel::OnPaneloverviewLeftDown(wxMouseEvent& event)
+void DiffSideBySidePanel::OnPanelOverviewLeftDown(wxMouseEvent& event)
 {
     event.Skip();
 

--- a/Plugin/Diff/DiffSideBySidePanel.h
+++ b/Plugin/Diff/DiffSideBySidePanel.h
@@ -113,15 +113,18 @@ protected:
     FileInfo m_right;
 
 protected:
-    virtual void OnBrowseLeftFile(wxCommandEvent& event);
-    virtual void OnBrowseRightFile(wxCommandEvent& event);
-    virtual void OnMouseWheel(wxMouseEvent& event);
-    virtual void OnSingleUI(wxUpdateUIEvent& event);
-    virtual void OnSingleView(wxCommandEvent& event);
-    virtual void OnLeftPickerUI(wxUpdateUIEvent& event);
-    virtual void OnRightPickerUI(wxUpdateUIEvent& event);
-    virtual void OnPaneloverviewLeftDown(wxMouseEvent& event);
+    void OnBrowseLeftFile(wxCommandEvent& event) override;
+    void OnBrowseRightFile(wxCommandEvent& event) override;
+    void OnMouseWheel(wxMouseEvent& event) override;
+    void OnLeftPickerUI(wxUpdateUIEvent& event) override;
+    void OnRightPickerUI(wxUpdateUIEvent& event) override;
+    void OnPanelOverviewEraseBackground(wxEraseEvent& event) override;
+    void OnPanelOverviewLeftDown(wxMouseEvent& event) override;
+    void OnLeftStcPainted(wxStyledTextEvent& event) override;
+    void OnRightStcPainted(wxStyledTextEvent& event) override;
 
+    void OnSingleUI(wxUpdateUIEvent& event);
+    void OnSingleView(wxCommandEvent& event);
     void OnMenuCopyLeft2Right(wxCommandEvent& event);
     void OnMenuCopyRight2Left(wxCommandEvent& event);
     void OnCopyAllMenu(wxCommandEvent& event);
@@ -137,35 +140,32 @@ protected:
     bool IsOriginSourceControl() const { return m_flags & kOriginSourceControl; }
 
 public:
-    virtual void OnRefreshDiffUI(wxUpdateUIEvent& event);
-    virtual void OnHorizontal(wxCommandEvent& event);
-    virtual void OnHorizontalUI(wxUpdateUIEvent& event);
-    virtual void OnVertical(wxCommandEvent& event);
-    virtual void OnVerticalUI(wxUpdateUIEvent& event);
-    virtual void OnCopyFileFromRight(wxCommandEvent& event);
-    virtual void OnCopyFileLeftToRight(wxCommandEvent& event);
-    virtual void OnSaveChanges(wxCommandEvent& event);
-    virtual void OnFind(wxCommandEvent& event);
-    virtual void OnSaveChangesUI(wxUpdateUIEvent& event);
-    virtual void OnCopyLeftToRight(wxCommandEvent& event);
-    virtual void OnCopyRightToLeft(wxCommandEvent& event);
-    virtual void OnCopyLeftToRightUI(wxUpdateUIEvent& event);
-    virtual void OnCopyRightToLeftUI(wxUpdateUIEvent& event);
-    virtual void OnNextDiffUI(wxUpdateUIEvent& event);
-    virtual void OnPrevDiffUI(wxUpdateUIEvent& event);
-    virtual void OnNextDiffSequence(wxCommandEvent& event);
-    virtual void OnPrevDiffSequence(wxCommandEvent& event);
-    virtual void OnRefreshDiff(wxCommandEvent& event);
-    virtual void OnLeftStcPainted(wxStyledTextEvent& event);
-    virtual void OnRightStcPainted(wxStyledTextEvent& event);
-    virtual void OnLeftStcUpdateUI(wxStyledTextEvent& event);
-    virtual void OnIgnoreWhitespaceClicked(wxCommandEvent& event);
-    virtual void OnIgnoreWhitespaceUI(wxUpdateUIEvent& event);
-    virtual void OnShowLinenosClicked(wxCommandEvent& event);
-    virtual void OnShowLinenosUI(wxUpdateUIEvent& event);
-    virtual void OnShowOverviewBarClicked(wxCommandEvent& event);
-    virtual void OnShowOverviewBarUI(wxUpdateUIEvent& event);
-    virtual void OnPaneloverviewEraseBackground(wxEraseEvent& event);
+    void OnRefreshDiffUI(wxUpdateUIEvent& event);
+    void OnHorizontal(wxCommandEvent& event);
+    void OnHorizontalUI(wxUpdateUIEvent& event);
+    void OnVertical(wxCommandEvent& event);
+    void OnVerticalUI(wxUpdateUIEvent& event);
+    void OnCopyFileFromRight(wxCommandEvent& event);
+    void OnCopyFileLeftToRight(wxCommandEvent& event);
+    void OnSaveChanges(wxCommandEvent& event);
+    void OnFind(wxCommandEvent& event);
+    void OnSaveChangesUI(wxUpdateUIEvent& event);
+    void OnCopyLeftToRight(wxCommandEvent& event);
+    void OnCopyRightToLeft(wxCommandEvent& event);
+    void OnCopyLeftToRightUI(wxUpdateUIEvent& event);
+    void OnCopyRightToLeftUI(wxUpdateUIEvent& event);
+    void OnNextDiffUI(wxUpdateUIEvent& event);
+    void OnPrevDiffUI(wxUpdateUIEvent& event);
+    void OnNextDiffSequence(wxCommandEvent& event);
+    void OnPrevDiffSequence(wxCommandEvent& event);
+    void OnRefreshDiff(wxCommandEvent& event);
+    void OnLeftStcUpdateUI(wxStyledTextEvent& event);
+    void OnIgnoreWhitespaceClicked(wxCommandEvent& event);
+    void OnIgnoreWhitespaceUI(wxUpdateUIEvent& event);
+    void OnShowLinenosClicked(wxCommandEvent& event);
+    void OnShowLinenosUI(wxUpdateUIEvent& event);
+    void OnShowOverviewBarClicked(wxCommandEvent& event);
+    void OnShowOverviewBarUI(wxUpdateUIEvent& event);
     void OnPageClosing(wxNotifyEvent& event);
 
     void PrepareViews();
@@ -186,8 +186,8 @@ public:
     void DefineMarkers(wxStyledTextCtrl* ctrl);
 
 public:
-    DiffSideBySidePanel(wxWindow* parent);
-    virtual ~DiffSideBySidePanel();
+    explicit DiffSideBySidePanel(wxWindow* parent);
+    ~DiffSideBySidePanel() override;
 
     void DoLayout();
     /**

--- a/Plugin/Diff/DiffUI.wxcp
+++ b/Plugin/Diff/DiffUI.wxcp
@@ -2145,7 +2145,15 @@
                                       "m_value": true
                                     }
                                   ],
-                                  "m_events": [],
+                                  "m_events": [
+                                    {
+                                      "m_description": "Process a wxEVT_UPDATE_UI event",
+                                      "m_eventClass": "wxUpdateUIEvent",
+                                      "m_eventName": "wxEVT_UPDATE_UI",
+                                      "m_functionNameAndSignature": "OnLeftPickerUI(wxUpdateUIEvent& event)",
+                                      "m_noBody": false
+                                    }
+                                  ],
                                   "m_children": []
                                 },
                                 {
@@ -2263,7 +2271,22 @@
                                       "m_value": "2,2"
                                     }
                                   ],
-                                  "m_events": [],
+                                  "m_events": [
+                                    {
+                                      "m_description": "Process a wxEVT_UPDATE_UI event",
+                                      "m_eventClass": "wxUpdateUIEvent",
+                                      "m_eventName": "wxEVT_UPDATE_UI",
+                                      "m_functionNameAndSignature": "OnLeftPickerUI(wxUpdateUIEvent& event)",
+                                      "m_noBody": false
+                                    },
+                                    {
+                                      "m_description": "Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked.",
+                                      "m_eventClass": "wxCommandEvent",
+                                      "m_eventName": "wxEVT_COMMAND_BUTTON_CLICKED",
+                                      "m_functionNameAndSignature": "OnBrowseLeftFile(wxCommandEvent& event)",
+                                      "m_noBody": false
+                                    }
+                                  ],
                                   "m_children": []
                                 }
                               ]
@@ -2576,7 +2599,22 @@
                                       "m_value": ""
                                     }
                                   ],
-                                  "m_events": [],
+                                  "m_events": [
+                                    {
+                                      "m_description": "Process a wxEVT_MOUSEWHEEL event",
+                                      "m_eventClass": "wxMouseEvent",
+                                      "m_eventName": "wxEVT_MOUSEWHEEL",
+                                      "m_functionNameAndSignature": "OnMouseWheel(wxMouseEvent& event)",
+                                      "m_noBody": false
+                                    },
+                                    {
+                                      "m_description": "Painting has just been done.\nUseful when you want to update some other widgets based on a change in Scintilla\nbut want to have the paint occur first to appear more responsive",
+                                      "m_eventClass": "wxStyledTextEvent",
+                                      "m_eventName": "wxEVT_STC_PAINTED",
+                                      "m_functionNameAndSignature": "OnLeftStcPainted(wxStyledTextEvent& event)",
+                                      "m_noBody": false
+                                    }
+                                  ],
                                   "m_children": []
                                 },
                                 {
@@ -2668,7 +2706,22 @@
                                       "m_value": ""
                                     }
                                   ],
-                                  "m_events": [],
+                                  "m_events": [
+                                    {
+                                      "m_description": "Process a wxEVT_ERASE_BACKGROUND event.",
+                                      "m_eventClass": "wxEraseEvent",
+                                      "m_eventName": "wxEVT_ERASE_BACKGROUND",
+                                      "m_functionNameAndSignature": "OnPanelOverviewEraseBackground(wxEraseEvent& event)",
+                                      "m_noBody": false
+                                    },
+                                    {
+                                      "m_description": "Process a wxEVT_LEFT_DOWN event. The handler of this event should normally call event.Skip() to allow the default processing to take place as otherwise the window under mouse wouldn't get the focus.",
+                                      "m_eventClass": "wxMouseEvent",
+                                      "m_eventName": "wxEVT_LEFT_DOWN",
+                                      "m_functionNameAndSignature": "OnPanelOverviewLeftDown(wxMouseEvent& event)",
+                                      "m_noBody": false
+                                    }
+                                  ],
                                   "m_children": []
                                 }
                               ]
@@ -3197,7 +3250,22 @@
                                       "m_value": "2,2"
                                     }
                                   ],
-                                  "m_events": [],
+                                  "m_events": [
+                                    {
+                                      "m_description": "Process a wxEVT_COMMAND_BUTTON_CLICKED event, when the button is clicked.",
+                                      "m_eventClass": "wxCommandEvent",
+                                      "m_eventName": "wxEVT_COMMAND_BUTTON_CLICKED",
+                                      "m_functionNameAndSignature": "OnBrowseRightFile(wxCommandEvent& event)",
+                                      "m_noBody": false
+                                    },
+                                    {
+                                      "m_description": "Process a wxEVT_UPDATE_UI event",
+                                      "m_eventClass": "wxUpdateUIEvent",
+                                      "m_eventName": "wxEVT_UPDATE_UI",
+                                      "m_functionNameAndSignature": "OnRightPickerUI(wxUpdateUIEvent& event)",
+                                      "m_noBody": false
+                                    }
+                                  ],
                                   "m_children": []
                                 }
                               ]
@@ -3510,7 +3578,22 @@
                                       "m_value": ""
                                     }
                                   ],
-                                  "m_events": [],
+                                  "m_events": [
+                                    {
+                                      "m_description": "Painting has just been done.\nUseful when you want to update some other widgets based on a change in Scintilla\nbut want to have the paint occur first to appear more responsive",
+                                      "m_eventClass": "wxStyledTextEvent",
+                                      "m_eventName": "wxEVT_STC_PAINTED",
+                                      "m_functionNameAndSignature": "OnRightStcPainted(wxStyledTextEvent& event)",
+                                      "m_noBody": false
+                                    },
+                                    {
+                                      "m_description": "Process a wxEVT_MOUSEWHEEL event",
+                                      "m_eventClass": "wxMouseEvent",
+                                      "m_eventName": "wxEVT_MOUSEWHEEL",
+                                      "m_functionNameAndSignature": "OnMouseWheel(wxMouseEvent& event)",
+                                      "m_noBody": false
+                                    }
+                                  ],
                                   "m_children": []
                                 },
                                 {
@@ -3602,7 +3685,22 @@
                                       "m_value": ""
                                     }
                                   ],
-                                  "m_events": [],
+                                  "m_events": [
+                                    {
+                                      "m_description": "Process a wxEVT_ERASE_BACKGROUND event.",
+                                      "m_eventClass": "wxEraseEvent",
+                                      "m_eventName": "wxEVT_ERASE_BACKGROUND",
+                                      "m_functionNameAndSignature": "OnPanelOverviewEraseBackground(wxEraseEvent& event)",
+                                      "m_noBody": false
+                                    },
+                                    {
+                                      "m_description": "Process a wxEVT_LEFT_DOWN event. The handler of this event should normally call event.Skip() to allow the default processing to take place as otherwise the window under mouse wouldn't get the focus.",
+                                      "m_eventClass": "wxMouseEvent",
+                                      "m_eventName": "wxEVT_LEFT_DOWN",
+                                      "m_functionNameAndSignature": "OnPanelOverviewLeftDown(wxMouseEvent& event)",
+                                      "m_noBody": false
+                                    }
+                                  ],
                                   "m_children": []
                                 }
                               ]


### PR DESCRIPTION
Restore events lost with ee8556613c9b364d147cc19e36d56c0246df8852 (move DiffSideBySidePanel.cpp/h files near its wxcp (#4081))

Add missing `override`