### PR TITLE
[wxCrafter] Load old `wxEVT_COMMAND_MENU_SELECTED` as `wxEVT_MENU`.

### DIFF
--- a/wxcrafter/wxCrafterCommon/src/wxc_widget.cpp
+++ b/wxcrafter/wxCrafterCommon/src/wxc_widget.cpp
@@ -833,6 +833,9 @@ void wxcWidget::UnSerialize(const JSONItem& json)
             new_name.Replace("_WEB_VIEW_", "_WEBVIEW_");
             details.SetEventName(new_name);
         }
+        if (details.GetEventName() == "wxEVT_COMMAND_MENU_SELECTED") {
+            details.SetEventName("wxEVT_MENU");
+        }
         m_connectedEvents.PushBack(details.GetEventName(), details);
     }
 


### PR DESCRIPTION
Apply to wxcp generated before e071810bc3128809c37d1df1dade8651fe3a9181 (wxCrafter: use `Bind()` syntax to connect events instead of the old `Connect()` syntax) (2022/01/12).