### PR TITLE
Update download link to point to correct path

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -21,4 +21,4 @@ More information can be found here:
 [2]: https://codelite.org/support.php
 [3]: https://codelite.org
 [4]: https://codelite.org/support.php
-[5]: download.md
+[5]: ./downloads/download.md


### PR DESCRIPTION
Although link from docs header is correct, link at bottom of docs homepage is not.